### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,21 @@
+# CODEOWNERS
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+# Order is important; the last matching pattern takes the most
+# precedence.
+# https://help.github.com/en/articles/about-code-owners
+
+# Default owners for everything in the repo
+*									@cloud-sdk-ios-fiori-admin
+
+# Owners for Cards
+Sources/FioriIntegrationCards/*  	@sstadelman @ShawnMa16
+
+# Owners for Charts
+Sources/FioriCharts/*  				@shengxu7 @billzhou0223
+
+# Owners for SwiftUI Controls
+Sources/FioriSwiftUI/*  			@SAP/cloud-sdk-ios-fiori-team
+
+# Owners for GitHub Integration
+.github/*  							@MarcoEidinger @billzhou0223


### PR DESCRIPTION
Code owners are automatically requested for review when someone opens a pull request
that modifies code that they own.

FYI and outside of this commit:
In addition a team (e.g. cloud-sdk-ios-fiori-admin and cloud-sdk-ios-fiori-team) can
leverage code review assignments (it's a setting in GitHub)
Any time a team has been requested to review a pull request, the team is removed as
reviewer and a specified subset of team members are assigned in the team's place.
Code review assignments allow you to decide whether the whole team or just a subset
of team members are notified when a team is requested for review.