### PR TITLE
ci: being able to trigger sonar scan for pull requests from forks

### DIFF
--- a/.github/workflows/ci_xcode11.yml
+++ b/.github/workflows/ci_xcode11.yml
@@ -3,9 +3,8 @@ name: CI (Xcode 11)
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
   pull_request_target:
+    branches: [ main ]
 
 jobs:
   build:
@@ -31,7 +30,7 @@ jobs:
 
   sonar:
     needs: build
-    if: github.event_name == 'push' || github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
+    if: github.repository == 'SAP/cloud-sdk-ios-fiori'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -41,8 +40,19 @@ jobs:
       uses: actions/download-artifact@v1
       with:
         name: coverage
-    - name: Scan
+    - name: Scan (main branch)
+      if: github.event_name == 'push'
       uses: sonarsource/sonarcloud-github-action@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
+    - name: Scan (PR)
+      if: github.event_name == 'pull_request_target'
+      uses: sonarsource/sonarcloud-github-action@master
+      with:
+        args: >
+          -Dsonar.branch.name=${{ github.event.pull_request.head.ref }}
+          -Dsonar.branch.target=main
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}


### PR DESCRIPTION
use pull_request_target

GitHub added a new pull_request_target event, which behaves
 in an almost identical way to the pull_request event with the
same set of filters and payload. However, instead of running
against the workflow and code from the merge commit, the event
runs against the workflow and code from the base of the pull
request. This means the workflow is running from a trusted source
and is given access to a read/write token as well as secrets
enabling the maintainer to safely comment on or label a pull request.

https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/