### PR TITLE
ci: swift-api-assign-reviewer

### DIFF
--- a/.github/configActions/swift-api-assign-reviewer.yml
+++ b/.github/configActions/swift-api-assign-reviewer.yml
@@ -1,0 +1,7 @@
+# Set to true to add reviewers to pull requests
+addReviewers: true
+
+# A list of reviewers to be added to pull requests (GitHub user name)
+reviewers:
+  - MarcoEidinger
+  - billzhou0223

--- a/.github/workflows/pr_only.yml
+++ b/.github/workflows/pr_only.yml
@@ -1,0 +1,15 @@
+name: PR
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+
+  swift-api-assign-reviewer:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: MarcoEidinger/swift-api-assign-reviewer@1.0.0
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: ".github/configActions/swift-api-assign-reviewer.yml"


### PR DESCRIPTION
use GitHub action `swift-api-assign-reviewer` to automatically assign reviewers for pull requests which contain API changes (open/public)