### PR TITLE
fix: project ‘FioriSwiftUI’ is damaged and cannot be opened due to a …

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ We recommend to run `setupForCollaborators.sh` in root directory once to install
 - install Xcode project file and adds a run script to ensure that SwiftLint checks are getting executed when you are working within XCode
 
 If you choose to run the script please make sure your dev machine has
-- `python` (with `pip` as package manager which is included with 3.4+) and
+- `python` 3.7+ (includes `pip` as package manager)
   - tip: you can use [pyenv](https://github.com/pyenv/pyenv) to manage and switch between multiple python versions
 - `npm` (with `npx` as package runner which is included with 5.2+)
 

--- a/setupForCollaborators.sh
+++ b/setupForCollaborators.sh
@@ -9,5 +9,15 @@ bash scripts/installGitHooks.sh
 rm -f -r ./FioriSwiftUI.xcodeproj
 swift package generate-xcodeproj
 
-# add run script to xocde project file
+# add run script to xcode project file (if python 3.7+ is available)
+if ! hash python; then
+    echo "WARNING: no run script was added to Xcode project file to execute SwiftLint check because python version of 3.7+ required"
+    exit 0
+fi
+
+ver=$(python -V 2>&1 | sed 's/.* \([0-9]\).\([0-9]\).*/\1\2/')
+if [ "$ver" -lt "37" ]; then
+    echo "WARNING: no run script was added to Xcode project file to execute SwiftLint check because python version of 3.7+ required"
+    exit 0
+fi
 python scripts/addSwiftLintRunScriptToXcodeProj.py


### PR DESCRIPTION
…parse error

occurs when using python 2.7 :(

change setupForCollaborators.sh in such a way that it attempts to
add the run script when python version 3 is present.

Users with python 2.7 have to manually add such run script.