### PR TITLE
Package 5 3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,11 +1,12 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "FioriSwiftUI",
-    platforms: [.iOS(.v13)],
+    defaultLocalization: "en",
+    platforms: [.iOS(.v14)],
     products: [
         .library(
             name: "FioriSwiftUI",
@@ -22,9 +23,9 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/objcio/tiny-networking", from: "0.2.0"),
+        .package(name: "TinyNetworking", url: "https://github.com/objcio/tiny-networking", from: "0.2.0"),
         .package(url: "https://github.com/Flight-School/AnyCodable.git", from: "0.2.3"),
-        .package(url: "https://github.com/sstadelman/observable-array.git", from: "1.2.0"),
+        .package(name: "ObservableArray", url: "https://github.com/sstadelman/observable-array.git", from: "1.2.0"),
         .package(url: "https://github.com/marmelroy/Zip.git", from: "2.0.0")
     ],
     targets: [
@@ -36,10 +37,12 @@ let package = Package(
             dependencies: ["AnyCodable", "TinyNetworking", "ObservableArray", "FioriCharts", "Zip"]),
         .target(
             name: "FioriCharts",
-            dependencies: ["FioriSwiftUICore"]),
+            dependencies: ["FioriSwiftUICore"],
+            exclude: ["TestCases/SF_EnergyBenchmarking.csv"]),
         .target(
             name: "FioriSwiftUICore",
-            dependencies: []),
+            dependencies: [],
+            resources: [.process("FioriSwiftUICore.strings")]),
         .testTarget(
             name: "FioriSwiftUITests",
             dependencies: ["FioriSwiftUI"]),

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "FioriSwiftUI",
     defaultLocalization: "en",
-    platforms: [.iOS(.v14)],
+    platforms: [.iOS(.v13)],
     products: [
         .library(
             name: "FioriSwiftUI",


### PR DESCRIPTION
Updated Package.swift for 5.3.  

Notable changes:
 1. SPM 5.3 requires packages with localization resources to declare a default.  Set to `en`.
 2. Non-swift resources need to be explicitly included or excluded.  Handled strings file, and test case csv data. 