### PR TITLE
chore: update dependency "observable-array" to version 1.2.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/sstadelman/observable-array.git",
         "state": {
           "branch": null,
-          "revision": "abb849c3bb73359b85bfd8588bc15480536f4d00",
-          "version": "1.1.0"
+          "revision": "8cc76410f71b6653897f974b453e9a15ef8f96b4",
+          "version": "1.2.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/objcio/tiny-networking", from: "0.2.0"),
         .package(url: "https://github.com/Flight-School/AnyCodable.git", from: "0.2.3"),
-        .package(url: "https://github.com/sstadelman/observable-array.git", from: "1.1.0"),
+        .package(url: "https://github.com/sstadelman/observable-array.git", from: "1.2.0"),
         .package(url: "https://github.com/marmelroy/Zip.git", from: "2.0.0")
     ],
     targets: [


### PR DESCRIPTION
no code changes in release 1.2.0 it just declares cross-platform support