### PR TITLE
refactor: 💡 cache used colors and palette update

### DIFF
--- a/Sources/FioriSwiftUICore/ColorPalette/Colors/ColorStyle.swift
+++ b/Sources/FioriSwiftUICore/ColorPalette/Colors/ColorStyle.swift
@@ -94,21 +94,21 @@ public enum ColorStyle: String, CaseIterable {
     /// (base light variant) ![](https://dummyimage.com/48x18/1C2228.png&text=+)              Hex color: 1C2228
     /// (elevated dark variant) ![](https://dummyimage.com/48x18/EDEFF0.png&text=+)        Hex color: EDEFF0
     /// (elevated light variant) ![](https://dummyimage.com/48x18/232A31.png&text=+)        Hex color: 232A31
-    case primaryGroupedBackgrond
+    case primaryGroupedBackground
     
     /// Secondary grouped background colors, with variants for base and elevated UI schemes.
     /// (base dark variant) ![](https://dummyimage.com/48x18/FFFFFF.png&text=+)              Hex color: FFFFFF
     /// (base light variant) ![](https://dummyimage.com/48x18/232A31.png&text=+)              Hex color: 232A31
     /// (elevated dark variant) ![](https://dummyimage.com/48x18/FFFFFF.png&text=+)        Hex color: FFFFFF
     /// (elevated light variant) ![](https://dummyimage.com/48x18/29313A.png&text=+)        Hex color: 29313A
-    case secondaryGroupedBackgrond
+    case secondaryGroupedBackground
     
     /// Secondary grouped background colors, with variants for base and elevated UI schemes.
     /// (base dark variant) ![](https://dummyimage.com/48x18/FFFFFF.png&text=+)              Hex color: FFFFFF
     /// (base light variant) ![](https://dummyimage.com/48x18/29313A.png&text=+)              Hex color: 29313A
     /// (elevated dark variant) ![](https://dummyimage.com/48x18/FFFFFF.png&text=+)        Hex color: FFFFFF
     /// (elevated light variant) ![](https://dummyimage.com/48x18/2F3943.png&text=+)        Hex color: 2F3943
-    case tertiaryGroupedBackgrond
+    case tertiaryGroupedBackground
     
     // MARK: - Background Colors
     
@@ -117,21 +117,21 @@ public enum ColorStyle: String, CaseIterable {
     /// (base light variant) ![](https://dummyimage.com/48x18/232A31.png&text=+)              Hex color: 232A31
     /// (elevated dark variant) ![](https://dummyimage.com/48x18/FFFFFF.png&text=+)        Hex color: FFFFFF
     /// (elevated light variant) ![](https://dummyimage.com/48x18/29313A.png&text=+)        Hex color: 29313A
-    case primaryBackgrond
+    case primaryBackground
     
     /// Secondary grouped background colors, with variants for base and elevated UI schemes.
     /// (base dark variant) ![](https://dummyimage.com/48x18/F7F7F7.png&text=+)              Hex color: F7F7F7
     /// (base light variant) ![](https://dummyimage.com/48x18/1C2228.png&text=+)              Hex color: 1C2228
     /// (elevated dark variant) ![](https://dummyimage.com/48x18/F7F7F7.png&text=+)        Hex color: F7F7F7
     /// (elevated light variant) ![](https://dummyimage.com/48x18/232A31.png&text=+)        Hex color: 232A31
-    case secondaryBackgrond
+    case secondaryBackground
     
     /// Secondary grouped background colors, with variants for base and elevated UI schemes.
     /// (base dark variant) ![](https://dummyimage.com/48x18/FFFFFF.png&text=+)              Hex color: FFFFFF
     /// (base light variant) ![](https://dummyimage.com/48x18/29313A.png&text=+)              Hex color: 29313A
     /// (elevated dark variant) ![](https://dummyimage.com/48x18/FFFFFF.png&text=+)        Hex color: FFFFFF
     /// (elevated light variant) ![](https://dummyimage.com/48x18/2F3943.png&text=+)        Hex color: 2F3943
-    case tertiaryBackgrond
+    case tertiaryBackground
     
     // MARK: - Label Colors
     
@@ -200,6 +200,18 @@ public enum ColorStyle: String, CaseIterable {
     /// (light variant) ![](https://dummyimage.com/48x18/2C3D4F.png&text=+)          Hex value: 2C3D4F
     case header
     
+    /// Blended color for navigation bar or headers.
+    /// (dark variant) ![](https://dummyimage.com/48x18/FFFFFF.png&text=+)          Hex value: FFFFFFA6 (alpha: 65%)
+    /// (light variant) ![](https://dummyimage.com/48x18/1C2228.png&text=+)          Hex value: 1C2228A6 (alpha: 65%)
+    /// (elevated dark variant) ![](https://dummyimage.com/48x18/FFFFFF.png&text=+)        Hex color: FFFFFFA6 (alpha: 65%)
+    /// (elevated light variant) ![](https://dummyimage.com/48x18/232A31.png&text=+)        Hex color: 232A31A6 (alpha: 65%)
+    case headerBlended
+    
+    /// Transparent color for navigation bar or tap bar.
+    /// (dark variant) ![](https://dummyimage.com/48x18/23303E.png&text=+)          Hex value: 23303ED9 (alpha: 85%)
+    /// (light variant) ![](https://dummyimage.com/48x18/23303E.png&text=+)          Hex value: 23303ED9 (alpha: 85%)
+    case barTransparent
+    
     /// Standard background color for toolbar, tab bar or footers.
     /// (dark variant) ![](https://dummyimage.com/48x18/FAFAFA.png&text=+)          Hex value: FAFAFAEB (alpha: 92%)
     /// (light variant) ![](https://dummyimage.com/48x18/23303E.png&text=+)          Hex value: 23303EEB (alpha: 92%)
@@ -218,17 +230,17 @@ public enum ColorStyle: String, CaseIterable {
     /// Wraps `tintColorLight` and `tintColorDark`.
     /// Use `Color.preferredColor(forStyle:background:)` to select appropriate variant.
     /// (dark variant) ![](https://dummyimage.com/48x18/0A6ED1.png&text=+)          Hex color: 0A6ED1
-    /// (light variant) ![](https://dummyimage.com/48x18/D1E8FF.png&text=+)          Hex color: D1E8FF
+    /// (light variant) ![](https://dummyimage.com/48x18/91C8F6.png&text=+)          Hex color: 91C8F6
     case tintColor
     
     /// Default light `tintColor`.
-    /// (dark variant) ![](https://dummyimage.com/48x18/D1E8FF.png&text=+)          Hex color: D1E8FF
-    /// (light variant) ![](https://dummyimage.com/48x18/0A84FF.png&text=+)          Hex color: 0A84FF
+    /// (dark variant) ![](https://dummyimage.com/48x18/91C8F6.png&text=+)          Hex color: 91C8F6
+    /// (light variant) ![](https://dummyimage.com/48x18/91C8F6.png&text=+)          Hex color: 91C8F6
     case tintColorLight
     
     /// Default dark `tintColor`.
     /// (dark variant) ![](https://dummyimage.com/48x18/0A6ED1.png&text=+)          Hex color: 0A6ED1
-    /// (light variant) ![](https://dummyimage.com/48x18/0A84FF.png&text=+)          Hex color: 0A84FF
+    /// (light variant) ![](https://dummyimage.com/48x18/0A6ED1.png&text=+)          Hex color: 0A6ED1
     case tintColorDark
     
     /// Wraps `tintColorTapStateLight` and `tintColorTapStateDark`.

--- a/Sources/FioriSwiftUICore/ColorPalette/PaletteVersion.swift
+++ b/Sources/FioriSwiftUICore/ColorPalette/PaletteVersion.swift
@@ -118,7 +118,7 @@ public enum PaletteVersion: CaseIterable {
         case .v4:
             return [.navigationBar, .stockUpStroke, .stockDownStroke]
         case .v5:
-            return [.shell, .background1, .background2, .separator, .shadow, .primaryGroupedBackgrond, .secondaryGroupedBackgrond, .tertiaryGroupedBackgrond, .primaryBackgrond, .secondaryBackgrond, .tertiaryBackgrond, .primaryLabel, .secondaryLabel, .tertiaryLabel, .quarternaryLabel, .primaryFill, .secondaryFill, .tertiaryFill, .quarternaryFill, .header, .footer, .cellBackground, .negativeLabel, .positiveLabel, .criticalLabel, .negativeBackground, .positiveBackground, .criticalBackground, .informationBackground]
+            return [.shell, .background1, .background2, .separator, .shadow, .primaryGroupedBackground, .secondaryGroupedBackground, .tertiaryGroupedBackground, .primaryBackground, .secondaryBackground, .tertiaryBackground, .primaryLabel, .secondaryLabel, .tertiaryLabel, .quarternaryLabel, .primaryFill, .secondaryFill, .tertiaryFill, .quarternaryFill, .header, .footer, .cellBackground, .negativeLabel, .positiveLabel, .criticalLabel, .negativeBackground, .positiveBackground, .criticalBackground, .informationBackground]
         }
     }
 }

--- a/Sources/FioriSwiftUICore/ColorPalette/Palettes/PaletteV5.swift
+++ b/Sources/FioriSwiftUICore/ColorPalette/Palettes/PaletteV5.swift
@@ -53,17 +53,17 @@ struct PaletteV5: PaletteProvider {
             return HexColor(lightColor: "8696A9", darkColor: "89919A")
         case .shadow:
             return HexColor(lightColor: "000000")
-        case .primaryGroupedBackgrond:
+        case .primaryGroupedBackground:
             return HexColor(lightColor: "1C2228", darkColor: "EDEFF0", elevatedLightColor: "232A31", elevatedDarkColor: "EDEFF0")
-        case .secondaryGroupedBackgrond:
+        case .secondaryGroupedBackground:
             return HexColor(lightColor: "232A31", darkColor: "FFFFFF", elevatedLightColor: "29313A", elevatedDarkColor: "FFFFFF")
-        case .tertiaryGroupedBackgrond:
+        case .tertiaryGroupedBackground:
             return HexColor(lightColor: "29313A", darkColor: "FFFFFF", elevatedLightColor: "2F3943", elevatedDarkColor: "FFFFFF")
-        case .primaryBackgrond:
+        case .primaryBackground:
             return HexColor(lightColor: "232A31", darkColor: "FFFFFF", elevatedLightColor: "29313A", elevatedDarkColor: "FFFFFF")
-        case .secondaryBackgrond:
+        case .secondaryBackground:
             return HexColor(lightColor: "1C2228", darkColor: "F7F7F7", elevatedLightColor: "232A31", elevatedDarkColor: "F7F7F7")
-        case .tertiaryBackgrond:
+        case .tertiaryBackground:
             return HexColor(lightColor: "29313A", darkColor: "FFFFFF", elevatedLightColor: "2F3943", elevatedDarkColor: "FFFFFF")
         case .primaryLabel:
             return HexColor(lightColor: "FAFAFA", darkColor: "32363A", contrastLightColor: "FAFAFA", contrastDarkColor: "FAFAFA")
@@ -83,6 +83,10 @@ struct PaletteV5: PaletteProvider {
             return HexColor(lightColor: "8696A91C", darkColor: "89919A14", contrastLightColor: "8696A91C", contrastDarkColor: "8696A91C")
         case .header:
             return HexColor(lightColor: "2C3D4F", darkColor: "354A5F")
+        case .headerBlended:
+            return HexColor(lightColor: "1C2228A6", darkColor: "FFFFFFA6", contrastLightColor: "232A31A6", contrastDarkColor: "FFFFFFA6")
+        case .barTransparent:
+            return HexColor(lightColor: "23303ED9", darkColor: "23303ED9")
         case .footer:
             return HexColor(lightColor: "23303EEB", darkColor: "FAFAFAEB")
         case .cellBackground:
@@ -92,11 +96,11 @@ struct PaletteV5: PaletteProvider {
         case .tintColor:
             return HexColor(lightColor: "91C8F6", darkColor: "0A6ED1", contrastLightColor: "91C8F6", contrastDarkColor: "91C8F6")
         case .tintColorLight:
-            return HexColor(lightColor: "0A84FF", darkColor: "D1E8FF")
+            return HexColor(lightColor: "91C8F6", darkColor: "91C8F6")
         case .tintColorDark:
-            return HexColor(lightColor: "0A84FF", darkColor: "0A6ED1")
+            return HexColor(lightColor: "91C8F6", darkColor: "0A6ED1")
         case .tintColorTapState:
-            return HexColor(lightColor: "0A84FF66", darkColor: "0854A1")
+            return HexColor(lightColor: "91C8F666", darkColor: "0A6ED166", contrastLightColor: "91C8F666", contrastDarkColor: "91C8F666")
         case .tintColorTapStateLight:
             return HexColor(lightColor: "0A84FF66", darkColor: "74A5D5")
         case .tintColorTapStateDark:

--- a/Sources/FioriSwiftUICore/ColorPalette/ThemeManager.swift
+++ b/Sources/FioriSwiftUICore/ColorPalette/ThemeManager.swift
@@ -13,6 +13,8 @@ public class ThemeManager {
     /// Singleton instance shared by all application components.
     public static let shared: ThemeManager = ThemeManager()
     
+    private var resolvedColors: [ColorStyle: Color] = [ColorStyle: Color]()
+    
     private init() {}
     
     /// Method to allow selecting a specific version of the palette.  Defaults to `latest`.
@@ -43,14 +45,19 @@ public class ThemeManager {
     
     /// :nodoc:
     internal func color(for style: ColorStyle, background scheme: BackgroundColorScheme?, interface level: InterfaceLevel?, display mode: ColorDisplayMode?) -> Color {
+        if let resolvedColor = resolvedColors[style] {
+            return resolvedColor
+        }
         let hexColor: HexColor = palette.hexColor(for: style)
         let uiColor: UIColor = UIColor { traitCollection in
-            let variant = hexColor.getVariant(traits: traitCollection, background: scheme, interface: level, display: mode)
-            let hexColorString = hexColor.hex(variant)
+            let variant: ColorVariant = hexColor.getVariant(traits: traitCollection, background: scheme, interface: level, display: mode)
+            let hexColorString: String = hexColor.hex(variant)
             let components = hexColor.rgba(hexColorString)
             return UIColor(red: CGFloat(components.r), green: CGFloat(components.g),
                            blue: CGFloat(components.b), alpha: CGFloat(components.a))
         }
-        return Color(uiColor)
+        let color: Color = Color(uiColor)
+        resolvedColors[style] = color
+        return color
     }
 }


### PR DESCRIPTION
1. Address naming typos mentioned in Issue #152.
2. Update color palette per GD recommendations.
3. Cached generated dynamic colors per style to reduce new HexColor creations.