### PR TITLE
ci: improve runtime and avoid issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-  pull_request_target:
 
 jobs:
   build:
@@ -17,36 +16,3 @@ jobs:
       run: swift package generate-xcodeproj
     - name: Build and Test on iOS 14 / Xcode 12
       run: set -o pipefail && xcodebuild -project FioriSwiftUI.xcodeproj -scheme FioriSwiftUI-Package -sdk iphonesimulator -destination 'platform=iOS Simulator,OS=14.0,name=iPhone 11' clean build test | xcpretty
-      env:
-        DEVELOPER_DIR: '/Applications/Xcode_12.app/Contents/Developer'
-    - name: Build and Test on iOS 13 / Xcode 11
-      run: set -o pipefail && xcodebuild -enableCodeCoverage YES -derivedDataPath Build/ -project FioriSwiftUI.xcodeproj -scheme FioriSwiftUI-Package -sdk iphonesimulator -destination 'platform=iOS Simulator,OS=13.7,name=iPhone 11' clean build test | xcpretty
-      env:
-        DEVELOPER_DIR: '/Applications/Xcode_11.7.app/Contents/Developer'
-    - name: Create code coverage report
-      run: ./scripts/xccov-to-sonarqube-generic.sh Build/Logs/Test/*.xcresult/ > sonarqube-generic-coverage.xml
-    - name: Store coverage for sonar job
-      uses: actions/upload-artifact@v1
-      with:
-        name: coverage
-        path: sonarqube-generic-coverage.xml
-
-  sonar:
-    needs: build
-    if: github.event_name == 'push' || github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Get coverage from build job
-      uses: actions/download-artifact@v1
-      with:
-        name: coverage
-    - name: Scan
-      uses: sonarsource/sonarcloud-github-action@master
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
-
-

--- a/.github/workflows/ci_xcode11.yml
+++ b/.github/workflows/ci_xcode11.yml
@@ -1,0 +1,48 @@
+name: CI (Xcode 11)
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  pull_request_target:
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Generate Xcode project
+      run: swift package generate-xcodeproj
+      env:
+        DEVELOPER_DIR: '/Applications/Xcode_11.7.app/Contents/Developer'
+    - name: Build and Test on iOS 13 / Xcode 11
+      run: set -o pipefail && xcodebuild -enableCodeCoverage YES -derivedDataPath Build/ -project FioriSwiftUI.xcodeproj -scheme FioriSwiftUI-Package -sdk iphonesimulator -destination 'platform=iOS Simulator,OS=13.7,name=iPhone 11' clean build test | xcpretty
+      env:
+        DEVELOPER_DIR: '/Applications/Xcode_11.7.app/Contents/Developer'
+    - name: Create code coverage report
+      run: ./scripts/xccov-to-sonarqube-generic.sh Build/Logs/Test/*.xcresult/ > sonarqube-generic-coverage.xml
+    - name: Store coverage for sonar job
+      uses: actions/upload-artifact@v1
+      with:
+        name: coverage
+        path: sonarqube-generic-coverage.xml
+
+  sonar:
+    needs: build
+    if: github.event_name == 'push' || github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Get coverage from build job
+      uses: actions/download-artifact@v1
+      with:
+        name: coverage
+    - name: Scan
+      uses: sonarsource/sonarcloud-github-action@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}

--- a/.github/workflows/pr_only.yml
+++ b/.github/workflows/pr_only.yml
@@ -40,20 +40,32 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+    - name: Check for file changes in Sources folder
+      uses: getsentry/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          src:
+            - 'Sources/**'
     - name: Checkout Snapshot references
       uses: actions/checkout@v2
+      if: steps.changes.outputs.src == 'true'
       with:
         repository: SAP/cloud-sdk-ios-fiori-snapshot-references
         path: Apps/Examples/cloud-sdk-ios-fiori-snapshot-references
     - name: Generate Xcode project
+      if: steps.changes.outputs.src == 'true'
       run: swift package generate-xcodeproj
     - name: Install xcbeautify tool
+      if: steps.changes.outputs.src == 'true'
       run:  |
         brew tap thii/xcbeautify https://github.com/thii/xcbeautify.git
         brew install swiftlint xcbeautify
     - name: Build Package
+      if: steps.changes.outputs.src == 'true'
       run: set -o pipefail && xcodebuild -project FioriSwiftUI.xcodeproj -scheme FioriSwiftUI-Package -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 11' build | xcbeautify
     - name: Run snapshot tests
+      if: steps.changes.outputs.src == 'true'
       run: set -o pipefail && xcodebuild -project ./Apps/Examples/Examples.xcodeproj -scheme ExamplesTests -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone SE (2nd generation)' test | xcbeautify
     - name: Collect screenshot results on failure
       if: failure()


### PR DESCRIPTION
- separate different xcode build jobs to avoid issues
- run snapshot tests only if `Sources/**` were changed