### PR TITLE
chore: 🤖 proper type-based initializer for composite view model

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/Experimental/Examples/ContactItemActionItemsExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/Experimental/Examples/ContactItemActionItemsExample.swift
@@ -52,6 +52,12 @@ struct ContactItemActionItemsExample: View {
                 }
                 .exampleHighlighting()
 
+                ExpHeaderView(nil, subtitle: "Option: Type-based init", desc: "SDK will internally choose and initialize the control handling action items")
+
+                ContactItem(title: viewModel.title_, subtitle: viewModel.subtitle_, footnote: viewModel.footnote_, descriptionText: viewModel.descriptionText_,
+                            detailImage: viewModel.detailImage_, actionItems: viewModel.actionItems_, didSelectClosure: viewModel.didSelect(_:))
+                    .exampleHighlighting()
+
                 ExpHeaderView(nil, subtitle: "Option: Protocol/Model-based init", desc: "conform your model to protocol `ContactItemModel`")
 
                 ContactItem(model: viewModel)

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Example is `ContactItemModel` which is composed of primitive components (TitleCo
 public protocol ContactItemModel: TitleComponent, SubtitleComponent, FootnoteComponent, DescriptionTextComponent, DetailImageComponent, ActivityItemsModel {}
 ```
 
-To generate a ViewModel (e.g `ContactItem`) on which a property shall be backed by a SDK control implementation (generated or written manually, here: `ActivityItems` as generated implementation conforming to `ActionItemsComponent`) you have to declare the following sourcery tag **twice**.
+To generate a ViewModel (e.g `ContactItem`) on which a property shall be backed by a SDK control implementation (generated or written manually, here: `ActivityItems` as generated implementation conforming to `ActionItemsComponent`) you have to declare the following sourcery tag.
 
 - `backingComponent = <NameOfBackingView>`
 
@@ -264,7 +264,6 @@ To generate a ViewModel (e.g `ContactItem`) on which a property shall be backed 
 // sourcery: backingComponent=ActivityItems
 internal protocol _ActionItems: _ComponentMultiPropGenerating {
   // sourcery: no_style
-  // sourcery: backingComponent=ActivityItems
   var actionItems_: [ActivityItemDT]?
   func didSelect(_ activityItem: ActivityItemDT) {}
 }
@@ -275,7 +274,6 @@ Those annotations will be copied to the standard component interface (`Component
 ```swift
 // sourcery: backingComponent=ActivityItems
 public protocol ActionItemsComponent {
-	// sourcery: backingComponent=ActivityItems
 	// sourcery: no_style
     var actionItems_: [ActivityItemDataType]? { get }
 	func didSelect(_ activityItem: ActivityItemDataType) -> Void

--- a/Sources/FioriSwiftUICore/Components/MultiPropertyComponents.swift
+++ b/Sources/FioriSwiftUICore/Components/MultiPropertyComponents.swift
@@ -6,7 +6,6 @@ internal protocol _ComponentMultiPropGenerating {}
 // sourcery: backingComponent=ActivityItems
 internal protocol _ActionItems: _ComponentMultiPropGenerating {
     // sourcery: no_style
-    // sourcery: backingComponent=ActivityItems
     var actionItems_: [ActivityItemDataType]? { get }
     func didSelect(_ activityItem: ActivityItemDataType)
 }

--- a/Sources/FioriSwiftUICore/Components/MultiPropertyComponents.swift
+++ b/Sources/FioriSwiftUICore/Components/MultiPropertyComponents.swift
@@ -3,10 +3,10 @@ import Foundation
 /// use for component with a function and one (or more) properties
 internal protocol _ComponentMultiPropGenerating {}
 
+// sourcery: backingComponent=ActivityItems
 internal protocol _ActionItems: _ComponentMultiPropGenerating {
     // sourcery: no_style
     // sourcery: backingComponent=ActivityItems
-    // sourcery: backingComponentArgumentLabel=actionItemsControl
     var actionItems_: [ActivityItemDataType]? { get }
     func didSelect(_ activityItem: ActivityItemDataType)
 }

--- a/Sources/FioriSwiftUICore/_generated/Components/Component+Protocols.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/Components/Component+Protocols.generated.swift
@@ -122,7 +122,6 @@ public protocol UpperBoundTitleComponent {
 
 // sourcery: backingComponent=ActivityItems
 public protocol ActionItemsComponent {
-	// sourcery: backingComponent=ActivityItems
 	// sourcery: no_style
     var actionItems_: [ActivityItemDataType]? { get }
 	func didSelect(_ activityItem: ActivityItemDataType) -> Void

--- a/Sources/FioriSwiftUICore/_generated/Components/Component+Protocols.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/Components/Component+Protocols.generated.swift
@@ -120,9 +120,9 @@ public protocol UpperBoundTitleComponent {
 }
 
 
+// sourcery: backingComponent=ActivityItems
 public protocol ActionItemsComponent {
 	// sourcery: backingComponent=ActivityItems
-	// sourcery: backingComponentArgumentLabel=actionItemsControl
 	// sourcery: no_style
     var actionItems_: [ActivityItemDataType]? { get }
 	func didSelect(_ activityItem: ActivityItemDataType) -> Void

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/API/ContactItem+API.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/API/ContactItem+API.generated.swift
@@ -63,15 +63,20 @@ extension ContactItem where Title == Text,
 		ActionItems == _ConditionalContent<ActivityItems, EmptyView> {
 
     public init(model: ContactItemModel) {
-        self.init(title: model.title_, subtitle: model.subtitle_, footnote: model.footnote_, descriptionText: model.descriptionText_, detailImage: model.detailImage_, actionItemsControl: ActivityItems(model: model))
+        self.init(title: model.title_, subtitle: model.subtitle_, footnote: model.footnote_, descriptionText: model.descriptionText_, detailImage: model.detailImage_, actionItems: model.actionItems_, didSelectClosure: model.didSelect(_:))
     }
 
-    public init(title: String, subtitle: String? = nil, footnote: String? = nil, descriptionText: String? = nil, detailImage: Image? = nil, actionItemsControl: ActivityItems? = nil) {
+    public init(title: String, subtitle: String? = nil, footnote: String? = nil, descriptionText: String? = nil, detailImage: Image? = nil, actionItems: [ActivityItemDataType]? = nil, didSelectClosure: ((ActivityItemDataType) -> Void)? = nil) {
         self._title = Text(title)
 		self._subtitle = subtitle != nil ? ViewBuilder.buildEither(first: Text(subtitle!)) : ViewBuilder.buildEither(second: EmptyView())
 		self._footnote = footnote != nil ? ViewBuilder.buildEither(first: Text(footnote!)) : ViewBuilder.buildEither(second: EmptyView())
 		self._descriptionText = descriptionText != nil ? ViewBuilder.buildEither(first: Text(descriptionText!)) : ViewBuilder.buildEither(second: EmptyView())
 		self._detailImage = detailImage != nil ? ViewBuilder.buildEither(first: detailImage!) : ViewBuilder.buildEither(second: EmptyView())
-		self._actionItems = actionItemsControl != nil ? ViewBuilder.buildEither(first: actionItemsControl!) : ViewBuilder.buildEither(second: EmptyView())
+		// handle ActivityItemsModel
+        if (actionItems != nil || didSelectClosure != nil) {
+            self._actionItems =  ViewBuilder.buildEither(first: ActivityItems(actionItems: actionItems,didSelectClosure: didSelectClosure))
+        } else {
+            self._actionItems = ViewBuilder.buildEither(second: EmptyView())
+        }
     }
 }

--- a/sourcery/.lib/Sources/utils/Array+Variable.swift
+++ b/sourcery/.lib/Sources/utils/Array+Variable.swift
@@ -7,7 +7,7 @@ public extension Array where Element == Variable {
     func foo() -> String { "Foo" }
     /**
      Formats a list `View`-conforming generic parameter for struct declaration.
-     
+
      Returned as an array, so that it can be flat-mapped with generic parameters specified in sourcery annotations.
      ```
      Title: View, Subtitle: View, ...
@@ -16,7 +16,7 @@ public extension Array where Element == Variable {
     var templateParameterDecls: [String] {
         map { "\($0.trimmedName.capitalizingFirst()): View" }
     }
-    
+
     /**
      Formats accessor property to Environment-cached `ViewModifier` for each component property
      ```
@@ -29,7 +29,7 @@ public extension Array where Element == Variable {
         filter { $0.annotations.keys.contains("no_style") == false }
             .map { "@Environment(\\.\($0.trimmedName)Modifier) private var \($0.trimmedName)Modifier" }
     }
-    
+
     /**
      Formats private 'caching' properties to hold the developer-supplied ViewBuilder for each property
      ```
@@ -45,7 +45,7 @@ public extension Array where Element == Variable {
     var dataTypePropertyDecls: [String] {
         map { "var _\($0.trimmedName): \($0.typeName) = nil" }
     }
-    
+
     /**
      Formats list of init ViewBuilder parameters
      ```
@@ -57,7 +57,7 @@ public extension Array where Element == Variable {
     var viewBuilderInitParams: [String] {
         map { "@ViewBuilder \($0.trimmedName): @escaping () -> \($0.trimmedName.capitalizingFirst())" }
     }
-    
+
     /**
      Formats the assignment from init params to caching stored properties
      ```
@@ -72,10 +72,10 @@ public extension Array where Element == Variable {
     var viewBuilderInitParamAssignment: [String] {
         map { "self._\($0.trimmedName) = \($0.trimmedName)()" }
     }
-    
+
     /**
      Responsible for resolving view modifiers from default styling, and Environment property
-     
+
        Generates as follows:
       ```
       var title: some View {
@@ -94,7 +94,7 @@ public extension Array where Element == Variable {
 public extension Array where Element: Variable {
     /**
      Formatted assignments for initializer which takes optional content.
-     
+
      Uses `ViewBuilder.buildEither` to account for nil content injected via this API
      ```
      init( /* ... */ ) { // starts here =>
@@ -110,10 +110,6 @@ public extension Array where Element: Variable {
      */
     var extensionModelInitParamsAssignments: [String] {
         map { "self._\($0.trimmedName) = \($0.conditionalAssignment)" }
-    }
-
-    var extensionModelInitParamsBackedAssignments: [String] {
-        map { "self._\($0.trimmedName) = \($0.conditionalAssignmentBacked)" }
     }
 
     var extensionModelInitParamsDataTypeAssignments: [String] {
@@ -152,26 +148,6 @@ extension Array where Element: Variable {
 
     public var extensionModelInitParams: [String] {
         map { "\($0.trimmedName): \($0.typeName.name)\($0.emptyDefault)" }
-    }
-
-    public var extensionModelInitParamsBacked: [String] {
-        map {
-            if let backingSwiftUIComponent = $0.backingSwiftUIComponent {
-                return "\($0.backingSwiftUIComponentArgumentLabel!): \(backingSwiftUIComponent)\($0.isOptional ? "?" : "")\($0.emptyDefault)"
-            } else {
-                return "\($0.trimmedName): \($0.typeName.name)\($0.emptyDefault)"
-            }
-        }
-    }
-
-    public var extensionModelInitParamsBackedChaining: [String] {
-        map {
-            if let backingComponentSwiftUIComponent = $0.backingSwiftUIComponent, let backingSwiftUIComponentArgumentLabel = $0.backingSwiftUIComponentArgumentLabel {
-                return "\(backingSwiftUIComponentArgumentLabel): \(backingComponentSwiftUIComponent)(model: model)"
-            } else {
-                return "\($0.trimmedName): model.\($0.name)"
-            }
-        }
     }
 
     public var extensionModelInitParamsChaining: [String] {

--- a/sourcery/.lib/Sources/utils/Variable+Extensions.swift
+++ b/sourcery/.lib/Sources/utils/Variable+Extensions.swift
@@ -35,7 +35,7 @@ public extension Variable {
 
     var conditionalAssignmentBacked: String {
         if isOptional {
-            return "\(self.backingSwiftUIComponentArgumentLabel ?? self.trimmedName) != nil ? ViewBuilder.buildEither(first: \(self.toSwiftUIBacked)) : ViewBuilder.buildEither(second: EmptyView())"
+            return "\(self.trimmedName) != nil ? ViewBuilder.buildEither(first: \(self.toSwiftUIBacked)) : ViewBuilder.buildEither(second: EmptyView())"
         } else {
             return self.toSwiftUIBacked
         }
@@ -43,10 +43,6 @@ public extension Variable {
 
     var backingSwiftUIComponent: String? {
         resolvedAnnotations("backingComponent").first
-    }
-
-    var backingSwiftUIComponentArgumentLabel: String? {
-        resolvedAnnotations("backingComponentArgumentLabel").first
     }
 
     var toSwiftUI: String {
@@ -63,10 +59,6 @@ public extension Variable {
     }
 
     var toSwiftUIBacked: String {
-        if let backingSwiftUIComponentLabel = backingSwiftUIComponentArgumentLabel {
-            return isOptional ? "\(backingSwiftUIComponentLabel)!" : backingSwiftUIComponentLabel
-        }
-
         switch self.typeName.unwrappedTypeName {
         case "String":
             return isOptional ? "Text(\(self.trimmedName)!)" : "Text(\(self.trimmedName))"

--- a/sourcery/.lib/Sources/utils/Variable+Extensions.swift
+++ b/sourcery/.lib/Sources/utils/Variable+Extensions.swift
@@ -42,7 +42,7 @@ public extension Variable {
     }
 
     var backingSwiftUIComponent: String? {
-        resolvedAnnotations("backingComponent").first
+        self.definedInType?.resolvedAnnotations("backingComponent").first
     }
 
     var toSwiftUI: String {

--- a/sourcery/stencils/main_phase/model_decl_base.swifttemplate
+++ b/sourcery/stencils/main_phase/model_decl_base.swifttemplate
@@ -45,19 +45,19 @@ for model in models {
     ].flatMap { $0 }.joined(separator: "\n\t\t\t")
 
     let extensionModelInitParams = [
-        componentProperties.extensionModelInitParamsBacked,
+        componentProperties.extensionModelInitParams,
         closureProperties.extensionModelInitClosureParams,
         model.add_view_builder_paramsViewBuilderInitParams
     ].flatMap { $0 }.joined(separator: ", ")
 
     let extensionModelInitParamsChaining = [
-        componentProperties.extensionModelInitParamsBackedChaining,
+        componentProperties.extensionModelInitParamsChaining,
         closureProperties.extensionModelInitClosureParamsChaining,
         model.add_view_builder_paramsExtensionModelInitParamsChaining
     ].flatMap { $0 }.joined(separator: ", ")
 
     let extensionModelInitParamsAssignments = [
-        componentProperties.extensionModelInitParamsBackedAssignments,
+        componentProperties.extensionModelInitParamsAssignments,
         closureProperties.extensionModelInitClosureParamsAssignments,
         model.add_view_builder_paramsViewBuilderInitParamAssignment
     ].flatMap { $0 }.joined(separator: "\n\t\t")

--- a/sourcery/stencils/post_phase/composite_model_decl.swifttemplate
+++ b/sourcery/stencils/post_phase/composite_model_decl.swifttemplate
@@ -56,7 +56,7 @@ for model in models {
     ].flatMap { $0 }.joined(separator: ", ")
 
     let extensionModelInitParamsAssignments = [
-        model.extensionModelInitParamsAssignments(contextType: type, allTypes: types),
+        model.extensionModelInitParamsAssignments,
         model.add_view_builder_paramsViewBuilderInitParamAssignment
     ].flatMap { $0 }.joined(separator: "\n\t\t")
 

--- a/sourcery/stencils/post_phase/composite_model_decl.swifttemplate
+++ b/sourcery/stencils/post_phase/composite_model_decl.swifttemplate
@@ -11,6 +11,8 @@ let models = types.protocols.filter({ $0.annotations["generated_component_compos
 
 for model in models {
 
+    let closureProperties = model.closureProperties(contextType: type)
+
     let componentProperties = model.flattenedComponentProperties(contextType: type)
     let styleName = model.componentStyleName
 
@@ -42,17 +44,19 @@ for model in models {
     ].flatMap { $0 }.joined(separator: "\n\t\t\t")
 
     let extensionModelInitParams = [
-        componentProperties.extensionModelInitParamsBacked,
+        componentProperties.extensionModelInitParams,
+		closureProperties.extensionModelInitClosureParams,
         model.add_view_builder_paramsViewBuilderInitParams
     ].flatMap { $0 }.joined(separator: ", ")
 
     let extensionModelInitParamsChaining = [
-        componentProperties.extensionModelInitParamsBackedChaining,
+        componentProperties.extensionModelInitParamsChaining,
+		closureProperties.extensionModelInitClosureParamsChaining,
         model.add_view_builder_paramsExtensionModelInitParamsChaining
     ].flatMap { $0 }.joined(separator: ", ")
 
     let extensionModelInitParamsAssignments = [
-        componentProperties.extensionModelInitParamsBackedAssignments,
+        model.extensionModelInitParamsAssignments(contextType: type, allTypes: types),
         model.add_view_builder_paramsViewBuilderInitParamAssignment
     ].flatMap { $0 }.joined(separator: "\n\t\t")
 
@@ -105,6 +109,7 @@ extension <%= model.componentName %> where <%= componentProperties.extensionCons
         <%= extensionModelInitParamsAssignments %>
     }
 }
+
 // sourcery:end
 
 // sourcery:file:ViewModels/Boilerplate/<%= model.componentName %>+View.generated.swift

--- a/sourcery/stencils/pre_phase/component_decl.stencil
+++ b/sourcery/stencils/pre_phase/component_decl.stencil
@@ -26,9 +26,8 @@ public protocol {{NAME | upperFirstLetter}}Component {
 {% for type in types.implementing._ComponentMultiPropGenerating %}
 {% set NAME %}{{ type.name|replace:'_','' }}{% endset %}
 
-{% for annotationKey, annotationValue in type.annotations %}{% if annotationKey|contains:"virtualProp" %}{# copy over sourcery annotations to define virtual props #}
+{% for annotationKey, annotationValue in type.annotations %}
 // sourcery: {{ annotationKey }}={{ annotationValue }}
-{% endif %}
 {% endfor %}
 public protocol {{NAME | upperFirstLetter}}Component {
 {% for variable in type.variables where variable %}


### PR DESCRIPTION
**Previously**: type-based initializer of a composite view was generated that developer passes a view

```swift
 public init(.., actionItemsControl: ActivityItems? = nil) {
  // ..
}
```

**Now:** type-based initializer of a composite view will be generated that developer passes just the data

```swift
public init(.., actionItems: [ActivityItemDataType]? = nil, didSelectClosure: ((ActivityItemDataType) -> Void)? = nil) {
  // ...
}
```

**Changes necessary by contributor**s: move `// sourcery: backingComponent=<Name>` property to the top of the protocol definition

*Previously*

```swift
internal protocol _ActionItems: _ComponentMultiPropGenerating {
    // sourcery: no_style
    // sourcery: backingComponent=ActivityItems
    var actionItems_: [ActivityItemDataType]? { get }
    func didSelect(_ activityItem: ActivityItemDataType)
}
```

*Now*

```swift
// sourcery: backingComponent=ActivityItems
internal protocol _ActionItems: _ComponentMultiPropGenerating {
    // sourcery: no_style
    var actionItems_: [ActivityItemDataType]? { get }
    func didSelect(_ activityItem: ActivityItemDataType)
}
```