### PR TITLE
feat: request data for remote int. card (non-cardBundle)

### DIFF
--- a/Apps/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Apps/Examples/Examples.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		8A1E99AF24D59D1500ED8A39 /* FioriSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = 8A1E99AE24D59D1500ED8A39 /* FioriSwiftUI */; };
 		8A1E99B024D59D1500ED8A39 /* FioriSwiftUI in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 8A1E99AE24D59D1500ED8A39 /* FioriSwiftUI */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		8A3C4E0424EB4A7B0084451B /* DataRequestTestCases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3C4E0324EB4A7B0084451B /* DataRequestTestCases.swift */; };
 		8A55795724C1286E0098003A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A55795624C1286E0098003A /* AppDelegate.swift */; };
 		8A55795924C1286E0098003A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A55795824C1286E0098003A /* SceneDelegate.swift */; };
 		8A55795B24C1286E0098003A /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A55795A24C1286E0098003A /* ContentView.swift */; };
@@ -115,6 +116,7 @@
 
 /* Begin PBXFileReference section */
 		8A1E99AD24D59C8000ED8A39 /* cloud-sdk-ios-fiori */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "cloud-sdk-ios-fiori"; path = ../..; sourceTree = "<group>"; };
+		8A3C4E0324EB4A7B0084451B /* DataRequestTestCases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataRequestTestCases.swift; sourceTree = "<group>"; };
 		8A55795324C1286E0098003A /* Examples.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Examples.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A55795624C1286E0098003A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		8A55795824C1286E0098003A /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -356,6 +358,7 @@
 				8A5579C524C1293C0098003A /* analytical.json */,
 				8A5579C624C1293C0098003A /* adativecard-embedded1.card.zip */,
 				8A5579C724C1293C0098003A /* card-explorer-numeric-list-card.card.zip */,
+				8A3C4E0324EB4A7B0084451B /* DataRequestTestCases.swift */,
 			);
 			path = SampleData;
 			sourceTree = "<group>";
@@ -604,6 +607,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8A55795724C1286E0098003A /* AppDelegate.swift in Sources */,
+				8A3C4E0424EB4A7B0084451B /* DataRequestTestCases.swift in Sources */,
 				8A557A0824C1293C0098003A /* BundleTestCases.swift in Sources */,
 				8A557A2424C12F380098003A /* ChartDetailView.swift in Sources */,
 				8A5579D024C1293C0098003A /* SettingsLine.swift in Sources */,

