### PR TITLE
ci: being able to trigger sonar scan for pull requests from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,10 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  pull_request_target:
 
 jobs:
   build:
-
     runs-on: macos-latest
 
     steps:
@@ -33,6 +33,7 @@ jobs:
 
   sonar:
     needs: build
+    if: github.event_name == 'push' || github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -47,6 +48,5 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
-      if: github.repository == 'SAP/cloud-sdk-ios-fiori' && github.event_name == 'push'
 
 


### PR DESCRIPTION
GitHub added a new pull_request_target event, which behaves
 in an almost identical way to the pull_request event with the
same set of filters and payload. However, instead of running
against the workflow and code from the merge commit, the event
runs against the workflow and code from the base of the pull
request. This means the workflow is running from a trusted source
and is given access to a read/write token as well as secrets
enabling the maintainer to safely comment on or label a pull request.

https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/