### PR TITLE
add all integration card types in Examples app and fix some Xcode 12 / iOS 14 bugs

### DIFF
--- a/Apps/Examples/Examples/FioriIntegrationCards/SampleData/InlineTestCases.swift
+++ b/Apps/Examples/Examples/FioriIntegrationCards/SampleData/InlineTestCases.swift
@@ -10,9 +10,11 @@ import Foundation
 import FioriIntegrationCards
 
 enum InlineTestCases: String, CaseIterable, Identifiable {
-    case analytical = "analytical_dataInCardLevel"
-    case list       = "list_dataInCardLevel"
-    case timeLine   = "timeline_dataInCardLevel"
+    case analytical = "analytical"
+    case list       = "list"
+    case timeLine   = "timeline"
+    case object     = "object"
+    case table      = "table"
     
     var id: String {
         return rawValue

--- a/Sources/FioriIntegrationCards/Components/Common/Header/DefaultHeader.swift
+++ b/Sources/FioriIntegrationCards/Components/Common/Header/DefaultHeader.swift
@@ -34,7 +34,7 @@ extension DefaultHeader: Placeholding {
         let _subTitle    = subTitle?.replacingPlaceholders(withValuesIn: object)
         let _actions     = actions /// TODO:  implement replacingPlaceholders for `actions`
         let _icon        = icon?.replacingPlaceholders(withValuesIn: object)
-        let _status      = status?.replacingPlaceholders(withValuesIn: object)
+        let _status      = status
         return DefaultHeader(type: _type, title: _title, subTitle: _subTitle, actions: _actions, icon: _icon, status: _status)
     }
 }

--- a/Sources/FioriIntegrationCards/Components/List/UI/ListCardView.swift
+++ b/Sources/FioriIntegrationCards/Components/List/UI/ListCardView.swift
@@ -26,8 +26,14 @@ public struct ListCardView: View {
     public var body: some View {
         VStack {
             Group {
-                HeaderView(model: model.header)
-                    .padding(.bottom, -30)
+                if ProcessInfo().isOperatingSystemAtLeast(OperatingSystemVersion(majorVersion: 14, minorVersion: 0, patchVersion: 0)) {
+                    HeaderView(model: model.header)
+                        .padding(.bottom, -1)
+                } else {
+                    HeaderView(model: model.header)
+                        .padding(.bottom, -30)
+                }
+
                 Divider().accentColor(Color.primary)
                 VStack(alignment: .leading) {
                     ForEach(model.content) {


### PR DESCRIPTION
in addition fix issue in the header of integration card as status specified with {} placeholder shall be ignored (that's the behavior in web anyway)