### PR TITLE
chore: add mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,8 @@
+Bill Zhou <bill.zhou01@sap.com>
+Fred Wirjo <fred.wirjo@sap.com>
+Krishna Murthy Bukkapatnam <krishna.murthy.bukkapatnam@sap.com>
+Marco Eidinger <marco.eidinger@sap.com> MarcoEidinger <eidingermarco@gmail.com>
+Marco Eidinger <marco.eidinger@sap.com> MarcoEidinger <marco.eidinger@sap.com>
+Shawn Ma <xiao.ma01@sap.com> Xiao Ma <xiao.ma01@sap.com>
+Sheng Xu <sheng.xu01@sap.com> <sheng.xu01@samp.com> I530147 <sheng.xu01@sap.com>
+Stan Stadelman <stan.stadelman@sap.com> <sstadelman@gmail.com>


### PR DESCRIPTION
to aliasing authors in Git and resolve duplicate names/emails
without rewriting Git History

Github considers .mailmap file for contributions and it takes time\
to update contributors graph and pulse

Locally use git log --use-mailmap

https://blog.developer.atlassian.com/aliasing-authors-in-git/