### PR TITLE
chore: 🤖 codeGen: Binding<String> to TextStyle

### DIFF
--- a/sourcery/stencils/pre_phase/component_decl_environment_key.stencil
+++ b/sourcery/stencils/pre_phase/component_decl_environment_key.stencil
@@ -1,6 +1,6 @@
 {# Utility function which returns the correct Style struct, for the unwrapped (non-optional) var type #}
 {% macro _StyleType unwrappedTypeName %}
-{% if unwrappedTypeName == "String" or unwrappedTypeName == "[String]" %}
+{% if unwrappedTypeName == "String" or unwrappedTypeName == "[String]" or unwrappedTypeName == "Binding<String>" %}
 TextStyle
 {% elif unwrappedTypeName == "Image" %}
 ImageStyle

--- a/sourcery/stencils/pre_phase/component_decl_environment_values.stencil
+++ b/sourcery/stencils/pre_phase/component_decl_environment_values.stencil
@@ -1,6 +1,6 @@
 {# Utility function which returns the correct Style struct, for the unwrapped (non-optional) var type #}
 {% macro _StyleType unwrappedTypeName %}
-{% if unwrappedTypeName == "String" or unwrappedTypeName == "[String]" %}
+{% if unwrappedTypeName == "String" or unwrappedTypeName == "[String]" or unwrappedTypeName == "Binding<String>" %}
 TextStyle
 {% elif unwrappedTypeName == "Image" %}
 ImageStyle


### PR DESCRIPTION
Generated components should be able to accept a binding of a string (`var aBinding: Binding<String>` == `@Binding var aBinding: String`) but source code generation had a problem determining the correct style type, i.e.  code compilation error as generated EnvironmentKeys/Values for component were using `NothingStyle`)

With this change the following component declaration (please note that the binding is optional)

```swift
import SwiftUI
// sourcery: backingComponent=TextInput
internal protocol _TextInput: _ComponentMultiPropGenerating {
  var textFilled_: Binding<String>? { get }
  func onCommit() // action handler
}
```

in combination with

```swift
// sourcery: generated_component_not_configurable
public protocol TextInputModel: TextInputComponent {}
```

would result in

```swift
public struct TextInput {
    @Environment(\.textFilledModifier) private var textFilledModifier
    var _textFilled: Binding<String>? = nil
    var _onCommit: (() -> Void)? = nil
    public init(model: TextInputModel) {
        self.init(textFilled: model.textFilled_, onCommit: model.onCommit)
    }
    public init(textFilled: Binding<String>? = nil, onCommit: (() -> Void)? = nil) {
        self._textFilled = textFilled
	self._onCommit = onCommit
    }
}
```

which allows you to use the binding easily in the SwiftUI component, e.g. when using a TextField

```swift
extension TextInput: View {
    public var body: some View {
        TextField("Title", text: self._textFilled ?? .constant("Static Text"))
    }
}
```