### PR TITLE
ci: manual workflow to record snapshot images

### DIFF
--- a/.github/workflows/recordSnapshotImages.yml
+++ b/.github/workflows/recordSnapshotImages.yml
@@ -1,0 +1,53 @@
+name: ManualWorkflows
+
+on:
+  workflow_dispatch:
+    inputs:
+      actionName:
+        description: 'Action'
+        required: true
+        default: 'recordSnapshotTests'
+
+jobs:
+
+  recordSnapshotTests:
+    if: github.event.inputs.actionName == 'recordSnapshotTests'
+    runs-on: macos-latest
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_11.6.app/Contents/Developer
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v2
+    - name: Checkout Snapshot references
+      uses: actions/checkout@v2
+      with:
+        repository: SAP/cloud-sdk-ios-fiori-snapshot-references
+        path: Apps/Examples/cloud-sdk-ios-fiori-snapshot-references
+    - name: Delete old snapshot references
+      run:  |
+        rm -r -f Apps/Examples/cloud-sdk-ios-fiori-snapshot-references/FioriCharts
+        rm -r -f Apps/Examples/cloud-sdk-ios-fiori-snapshot-references/FioriIntegrationCards
+    - name: Generate Xcode project
+      run: swift package generate-xcodeproj
+    - name: Install xcbeautify tool
+      run:  |
+        brew tap thii/xcbeautify https://github.com/thii/xcbeautify.git
+        brew install swiftlint xcbeautify
+    - name: Build Package
+      run: set -o pipefail && xcodebuild -project FioriSwiftUI.xcodeproj -scheme FioriSwiftUI-Package -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 11' build | xcbeautify
+    - name: Run snapshot tests
+      run: set -o pipefail && xcodebuild -project ./Apps/Examples/Examples.xcodeproj -scheme ExamplesTests -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone SE (2nd generation)' test | xcbeautify
+    - name: Create Pull Request
+      if: failure()
+      uses: peter-evans/create-pull-request@v3
+      with:
+        token: ${{ secrets.UPLOAD_SNAPSHOT_IMAGES }}
+        path: Apps/Examples/cloud-sdk-ios-fiori-snapshot-references
+        commit-message: Create/update images
+        committer: GitHub <noreply@github.com>
+        author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+        signoff: false
+        branch: workflowTriggeredRecordings
+        delete-branch: true
+        title: 'Record new/updates images'
+        draft: false


### PR DESCRIPTION
being able to record snapshot reference images (with a specific Xcode and iOS simulator version) and create PR for SAP/cloud-sdk-ios-fiori-snapshot-references via triggering workflow (GitHub action) manually