--- a/Apps/Examples/Examples/FioriIntegrationCards/IntegrationCardsContentView.swift
+++ b/Apps/Examples/Examples/FioriIntegrationCards/IntegrationCardsContentView.swift
@@ -41,17 +41,21 @@ extension Card: View {
 struct IntegrationCardsContentView: View {
 
     let cards: [String]
+
+    private var testCases: [CardTestCase] = []
     
     init(cards: [String]) {
         self.cards = cards
+        self.testCases.append(contentsOf: InlineTestCases.allCases)
+        self.testCases.append(contentsOf: DataRequestTestCases.allCases)
     }
     
     var body: some View {
         TabView {
 
-            List(InlineTestCases.allCases) { bundle in
+            List(testCases, id: \.id) { bundle in
                 NavigationLink(destination: LoadingView(card: bundle)) {
-                    Text(bundle.rawValue)
+                    Text(bundle.name())
                 }
             }
             .tabItem { Text("Test Cases") }
@@ -77,7 +81,7 @@ struct IntegrationCardsContentView: View {
 }
 
 struct LoadingView: View {
-    let card: InlineTestCases
+    let card: CardTestCase
     
     @State var isLoading = true
     @State var loadingMessage = "Loading ..."

--- a/Apps/Examples/Examples/FioriIntegrationCards/SampleData/DataRequestTestCases.swift
+++ b/Apps/Examples/Examples/FioriIntegrationCards/SampleData/DataRequestTestCases.swift
@@ -1,0 +1,36 @@
+//
+//  DataRequestTestCases.swift
+//  Examples
+//
+//  Created by Eidinger, Marco on 8/17/20.
+//  Copyright © 2020 SAP. All rights reserved.
+//
+
+import Foundation
+import FioriIntegrationCards
+
+enum DataRequestTestCases: String, CaseIterable, Identifiable, CardTestCase {
+    case ListDataRequestStaticData = "list (load data with request)"
+
+    var id: String {
+        return rawValue
+    }
+
+    func name() -> String {
+        return rawValue
+    }
+
+    func path() -> URL? {
+        return nil
+    }
+
+    func manifest() -> Manifest? {
+        do {
+            return try Manifest(withCardBundleAt: URL(string: "https://openui5.hana.ondemand.com/test-resources/sap/ui/integration/demokit/cardExplorer/webapp/")!, manifestPath: "samples/data/manifest.json")
+        } catch {
+            print(error)
+        }
+        return nil
+    }
+}
+

--- a/Apps/Examples/Examples/FioriIntegrationCards/SampleData/InlineTestCases.swift
+++ b/Apps/Examples/Examples/FioriIntegrationCards/SampleData/InlineTestCases.swift
@@ -9,7 +9,13 @@
 import Foundation
 import FioriIntegrationCards
 
-enum InlineTestCases: String, CaseIterable, Identifiable {
+protocol CardTestCase {
+    var id: String { get }
+    func name() -> String
+    func manifest() -> Manifest?
+}
+
+enum InlineTestCases: String, CaseIterable, Identifiable, CardTestCase {
     case analytical = "analytical"
     case list       = "list"
     case timeLine   = "timeline"
@@ -17,6 +23,10 @@ enum InlineTestCases: String, CaseIterable, Identifiable {
     case table      = "table"
     
     var id: String {
+        return rawValue
+    }
+
+    func name() -> String {
         return rawValue
     }
     

--- a/Sources/FioriIntegrationCards/Components/Common/Model/Manifest.swift
+++ b/Sources/FioriIntegrationCards/Components/Common/Model/Manifest.swift
@@ -32,10 +32,20 @@ public class Manifest: Decodable, Identifiable, ObservableObject {
         let tempCard = try _container.decode(Card.self, forKey: .card)
         _card = Published(initialValue: tempCard)
     }
-    
-    public init(withCardBundleAt path: URL) throws {
+
+/**
+    Initializer for a Manifest stored remotely
+     - Parameter path: base URL to card bundle stored on a server
+     - Parameter manifestPath: optional; specify path component for manifest.json if manifest.json is not stored as `manifest.json` in base folder
+
+     ## Code usage:
+     ```
+     let manifest = try Manifest(withCardBundleAt: URL(string: "https://openui5.hana.ondemand.com/test-resources/sap/ui/integration/demokit/cardExplorer/webapp/")!, manifestPath: "samples/data/manifest.json")
+     ```
+     */
+    public init(withCardBundleAt path: URL, manifestPath: String? = nil) throws {
         var _model: Manifest!
-        let _path = path.appendingPathComponent("manifest.json")
+        let _path = path.appendingPathComponent(manifestPath ?? "manifest.json")
         do {
             let data = try Data(contentsOf: _path)
             _model = try JSONDecoder().decode(Manifest.self, from: data)


### PR DESCRIPTION
manifest.json is not stored in directory for baseURL

Example: https://ui5.sap.com/test-resources/sap/ui/integration/demokit/cardExplorer/webapp/index.html#/explore/data

Card Base URL: https://openui5.hana.ondemand.com/test-resources/sap/ui/integration/demokit/cardExplorer/webapp/

Manifest URL: https://openui5.hana.ondemand.com/test-resources/sap/ui/integration/demokit/cardExplorer/webapp/samples/data/manifest.json