### PR TITLE
test: fix crash in Examples app when selecting a chart

### DIFF
--- a/Apps/Examples/Examples/FioriCharts/ChartsContentView.swift
+++ b/Apps/Examples/Examples/FioriCharts/ChartsContentView.swift
@@ -69,7 +69,11 @@ struct ChartHomeView: View {
         }
         .navigationBarTitle(info.0)
         .sheet(isPresented: $showingDetail) {
-            ChartDetailView(model: self.currentModel!)
+            if self.currentModel != nil {
+                ChartDetailView(model: self.currentModel!)
+            } else {
+                Text("Error: try to switch model for same chart type")
+            }
         }
     }
     


### PR DESCRIPTION
iOS 14 issue

root cause still under investigation

workaround is to tap different example of same chart type and
then it works