### PR TITLE
chore: 🤖 generate ViewModifiers for cumulative styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,95 +85,143 @@ import SwiftUI
 
 public struct PersonDetailItem<Title: View, Subtitle: View, DetailImage: View> {
     @Environment(\.titleModifier) private var titleModifier
-    @Environment(\.subtitleModifier) private var subtitleModifier
-    @Environment(\.detailImageModifier) private var detailImageModifier
-    @Environment(\.horizontalSizeClass) var horizontalSizeClass
-    
-    private let _title: () -> Title
-    private let _subtitle: () -> Subtitle
-    private let _detailImage: () -> DetailImage
+	@Environment(\.subtitleModifier) private var subtitleModifier
+	@Environment(\.detailImageModifier) private var detailImageModifier
+	@Environment(\.horizontalSizeClass) var horizontalSizeClass
+
+    private let _title: Title
+	private let _subtitle: Subtitle
+	private let _detailImage: DetailImage
+	
+    private var isModelInit: Bool = false
+	private var isSubtitleNil: Bool = false
+	private var isDetailImageNil: Bool = false
 
     public init(
         @ViewBuilder title: @escaping () -> Title,
-	@ViewBuilder subtitle: @escaping () -> Subtitle,
-	@ViewBuilder detailImage: @escaping () -> DetailImage
-    ) {
-        self._title = title
-	self._subtitle = subtitle
-	self._detailImage = detailImage
+		@ViewBuilder subtitle: @escaping () -> Subtitle,
+		@ViewBuilder detailImage: @escaping () -> DetailImage
+        ) {
+            self._title = title()
+			self._subtitle = subtitle()
+			self._detailImage = detailImage()
     }
 
     @ViewBuilder var title: some View {
-	_title().modifier(titleModifier.concat(Fiori.PersonDetailItem.title))
+        if isModelInit {
+            _title.modifier(titleModifier.concat(Fiori.PersonDetailItem.title).concat(Fiori.PersonDetailItem.titleCumulative))
+        } else {
+            _title.modifier(titleModifier.concat(Fiori.PersonDetailItem.title))
+        }
     }
-    @ViewBuilder var subtitle: some View {
-        _subtitle().modifier(subtitleModifier.concat(Fiori.PersonDetailItem.subtitle))
+	@ViewBuilder var subtitle: some View {
+        if isModelInit {
+            _subtitle.modifier(subtitleModifier.concat(Fiori.PersonDetailItem.subtitle).concat(Fiori.PersonDetailItem.subtitleCumulative))
+        } else {
+            _subtitle.modifier(subtitleModifier.concat(Fiori.PersonDetailItem.subtitle))
+        }
     }
-    @ViewBuilder var detailImage: some View {
-	_detailImage().modifier(detailImageModifier.concat(Fiori.PersonDetailItem.detailImage))
+	@ViewBuilder var detailImage: some View {
+        if isModelInit {
+            _detailImage.modifier(detailImageModifier.concat(Fiori.PersonDetailItem.detailImage).concat(Fiori.PersonDetailItem.detailImageCumulative))
+        } else {
+            _detailImage.modifier(detailImageModifier.concat(Fiori.PersonDetailItem.detailImage))
+        }
+    }
+    
+	var isSubtitleEmptyView: Bool {
+        ((isModelInit && isSubtitleNil) || Subtitle.self == EmptyView.self) ? true : false
+    }
+
+	var isDetailImageEmptyView: Bool {
+        ((isModelInit && isDetailImageNil) || DetailImage.self == EmptyView.self) ? true : false
     }
 }
 
 extension PersonDetailItem where Title == Text,
-    Subtitle == _ConditionalContent<Text, EmptyView>,
-    DetailImage == _ConditionalContent<Image, EmptyView> {
-    
+		Subtitle == _ConditionalContent<Text, EmptyView>,
+		DetailImage == _ConditionalContent<Image, EmptyView> {
+
     public init(model: PersonDetailItemModel) {
         self.init(title: model.title_, subtitle: model.subtitle_, detailImage: model.detailImage_)
     }
 
     public init(title: String, subtitle: String? = nil, detailImage: Image? = nil) {
-        self._title = { Text(title) }
-	self._subtitle = { subtitle != nil ? ViewBuilder.buildEither(first: Text(subtitle!)) : ViewBuilder.buildEither(second: EmptyView()) }
-	self._detailImage = { detailImage != nil ? ViewBuilder.buildEither(first: detailImage!) : ViewBuilder.buildEither(second: EmptyView()) }
+        self._title = Text(title)
+		self._subtitle = subtitle != nil ? ViewBuilder.buildEither(first: Text(subtitle!)) : ViewBuilder.buildEither(second: EmptyView())
+		self._detailImage = detailImage != nil ? ViewBuilder.buildEither(first: detailImage!) : ViewBuilder.buildEither(second: EmptyView())
+
+		isModelInit = true
+		isSubtitleNil = subtitle == nil ? true : false
+		isDetailImageNil = detailImage == nil ? true : false
     }
-} 
+}
+
 ```
 
 **Sources/FioriSwiftUICore/\_generated/ViewModels/Boilerplate/ProfileDetailItem+View.generated.swift**
 ```swift
-// TODO: Extend PersonDetailItem to implement View in separate file
-// place at FioriSwiftUICore/Views/PersonDetailItem+View.swift
+//TODO: Copy commented code to new file: `FioriSwiftUICore/Views/PersonDetailItem+View.swift`
+//TODO: Implement default Fiori style definitions as `ViewModifier`
+//TODO: Implement PersonDetailItem `View` body
+//TODO: Implement LibraryContentProvider
 
-// Important: to make @Environment properties (e.g. horizontalSizeClass), available
-// in extensions, add as sourcery annotation in FioriSwiftUICore/Models/ModelDefinitions.swift
-// to declare a wrapped property
-// e.g.:  // sourcery: add_env_props = ["horizontalSizeClass"]
+/// - Important: to make `@Environment` properties (e.g. `horizontalSizeClass`), internally accessible
+/// to extensions, add as sourcery annotation in `FioriSwiftUICore/Models/ModelDefinitions.swift`
+/// to declare a wrapped property
+/// e.g.:  `// sourcery: add_env_props = ["horizontalSizeClass"]`
 
 /*
 import SwiftUI
 
-// TODO: - Implement Fiori style definitions
+// FIXME: - Implement Fiori style definitions
 
 extension Fiori {
     enum PersonDetailItem {
         typealias Title = EmptyModifier
-	typealias Subtitle = EmptyModifier
-	typealias DetailImage = EmptyModifier
+        typealias TitleCumulative = EmptyModifier
+		typealias Subtitle = EmptyModifier
+        typealias SubtitleCumulative = EmptyModifier
+		typealias DetailImage = EmptyModifier
+        typealias DetailImageCumulative = EmptyModifier
 
         // TODO: - substitute type-specific ViewModifier for EmptyModifier
         /*
-        // replace `typealias Subtitle = EmptyModifier` with: 
+            // replace `typealias Subtitle = EmptyModifier` with:
 
-        struct Subtitle: ViewModifier {
-            func body(content: Content) -> some View {
-                content
-                    .font(.body)
-                    .foregroundColor(.preferredColor(.primary3))
+            struct Subtitle: ViewModifier {
+                func body(content: Content) -> some View {
+                    content
+                        .font(.body)
+                        .foregroundColor(.preferredColor(.primary3))
+                }
             }
-        }
         */
         static let title = Title()
-	static let subtitle = Subtitle()
-	static let detailImage = DetailImage()
+		static let subtitle = Subtitle()
+		static let detailImage = DetailImage()
+        static let titleCumulative = TitleCumulative()
+		static let subtitleCumulative = SubtitleCumulative()
+		static let detailImageCumulative = DetailImageCumulative()
     }
 }
 
-// TODO: - Implement PersonDetailItem View body
+// FIXME: - Implement PersonDetailItem View body
 
 extension PersonDetailItem: View {
-    public var body: some View { 
-        <# View body #> 
+    public var body: some View {
+        <# View body #>
+    }
+}
+
+// FIXME: - Implement PersonDetailItem specific LibraryContentProvider
+
+@available(iOS 14.0, *)
+struct PersonDetailItemLibraryContent: LibraryContentProvider {
+    @LibraryContentBuilder
+    var views: [LibraryItem] {
+        LibraryItem(PersonDetailItem(model: LibraryPreviewData.Person.laurelosborn),
+                    category: .control)
     }
 }
 */
@@ -216,9 +264,15 @@ extension Fiori {
 This style will be applied in the computed variable in `ProfileDetailItem+API.generated.swift`, as a `ViewModifier` concatenation.
 ```swift
 @ViewBuilder var title: some View {
-    _title().modifier(titleModifier.concat(Fiori.PersonDetailItem.title))
+    if isModelInit {
+		_title.modifier(titleModifier.concat(Fiori.PersonDetailItem.title).concat(Fiori.PersonDetailItem.titleCumulative))
+    } else {
+        _title.modifier(titleModifier.concat(Fiori.PersonDetailItem.title))
+    }
 }
 ```
+
+Note: Component maintainers shall place cumulative styling, e.g. `.padding()` or `.overlay()`, in the respective ViewModifiers with suffix `Cumulative`. Those ViewModifiers will only be applied if the model or content-based initializer are used during runtime. Only non-cumulative styling, e.g. `.font()` or `.lineLimit()`, will be applied as Default Fiori Styling. This avoids side effects in case an app developer supplies an own view.
 
 ### Advanced: suppress EnvironmentKey/Variables and Style generation
 

--- a/Sources/FioriSwiftUICore/Views/ActivationScreen+View.swift
+++ b/Sources/FioriSwiftUICore/Views/ActivationScreen+View.swift
@@ -15,7 +15,8 @@ extension Fiori {
                     .multilineTextAlignment(.center)
             }
         }
-        
+
+        typealias TitleCumulative = EmptyModifier
         struct DescriptionText: ViewModifier {
             func body(content: Content) -> some View {
                 content
@@ -24,7 +25,8 @@ extension Fiori {
                     .multilineTextAlignment(.center)
             }
         }
-        
+
+        typealias DescriptionTextCumulative = EmptyModifier
         struct TextFilled: ViewModifier {
             func body(content: Content) -> some View {
                 content
@@ -32,14 +34,16 @@ extension Fiori {
                     .foregroundColor(.preferredColor(.primary1))
             }
         }
-        
+
+        typealias TextFilledCumulative = EmptyModifier
         struct ActionText: ViewModifier {
             func body(content: Content) -> some View {
                 content
                     .frame(width: 169.0, height: 20.0)
             }
         }
-        
+
+        typealias ActionTextCumulative = EmptyModifier
         struct Footnote: ViewModifier {
             func body(content: Content) -> some View {
                 content
@@ -47,7 +51,8 @@ extension Fiori {
                     .foregroundColor(.preferredColor(.primary1))
             }
         }
-        
+
+        typealias FootnoteCumulative = EmptyModifier
         struct SecondaryActionText: ViewModifier {
             func body(content: Content) -> some View {
                 content
@@ -55,13 +60,20 @@ extension Fiori {
                     .foregroundColor(.preferredColor(.primary1))
             }
         }
-        
+
+        typealias SecondaryActionTextCumulative = EmptyModifier
         static let title = Title()
         static let descriptionText = DescriptionText()
         static let textFilled = TextFilled()
         static let actionText = ActionText()
         static let footnote = Footnote()
         static let secondaryActionText = SecondaryActionText()
+        static let titleCumulative = TitleCumulative()
+        static let descriptionTextCumulative = DescriptionTextCumulative()
+        static let textFilledCumulative = TextFilledCumulative()
+        static let actionTextCumulative = ActionTextCumulative()
+        static let footnoteCumulative = FootnoteCumulative()
+        static let secondaryActionTextCumulative = SecondaryActionTextCumulative()
     }
 }
 

--- a/Sources/FioriSwiftUICore/Views/ActivityItem+View.swift
+++ b/Sources/FioriSwiftUICore/Views/ActivityItem+View.swift
@@ -6,6 +6,8 @@ extension Fiori {
     enum ActivityItem {
         typealias Icon = EmptyModifier
         typealias Subtitle = EmptyModifier
+        typealias IconCumulative = EmptyModifier
+        typealias SubtitleCumulative = EmptyModifier
 
         // TODO: - substitute type-specific ViewModifier for EmptyModifier
         /*
@@ -21,6 +23,8 @@ extension Fiori {
          */
         static let icon = Icon()
         static let subtitle = Subtitle()
+        static let iconCumulative = IconCumulative()
+        static let subtitleCumulative = SubtitleCumulative()
     }
 }
 

--- a/Sources/FioriSwiftUICore/Views/ChartFloorplan+View.swift
+++ b/Sources/FioriSwiftUICore/Views/ChartFloorplan+View.swift
@@ -5,11 +5,17 @@ import SwiftUI
 extension Fiori {
     enum ChartFloorplan {
         typealias Title = EmptyModifier
+        typealias TitleCumulative = EmptyModifier
         typealias Subtitle = EmptyModifier
+        typealias SubtitleCumulative = EmptyModifier
         typealias Status = EmptyModifier
+        typealias StatusCumulative = EmptyModifier
         typealias ValueAxisTitle = EmptyModifier
+        typealias ValueAxisTitleCumulative = EmptyModifier
         typealias SeriesTitles = EmptyModifier
+        typealias SeriesTitlesCumulative = EmptyModifier
         typealias CategoryAxisTitle = EmptyModifier
+        typealias CategoryAxisTitleCumulative = EmptyModifier
 
         // TODO: - substitute type-specific ViewModifier for EmptyModifier
         /*
@@ -29,6 +35,12 @@ extension Fiori {
         static let valueAxisTitle = ValueAxisTitle()
         static let seriesTitles = SeriesTitles()
         static let categoryAxisTitle = CategoryAxisTitle()
+        static let titleCumulative = TitleCumulative()
+        static let subtitleCumulative = SubtitleCumulative()
+        static let statusCumulative = StatusCumulative()
+        static let valueAxisTitleCumulative = ValueAxisTitleCumulative()
+        static let seriesTitlesCumulative = SeriesTitlesCumulative()
+        static let categoryAxisTitleCumulative = CategoryAxisTitleCumulative()
     }
 }
 

--- a/Sources/FioriSwiftUICore/Views/CollectionItem+View.swift
+++ b/Sources/FioriSwiftUICore/Views/CollectionItem+View.swift
@@ -5,8 +5,11 @@ import SwiftUI
 extension Fiori {
     enum CollectionItem {
         typealias DetailImage = EmptyModifier
+        typealias DetailImageCumulative = EmptyModifier
         typealias Title = EmptyModifier
+        typealias TitleCumulative = EmptyModifier
         typealias Subtitle = EmptyModifier
+        typealias SubtitleCumulative = EmptyModifier
 
         // TODO: - substitute type-specific ViewModifier for EmptyModifier
         /*
@@ -23,6 +26,9 @@ extension Fiori {
         static let detailImage = DetailImage()
         static let title = Title()
         static let subtitle = Subtitle()
+        static let detailImageCumulative = DetailImageCumulative()
+        static let titleCumulative = TitleCumulative()
+        static let subtitleCumulative = SubtitleCumulative()
     }
 }
 

--- a/Sources/FioriSwiftUICore/Views/ContactItem+View.swift
+++ b/Sources/FioriSwiftUICore/Views/ContactItem+View.swift
@@ -3,11 +3,17 @@ import SwiftUI
 extension Fiori {
     enum ContactItem {
         typealias Title = EmptyModifier
+        typealias TitleCumulative = EmptyModifier
         typealias Subtitle = EmptyModifier
+        typealias SubtitleCumulative = EmptyModifier
         typealias Footnote = EmptyModifier
+        typealias FootnoteCumulative = EmptyModifier
         typealias DescriptionText = EmptyModifier
+        typealias DescriptionTextCumulative = EmptyModifier
         typealias DetailImage = EmptyModifier
+        typealias DetailImageCumulative = EmptyModifier
         typealias ActionItems = EmptyModifier
+        typealias ActionItemsCumulative = EmptyModifier
 
         // TODO: - substitute type-specific ViewModifier for EmptyModifier
 
@@ -28,6 +34,12 @@ extension Fiori {
         static let descriptionText = DescriptionText()
         static let detailImage = DetailImage()
         static let actionItems = ActionItems()
+        static let titleCumulative = TitleCumulative()
+        static let subtitleCumulative = SubtitleCumulative()
+        static let footnoteCumulative = FootnoteCumulative()
+        static let descriptionTextCumulative = DescriptionTextCumulative()
+        static let detailImageCumulative = DetailImageCumulative()
+        static let actionItemsCumulative = ActionItemsCumulative()
     }
 }
 
@@ -44,7 +56,7 @@ extension ContactItem: View {
             }
             Spacer()
             HStack(spacing: 8) {
-                actionItems
+                actionItems.font(/*@START_MENU_TOKEN@*/ .title/*@END_MENU_TOKEN@*/)
             }
         }
         .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity, alignment: .topLeading)

--- a/Sources/FioriSwiftUICore/Views/HeaderChart+View.swift
+++ b/Sources/FioriSwiftUICore/Views/HeaderChart+View.swift
@@ -5,9 +5,13 @@ import SwiftUI
 extension Fiori {
     enum HeaderChart {
         typealias Title = EmptyModifier
+        typealias TitleCumulative = EmptyModifier
         typealias Subtitle = EmptyModifier
+        typealias SubtitleCumulative = EmptyModifier
         typealias Trend = EmptyModifier
+        typealias TrendCumulative = EmptyModifier
         typealias Kpi = EmptyModifier
+        typealias KpiCumulative = EmptyModifier
 
         // TODO: - substitute type-specific ViewModifier for EmptyModifier
         /*
@@ -25,6 +29,10 @@ extension Fiori {
         static let subtitle = Subtitle()
         static let trend = Trend()
         static let kpi = Kpi()
+        static let titleCumulative = TitleCumulative()
+        static let subtitleCumulative = SubtitleCumulative()
+        static let trendCumulative = TrendCumulative()
+        static let kpiCumulative = KpiCumulative()
     }
 }
 

--- a/Sources/FioriSwiftUICore/Views/KPIItem+View.swift
+++ b/Sources/FioriSwiftUICore/Views/KPIItem+View.swift
@@ -22,8 +22,13 @@ struct Subtitle: ViewModifier {
 
 extension Fiori {
     enum KPIItem {
+        typealias KpiCumulative = EmptyModifier
+        typealias SubtitleCumulative = EmptyModifier
+
         static let kpi = Kpi()
         static let subtitle = Subtitle()
+        static let kpiCumulative = KpiCumulative()
+        static let subtitleCumulative = SubtitleCumulative()
     }
 }
 

--- a/Sources/FioriSwiftUICore/Views/KeyValueItem+View.swift
+++ b/Sources/FioriSwiftUICore/Views/KeyValueItem+View.swift
@@ -6,7 +6,9 @@ import SwiftUI
 extension Fiori {
     enum KeyValueItem {
         typealias Key = EmptyModifier
+        typealias KeyCumulative = EmptyModifier
         typealias Value = EmptyModifier
+        typealias ValueCumulative = EmptyModifier
 
         // TODO: - substitute type-specific ViewModifier for EmptyModifier
         /*
@@ -22,6 +24,8 @@ extension Fiori {
          */
         static let key = Key()
         static let value = Value()
+        static let keyCumulative = KeyCumulative()
+        static let valueCumulative = ValueCumulative()
     }
 }
 

--- a/Sources/FioriSwiftUICore/Views/ListPickerItem+View.swift
+++ b/Sources/FioriSwiftUICore/Views/ListPickerItem+View.swift
@@ -10,11 +10,16 @@ extension Fiori {
                 content.font(.headline).foregroundColor(.preferredColor(.primary1))
             }
         }
+
+        typealias KeyCumulative = EmptyModifier
         
         typealias Value = EmptyModifier
+        typealias ValueCumulative = EmptyModifier
         
         static let key = Key()
         static let value = Value()
+        static let keyCumulative = KeyCumulative()
+        static let valueCumulative = ValueCumulative()
     }
 }
 

--- a/Sources/FioriSwiftUICore/Views/ObjectHeader+View.swift
+++ b/Sources/FioriSwiftUICore/Views/ObjectHeader+View.swift
@@ -5,12 +5,19 @@ import SwiftUI
 extension Fiori {
     enum ObjectHeader {
         typealias Title = EmptyModifier
+        typealias TitleCumulative = EmptyModifier
         typealias Subtitle = EmptyModifier
+        typealias SubtitleCumulative = EmptyModifier
         typealias Footnote = EmptyModifier
+        typealias FootnoteCumulative = EmptyModifier
         typealias DescriptionText = EmptyModifier
+        typealias DescriptionTextCumulative = EmptyModifier
         typealias Status = EmptyModifier
+        typealias StatusCumulative = EmptyModifier
         typealias Substatus = EmptyModifier
+        typealias SubstatusCumulative = EmptyModifier
         typealias DetailImage = EmptyModifier
+        typealias DetailImageCumulative = EmptyModifier
 
         // TODO: - substitute type-specific ViewModifier for EmptyModifier
         /*
@@ -31,6 +38,13 @@ extension Fiori {
         static let status = Status()
         static let substatus = Substatus()
         static let detailImage = DetailImage()
+        static let titleCumulative = TitleCumulative()
+        static let subtitleCumulative = SubtitleCumulative()
+        static let footnoteCumulative = FootnoteCumulative()
+        static let descriptionTextCumulative = DescriptionTextCumulative()
+        static let statusCumulative = StatusCumulative()
+        static let substatusCumulative = SubstatusCumulative()
+        static let detailImageCumulative = DetailImageCumulative()
     }
 }
 

--- a/Sources/FioriSwiftUICore/Views/ObjectItem+View.swift
+++ b/Sources/FioriSwiftUICore/Views/ObjectItem+View.swift
@@ -64,6 +64,16 @@ extension Fiori {
                     .overlay(RoundedRectangle(cornerRadius: 4).stroke(Color.preferredColor(.tintColorDark), lineWidth: 1))
             }
         }
+
+        typealias TitleCumulative = EmptyModifier
+        typealias SubtitleCumulative = EmptyModifier
+        typealias FootnoteCumulative = EmptyModifier
+        typealias DescriptionTextCumulative = EmptyModifier
+        typealias StatusCumulative = EmptyModifier
+        typealias SubstatusCumulative = EmptyModifier
+        typealias DetailImageCumulative = EmptyModifier
+        typealias IconsCumulative = EmptyModifier
+        typealias ActionTextCumulative = EmptyModifier
         
         typealias Icons = EmptyModifier
         static let title = Title()
@@ -75,6 +85,15 @@ extension Fiori {
         static let detailImage = DetailImage()
         static let icons = Icons()
         static let actionText = ActionText()
+        static let titleCumulative = TitleCumulative()
+        static let subtitleCumulative = SubtitleCumulative()
+        static let footnoteCumulative = FootnoteCumulative()
+        static let descriptionTextCumulative = DescriptionTextCumulative()
+        static let statusCumulative = StatusCumulative()
+        static let substatusCumulative = SubstatusCumulative()
+        static let detailImageCumulative = DetailImageCumulative()
+        static let iconsCumulative = IconsCumulative()
+        static let actionTextCumulative = ActionTextCumulative()
     }
 }
 

--- a/Sources/FioriSwiftUICore/Views/ProfileHeader+View.swift
+++ b/Sources/FioriSwiftUICore/Views/ProfileHeader+View.swift
@@ -3,10 +3,15 @@ import SwiftUI
 extension Fiori {
     enum ProfileHeader {
         typealias Title = EmptyModifier
+        typealias TitleCumulative = EmptyModifier
         typealias Subtitle = EmptyModifier
+        typealias SubtitleCumulative = EmptyModifier
         typealias Footnote = EmptyModifier
+        typealias FootnoteCumulative = EmptyModifier
         typealias DescriptionText = EmptyModifier
+        typealias DescriptionTextCumulative = EmptyModifier
         typealias DetailImage = EmptyModifier
+        typealias DetailImageCumulative = EmptyModifier
 
         // TODO: - substitute type-specific ViewModifier for EmptyModifier
         /*
@@ -25,6 +30,11 @@ extension Fiori {
         static let footnote = Footnote()
         static let descriptionText = DescriptionText()
         static let detailImage = DetailImage()
+        static let titleCumulative = TitleCumulative()
+        static let subtitleCumulative = SubtitleCumulative()
+        static let footnoteCumulative = FootnoteCumulative()
+        static let descriptionTextCumulative = DescriptionTextCumulative()
+        static let detailImageCumulative = DetailImageCumulative()
     }
 }
 

--- a/Sources/FioriSwiftUICore/Views/SectionHeader+View.swift
+++ b/Sources/FioriSwiftUICore/Views/SectionHeader+View.swift
@@ -6,6 +6,7 @@ extension Fiori {
     enum SectionHeader {
 //        typealias Title = EmptyModifier
         typealias Attribute = EmptyModifier
+        typealias AttributeCumulative = EmptyModifier
 
         // TODO: - substitute type-specific ViewModifier for EmptyModifier
         /*
@@ -26,8 +27,12 @@ extension Fiori {
             }
         }
 
+        typealias TitleCumulative = EmptyModifier
+
         static let title = Title()
         static let attribute = Attribute()
+        static let titleCumulative = TitleCumulative()
+        static let attributeCumulative = AttributeCumulative()
     }
 }
 

--- a/Sources/FioriSwiftUICore/Views/TimelineGridItem+View.swift
+++ b/Sources/FioriSwiftUICore/Views/TimelineGridItem+View.swift
@@ -5,9 +5,11 @@ import SwiftUI
 extension Fiori {
     enum TimelineGridItem {
         typealias Title = EmptyModifier
+        typealias TitleCumulative = EmptyModifier
         typealias Timestamp = EmptyModifier
+        typealias TimestampCumulative = EmptyModifier
         typealias Status = EmptyModifier
-
+        typealias StatusCumulative = EmptyModifier
         // TODO: - substitute type-specific ViewModifier for EmptyModifier
         /*
              // replace `typealias Subtitle = EmptyModifier` with:
@@ -23,6 +25,9 @@ extension Fiori {
         static let title = Title()
         static let timestamp = Timestamp()
         static let status = Status()
+        static let titleCumulative = TitleCumulative()
+        static let timestampCumulative = TimestampCumulative()
+        static let statusCumulative = StatusCumulative()
     }
 }
 

--- a/Sources/FioriSwiftUICore/Views/TimelineItem+View.swift
+++ b/Sources/FioriSwiftUICore/Views/TimelineItem+View.swift
@@ -5,14 +5,23 @@ import SwiftUI
 extension Fiori {
     enum TimelineItem {
         typealias Title = EmptyModifier
+        typealias TitleCumulative = EmptyModifier
         typealias Subtitle = EmptyModifier
+        typealias SubtitleCumulative = EmptyModifier
         typealias Footnote = EmptyModifier
+        typealias FootnoteCumulative = EmptyModifier
         typealias Attribute = EmptyModifier
+        typealias AttributeCumulative = EmptyModifier
         typealias SecondaryAttribute = EmptyModifier
+        typealias SecondaryAttributeCumulative = EmptyModifier
         typealias Timestamp = EmptyModifier
+        typealias TimestampCumulative = EmptyModifier
         typealias SecondaryTimestamp = EmptyModifier
+        typealias SecondaryTimestampCumulative = EmptyModifier
         typealias Status = EmptyModifier
+        typealias StatusCumulative = EmptyModifier
         typealias Substatus = EmptyModifier
+        typealias SubstatusCumulative = EmptyModifier
 
         // TODO: - substitute type-specific ViewModifier for EmptyModifier
         /*
@@ -35,6 +44,15 @@ extension Fiori {
         static let secondaryTimestamp = SecondaryTimestamp()
         static let status = Status()
         static let substatus = Substatus()
+        static let titleCumulative = TitleCumulative()
+        static let subtitleCumulative = SubtitleCumulative()
+        static let footnoteCumulative = FootnoteCumulative()
+        static let attributeCumulative = AttributeCumulative()
+        static let secondaryAttributeCumulative = SecondaryAttributeCumulative()
+        static let timestampCumulative = TimestampCumulative()
+        static let secondaryTimestampCumulative = SecondaryTimestampCumulative()
+        static let statusCumulative = StatusCumulative()
+        static let substatusCumulative = SubstatusCumulative()
     }
 }
 

--- a/Sources/FioriSwiftUICore/Views/WelcomeScreen+View.swift
+++ b/Sources/FioriSwiftUICore/Views/WelcomeScreen+View.swift
@@ -63,6 +63,14 @@ extension Fiori {
                     .frame(width: 20, height: 20, alignment: .center)
             }
         }
+
+        typealias TitleCumulative = EmptyModifier
+        typealias DescriptionTextCumulative = EmptyModifier
+        typealias ActionTextCumulative = EmptyModifier
+        typealias SubtitleCumulative = EmptyModifier
+        typealias FootnoteCumulative = EmptyModifier
+        typealias SecondaryActionTextCumulative = EmptyModifier
+        typealias IconCumulative = EmptyModifier
         
         static let title = Title()
         static let descriptionText = DescriptionText()
@@ -71,6 +79,13 @@ extension Fiori {
         static let footnote = Footnote()
         static let secondaryActionText = SecondaryActionText()
         static let icon = Icon()
+        static let titleCumulative = TitleCumulative()
+        static let descriptionTextCumulative = DescriptionTextCumulative()
+        static let actionTextCumulative = ActionTextCumulative()
+        static let subtitleCumulative = SubtitleCumulative()
+        static let footnoteCumulative = FootnoteCumulative()
+        static let secondaryActionTextCumulative = SecondaryActionTextCumulative()
+        static let iconCumulative = IconCumulative()
     }
 }
 

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/API/ActivationScreen+API.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/API/ActivationScreen+API.generated.swift
@@ -42,23 +42,47 @@ public struct ActivationScreen<Title: View, DescriptionText: View, TextFilled: V
 			self._secondaryActionText = secondaryActionText()
     }
 
-    var title: some View {
-        _title.modifier(titleModifier.concat(Fiori.ActivationScreen.title))
+    @ViewBuilder var title: some View {
+        if isModelInit {
+            _title.modifier(titleModifier.concat(Fiori.ActivationScreen.title).concat(Fiori.ActivationScreen.titleCumulative))
+        } else {
+            _title.modifier(titleModifier.concat(Fiori.ActivationScreen.title))
+        }
     }
-	var descriptionText: some View {
-        _descriptionText.modifier(descriptionTextModifier.concat(Fiori.ActivationScreen.descriptionText))
+	@ViewBuilder var descriptionText: some View {
+        if isModelInit {
+            _descriptionText.modifier(descriptionTextModifier.concat(Fiori.ActivationScreen.descriptionText).concat(Fiori.ActivationScreen.descriptionTextCumulative))
+        } else {
+            _descriptionText.modifier(descriptionTextModifier.concat(Fiori.ActivationScreen.descriptionText))
+        }
     }
-	var textFilled: some View {
-        _textFilled.modifier(textFilledModifier.concat(Fiori.ActivationScreen.textFilled))
+	@ViewBuilder var textFilled: some View {
+        if isModelInit {
+            _textFilled.modifier(textFilledModifier.concat(Fiori.ActivationScreen.textFilled).concat(Fiori.ActivationScreen.textFilledCumulative))
+        } else {
+            _textFilled.modifier(textFilledModifier.concat(Fiori.ActivationScreen.textFilled))
+        }
     }
-	var actionText: some View {
-        _actionText.modifier(actionTextModifier.concat(Fiori.ActivationScreen.actionText))
+	@ViewBuilder var actionText: some View {
+        if isModelInit {
+            _actionText.modifier(actionTextModifier.concat(Fiori.ActivationScreen.actionText).concat(Fiori.ActivationScreen.actionTextCumulative))
+        } else {
+            _actionText.modifier(actionTextModifier.concat(Fiori.ActivationScreen.actionText))
+        }
     }
-	var footnote: some View {
-        _footnote.modifier(footnoteModifier.concat(Fiori.ActivationScreen.footnote))
+	@ViewBuilder var footnote: some View {
+        if isModelInit {
+            _footnote.modifier(footnoteModifier.concat(Fiori.ActivationScreen.footnote).concat(Fiori.ActivationScreen.footnoteCumulative))
+        } else {
+            _footnote.modifier(footnoteModifier.concat(Fiori.ActivationScreen.footnote))
+        }
     }
-	var secondaryActionText: some View {
-        _secondaryActionText.modifier(secondaryActionTextModifier.concat(Fiori.ActivationScreen.secondaryActionText))
+	@ViewBuilder var secondaryActionText: some View {
+        if isModelInit {
+            _secondaryActionText.modifier(secondaryActionTextModifier.concat(Fiori.ActivationScreen.secondaryActionText).concat(Fiori.ActivationScreen.secondaryActionTextCumulative))
+        } else {
+            _secondaryActionText.modifier(secondaryActionTextModifier.concat(Fiori.ActivationScreen.secondaryActionText))
+        }
     }
     
 	var isDescriptionTextEmptyView: Bool {

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/API/ActivityItem+API.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/API/ActivityItem+API.generated.swift
@@ -21,11 +21,19 @@ public struct ActivityItem<Icon: View, Subtitle: View> {
 			self._subtitle = subtitle()
     }
 
-    var icon: some View {
-        _icon.modifier(iconModifier.concat(Fiori.ActivityItem.icon))
+    @ViewBuilder var icon: some View {
+        if isModelInit {
+            _icon.modifier(iconModifier.concat(Fiori.ActivityItem.icon).concat(Fiori.ActivityItem.iconCumulative))
+        } else {
+            _icon.modifier(iconModifier.concat(Fiori.ActivityItem.icon))
+        }
     }
-	var subtitle: some View {
-        _subtitle.modifier(subtitleModifier.concat(Fiori.ActivityItem.subtitle))
+	@ViewBuilder var subtitle: some View {
+        if isModelInit {
+            _subtitle.modifier(subtitleModifier.concat(Fiori.ActivityItem.subtitle).concat(Fiori.ActivityItem.subtitleCumulative))
+        } else {
+            _subtitle.modifier(subtitleModifier.concat(Fiori.ActivityItem.subtitle))
+        }
     }
     
 	var isIconEmptyView: Bool {

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/API/ChartFloorplan+API.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/API/ChartFloorplan+API.generated.swift
@@ -39,23 +39,47 @@ public struct ChartFloorplan<Title: View, Subtitle: View, Status: View, ValueAxi
 			self._categoryAxisTitle = categoryAxisTitle()
     }
 
-    var title: some View {
-        _title.modifier(titleModifier.concat(Fiori.ChartFloorplan.title))
+    @ViewBuilder var title: some View {
+        if isModelInit {
+            _title.modifier(titleModifier.concat(Fiori.ChartFloorplan.title).concat(Fiori.ChartFloorplan.titleCumulative))
+        } else {
+            _title.modifier(titleModifier.concat(Fiori.ChartFloorplan.title))
+        }
     }
-	var subtitle: some View {
-        _subtitle.modifier(subtitleModifier.concat(Fiori.ChartFloorplan.subtitle))
+	@ViewBuilder var subtitle: some View {
+        if isModelInit {
+            _subtitle.modifier(subtitleModifier.concat(Fiori.ChartFloorplan.subtitle).concat(Fiori.ChartFloorplan.subtitleCumulative))
+        } else {
+            _subtitle.modifier(subtitleModifier.concat(Fiori.ChartFloorplan.subtitle))
+        }
     }
-	var status: some View {
-        _status.modifier(statusModifier.concat(Fiori.ChartFloorplan.status))
+	@ViewBuilder var status: some View {
+        if isModelInit {
+            _status.modifier(statusModifier.concat(Fiori.ChartFloorplan.status).concat(Fiori.ChartFloorplan.statusCumulative))
+        } else {
+            _status.modifier(statusModifier.concat(Fiori.ChartFloorplan.status))
+        }
     }
-	var valueAxisTitle: some View {
-        _valueAxisTitle.modifier(valueAxisTitleModifier.concat(Fiori.ChartFloorplan.valueAxisTitle))
+	@ViewBuilder var valueAxisTitle: some View {
+        if isModelInit {
+            _valueAxisTitle.modifier(valueAxisTitleModifier.concat(Fiori.ChartFloorplan.valueAxisTitle).concat(Fiori.ChartFloorplan.valueAxisTitleCumulative))
+        } else {
+            _valueAxisTitle.modifier(valueAxisTitleModifier.concat(Fiori.ChartFloorplan.valueAxisTitle))
+        }
     }
-	var seriesTitles: some View {
-        _seriesTitles.modifier(seriesTitlesModifier.concat(Fiori.ChartFloorplan.seriesTitles))
+	@ViewBuilder var seriesTitles: some View {
+        if isModelInit {
+            _seriesTitles.modifier(seriesTitlesModifier.concat(Fiori.ChartFloorplan.seriesTitles).concat(Fiori.ChartFloorplan.seriesTitlesCumulative))
+        } else {
+            _seriesTitles.modifier(seriesTitlesModifier.concat(Fiori.ChartFloorplan.seriesTitles))
+        }
     }
-	var categoryAxisTitle: some View {
-        _categoryAxisTitle.modifier(categoryAxisTitleModifier.concat(Fiori.ChartFloorplan.categoryAxisTitle))
+	@ViewBuilder var categoryAxisTitle: some View {
+        if isModelInit {
+            _categoryAxisTitle.modifier(categoryAxisTitleModifier.concat(Fiori.ChartFloorplan.categoryAxisTitle).concat(Fiori.ChartFloorplan.categoryAxisTitleCumulative))
+        } else {
+            _categoryAxisTitle.modifier(categoryAxisTitleModifier.concat(Fiori.ChartFloorplan.categoryAxisTitle))
+        }
     }
     
 	var isSubtitleEmptyView: Bool {

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/API/CollectionItem+API.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/API/CollectionItem+API.generated.swift
@@ -25,14 +25,26 @@ public struct CollectionItem<DetailImage: View, Title: View, Subtitle: View> {
 			self._subtitle = subtitle()
     }
 
-    var detailImage: some View {
-        _detailImage.modifier(detailImageModifier.concat(Fiori.CollectionItem.detailImage))
+    @ViewBuilder var detailImage: some View {
+        if isModelInit {
+            _detailImage.modifier(detailImageModifier.concat(Fiori.CollectionItem.detailImage).concat(Fiori.CollectionItem.detailImageCumulative))
+        } else {
+            _detailImage.modifier(detailImageModifier.concat(Fiori.CollectionItem.detailImage))
+        }
     }
-	var title: some View {
-        _title.modifier(titleModifier.concat(Fiori.CollectionItem.title))
+	@ViewBuilder var title: some View {
+        if isModelInit {
+            _title.modifier(titleModifier.concat(Fiori.CollectionItem.title).concat(Fiori.CollectionItem.titleCumulative))
+        } else {
+            _title.modifier(titleModifier.concat(Fiori.CollectionItem.title))
+        }
     }
-	var subtitle: some View {
-        _subtitle.modifier(subtitleModifier.concat(Fiori.CollectionItem.subtitle))
+	@ViewBuilder var subtitle: some View {
+        if isModelInit {
+            _subtitle.modifier(subtitleModifier.concat(Fiori.CollectionItem.subtitle).concat(Fiori.CollectionItem.subtitleCumulative))
+        } else {
+            _subtitle.modifier(subtitleModifier.concat(Fiori.CollectionItem.subtitle))
+        }
     }
     
 	var isDetailImageEmptyView: Bool {

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/API/ContactItem+API.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/API/ContactItem+API.generated.swift
@@ -41,20 +41,40 @@ public struct ContactItem<Title: View, Subtitle: View, Footnote: View, Descripti
 			self._actionItems = actionItems()
     }
 
-    var title: some View {
-        _title.modifier(titleModifier.concat(Fiori.ContactItem.title))
+    @ViewBuilder var title: some View {
+        if isModelInit {
+            _title.modifier(titleModifier.concat(Fiori.ContactItem.title).concat(Fiori.ContactItem.titleCumulative))
+        } else {
+            _title.modifier(titleModifier.concat(Fiori.ContactItem.title))
+        }
     }
-	var subtitle: some View {
-        _subtitle.modifier(subtitleModifier.concat(Fiori.ContactItem.subtitle))
+	@ViewBuilder var subtitle: some View {
+        if isModelInit {
+            _subtitle.modifier(subtitleModifier.concat(Fiori.ContactItem.subtitle).concat(Fiori.ContactItem.subtitleCumulative))
+        } else {
+            _subtitle.modifier(subtitleModifier.concat(Fiori.ContactItem.subtitle))
+        }
     }
-	var footnote: some View {
-        _footnote.modifier(footnoteModifier.concat(Fiori.ContactItem.footnote))
+	@ViewBuilder var footnote: some View {
+        if isModelInit {
+            _footnote.modifier(footnoteModifier.concat(Fiori.ContactItem.footnote).concat(Fiori.ContactItem.footnoteCumulative))
+        } else {
+            _footnote.modifier(footnoteModifier.concat(Fiori.ContactItem.footnote))
+        }
     }
-	var descriptionText: some View {
-        _descriptionText.modifier(descriptionTextModifier.concat(Fiori.ContactItem.descriptionText))
+	@ViewBuilder var descriptionText: some View {
+        if isModelInit {
+            _descriptionText.modifier(descriptionTextModifier.concat(Fiori.ContactItem.descriptionText).concat(Fiori.ContactItem.descriptionTextCumulative))
+        } else {
+            _descriptionText.modifier(descriptionTextModifier.concat(Fiori.ContactItem.descriptionText))
+        }
     }
-	var detailImage: some View {
-        _detailImage.modifier(detailImageModifier.concat(Fiori.ContactItem.detailImage))
+	@ViewBuilder var detailImage: some View {
+        if isModelInit {
+            _detailImage.modifier(detailImageModifier.concat(Fiori.ContactItem.detailImage).concat(Fiori.ContactItem.detailImageCumulative))
+        } else {
+            _detailImage.modifier(detailImageModifier.concat(Fiori.ContactItem.detailImage))
+        }
     }
 	var actionItems: some View {
         _actionItems

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/API/HeaderChart+API.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/API/HeaderChart+API.generated.swift
@@ -30,17 +30,33 @@ public struct HeaderChart<Title: View, Subtitle: View, Trend: View, Kpi: View> {
 			self._kpi = kpi()
     }
 
-    var title: some View {
-        _title.modifier(titleModifier.concat(Fiori.HeaderChart.title))
+    @ViewBuilder var title: some View {
+        if isModelInit {
+            _title.modifier(titleModifier.concat(Fiori.HeaderChart.title).concat(Fiori.HeaderChart.titleCumulative))
+        } else {
+            _title.modifier(titleModifier.concat(Fiori.HeaderChart.title))
+        }
     }
-	var subtitle: some View {
-        _subtitle.modifier(subtitleModifier.concat(Fiori.HeaderChart.subtitle))
+	@ViewBuilder var subtitle: some View {
+        if isModelInit {
+            _subtitle.modifier(subtitleModifier.concat(Fiori.HeaderChart.subtitle).concat(Fiori.HeaderChart.subtitleCumulative))
+        } else {
+            _subtitle.modifier(subtitleModifier.concat(Fiori.HeaderChart.subtitle))
+        }
     }
-	var trend: some View {
-        _trend.modifier(trendModifier.concat(Fiori.HeaderChart.trend))
+	@ViewBuilder var trend: some View {
+        if isModelInit {
+            _trend.modifier(trendModifier.concat(Fiori.HeaderChart.trend).concat(Fiori.HeaderChart.trendCumulative))
+        } else {
+            _trend.modifier(trendModifier.concat(Fiori.HeaderChart.trend))
+        }
     }
-	var kpi: some View {
-        _kpi.modifier(kpiModifier.concat(Fiori.HeaderChart.kpi))
+	@ViewBuilder var kpi: some View {
+        if isModelInit {
+            _kpi.modifier(kpiModifier.concat(Fiori.HeaderChart.kpi).concat(Fiori.HeaderChart.kpiCumulative))
+        } else {
+            _kpi.modifier(kpiModifier.concat(Fiori.HeaderChart.kpi))
+        }
     }
     
 	var isSubtitleEmptyView: Bool {

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/API/KPIItem+API.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/API/KPIItem+API.generated.swift
@@ -21,11 +21,19 @@ public struct KPIItem<Kpi: View, Subtitle: View> {
 			self._subtitle = subtitle()
     }
 
-    var kpi: some View {
-        _kpi.modifier(kpiModifier.concat(Fiori.KPIItem.kpi))
+    @ViewBuilder var kpi: some View {
+        if isModelInit {
+            _kpi.modifier(kpiModifier.concat(Fiori.KPIItem.kpi).concat(Fiori.KPIItem.kpiCumulative))
+        } else {
+            _kpi.modifier(kpiModifier.concat(Fiori.KPIItem.kpi))
+        }
     }
-	var subtitle: some View {
-        _subtitle.modifier(subtitleModifier.concat(Fiori.KPIItem.subtitle))
+	@ViewBuilder var subtitle: some View {
+        if isModelInit {
+            _subtitle.modifier(subtitleModifier.concat(Fiori.KPIItem.subtitle).concat(Fiori.KPIItem.subtitleCumulative))
+        } else {
+            _subtitle.modifier(subtitleModifier.concat(Fiori.KPIItem.subtitle))
+        }
     }
     
 	var isKpiEmptyView: Bool {

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/API/KeyValueItem+API.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/API/KeyValueItem+API.generated.swift
@@ -20,11 +20,19 @@ public struct KeyValueItem<Key: View, Value: View> {
 			self._value = value()
     }
 
-    var key: some View {
-        _key.modifier(keyModifier.concat(Fiori.KeyValueItem.key))
+    @ViewBuilder var key: some View {
+        if isModelInit {
+            _key.modifier(keyModifier.concat(Fiori.KeyValueItem.key).concat(Fiori.KeyValueItem.keyCumulative))
+        } else {
+            _key.modifier(keyModifier.concat(Fiori.KeyValueItem.key))
+        }
     }
-	var value: some View {
-        _value.modifier(valueModifier.concat(Fiori.KeyValueItem.value))
+	@ViewBuilder var value: some View {
+        if isModelInit {
+            _value.modifier(valueModifier.concat(Fiori.KeyValueItem.value).concat(Fiori.KeyValueItem.valueCumulative))
+        } else {
+            _value.modifier(valueModifier.concat(Fiori.KeyValueItem.value))
+        }
     }
     
 	var isValueEmptyView: Bool {

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/API/ListPickerItem+API.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/API/ListPickerItem+API.generated.swift
@@ -20,11 +20,19 @@ public struct ListPickerItem<Key: View, Value: View> {
 			self._value = value()
     }
 
-    var key: some View {
-        _key.modifier(keyModifier.concat(Fiori.ListPickerItem.key))
+    @ViewBuilder var key: some View {
+        if isModelInit {
+            _key.modifier(keyModifier.concat(Fiori.ListPickerItem.key).concat(Fiori.ListPickerItem.keyCumulative))
+        } else {
+            _key.modifier(keyModifier.concat(Fiori.ListPickerItem.key))
+        }
     }
-	var value: some View {
-        _value.modifier(valueModifier.concat(Fiori.ListPickerItem.value))
+	@ViewBuilder var value: some View {
+        if isModelInit {
+            _value.modifier(valueModifier.concat(Fiori.ListPickerItem.value).concat(Fiori.ListPickerItem.valueCumulative))
+        } else {
+            _value.modifier(valueModifier.concat(Fiori.ListPickerItem.value))
+        }
     }
     
 	var isValueEmptyView: Bool {

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/API/ObjectHeader+API.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/API/ObjectHeader+API.generated.swift
@@ -45,26 +45,54 @@ public struct ObjectHeader<Title: View, Subtitle: View, Footnote: View, Descript
 			self._detailImage = detailImage()
     }
 
-    var title: some View {
-        _title.modifier(titleModifier.concat(Fiori.ObjectHeader.title))
+    @ViewBuilder var title: some View {
+        if isModelInit {
+            _title.modifier(titleModifier.concat(Fiori.ObjectHeader.title).concat(Fiori.ObjectHeader.titleCumulative))
+        } else {
+            _title.modifier(titleModifier.concat(Fiori.ObjectHeader.title))
+        }
     }
-	var subtitle: some View {
-        _subtitle.modifier(subtitleModifier.concat(Fiori.ObjectHeader.subtitle))
+	@ViewBuilder var subtitle: some View {
+        if isModelInit {
+            _subtitle.modifier(subtitleModifier.concat(Fiori.ObjectHeader.subtitle).concat(Fiori.ObjectHeader.subtitleCumulative))
+        } else {
+            _subtitle.modifier(subtitleModifier.concat(Fiori.ObjectHeader.subtitle))
+        }
     }
-	var footnote: some View {
-        _footnote.modifier(footnoteModifier.concat(Fiori.ObjectHeader.footnote))
+	@ViewBuilder var footnote: some View {
+        if isModelInit {
+            _footnote.modifier(footnoteModifier.concat(Fiori.ObjectHeader.footnote).concat(Fiori.ObjectHeader.footnoteCumulative))
+        } else {
+            _footnote.modifier(footnoteModifier.concat(Fiori.ObjectHeader.footnote))
+        }
     }
-	var descriptionText: some View {
-        _descriptionText.modifier(descriptionTextModifier.concat(Fiori.ObjectHeader.descriptionText))
+	@ViewBuilder var descriptionText: some View {
+        if isModelInit {
+            _descriptionText.modifier(descriptionTextModifier.concat(Fiori.ObjectHeader.descriptionText).concat(Fiori.ObjectHeader.descriptionTextCumulative))
+        } else {
+            _descriptionText.modifier(descriptionTextModifier.concat(Fiori.ObjectHeader.descriptionText))
+        }
     }
-	var status: some View {
-        _status.modifier(statusModifier.concat(Fiori.ObjectHeader.status))
+	@ViewBuilder var status: some View {
+        if isModelInit {
+            _status.modifier(statusModifier.concat(Fiori.ObjectHeader.status).concat(Fiori.ObjectHeader.statusCumulative))
+        } else {
+            _status.modifier(statusModifier.concat(Fiori.ObjectHeader.status))
+        }
     }
-	var substatus: some View {
-        _substatus.modifier(substatusModifier.concat(Fiori.ObjectHeader.substatus))
+	@ViewBuilder var substatus: some View {
+        if isModelInit {
+            _substatus.modifier(substatusModifier.concat(Fiori.ObjectHeader.substatus).concat(Fiori.ObjectHeader.substatusCumulative))
+        } else {
+            _substatus.modifier(substatusModifier.concat(Fiori.ObjectHeader.substatus))
+        }
     }
-	var detailImage: some View {
-        _detailImage.modifier(detailImageModifier.concat(Fiori.ObjectHeader.detailImage))
+	@ViewBuilder var detailImage: some View {
+        if isModelInit {
+            _detailImage.modifier(detailImageModifier.concat(Fiori.ObjectHeader.detailImage).concat(Fiori.ObjectHeader.detailImageCumulative))
+        } else {
+            _detailImage.modifier(detailImageModifier.concat(Fiori.ObjectHeader.detailImage))
+        }
     }
     
 	var isSubtitleEmptyView: Bool {

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/API/ObjectItem+API.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/API/ObjectItem+API.generated.swift
@@ -58,32 +58,64 @@ public struct ObjectItem<Title: View, Subtitle: View, Footnote: View, Descriptio
 			self._actionText = actionText()
     }
 
-    var title: some View {
-        _title.modifier(titleModifier.concat(Fiori.ObjectItem.title))
+    @ViewBuilder var title: some View {
+        if isModelInit {
+            _title.modifier(titleModifier.concat(Fiori.ObjectItem.title).concat(Fiori.ObjectItem.titleCumulative))
+        } else {
+            _title.modifier(titleModifier.concat(Fiori.ObjectItem.title))
+        }
     }
-	var subtitle: some View {
-        _subtitle.modifier(subtitleModifier.concat(Fiori.ObjectItem.subtitle))
+	@ViewBuilder var subtitle: some View {
+        if isModelInit {
+            _subtitle.modifier(subtitleModifier.concat(Fiori.ObjectItem.subtitle).concat(Fiori.ObjectItem.subtitleCumulative))
+        } else {
+            _subtitle.modifier(subtitleModifier.concat(Fiori.ObjectItem.subtitle))
+        }
     }
-	var footnote: some View {
-        _footnote.modifier(footnoteModifier.concat(Fiori.ObjectItem.footnote))
+	@ViewBuilder var footnote: some View {
+        if isModelInit {
+            _footnote.modifier(footnoteModifier.concat(Fiori.ObjectItem.footnote).concat(Fiori.ObjectItem.footnoteCumulative))
+        } else {
+            _footnote.modifier(footnoteModifier.concat(Fiori.ObjectItem.footnote))
+        }
     }
-	var descriptionText: some View {
-        _descriptionText.modifier(descriptionTextModifier.concat(Fiori.ObjectItem.descriptionText))
+	@ViewBuilder var descriptionText: some View {
+        if isModelInit {
+            _descriptionText.modifier(descriptionTextModifier.concat(Fiori.ObjectItem.descriptionText).concat(Fiori.ObjectItem.descriptionTextCumulative))
+        } else {
+            _descriptionText.modifier(descriptionTextModifier.concat(Fiori.ObjectItem.descriptionText))
+        }
     }
-	var status: some View {
-        _status.modifier(statusModifier.concat(Fiori.ObjectItem.status))
+	@ViewBuilder var status: some View {
+        if isModelInit {
+            _status.modifier(statusModifier.concat(Fiori.ObjectItem.status).concat(Fiori.ObjectItem.statusCumulative))
+        } else {
+            _status.modifier(statusModifier.concat(Fiori.ObjectItem.status))
+        }
     }
-	var substatus: some View {
-        _substatus.modifier(substatusModifier.concat(Fiori.ObjectItem.substatus))
+	@ViewBuilder var substatus: some View {
+        if isModelInit {
+            _substatus.modifier(substatusModifier.concat(Fiori.ObjectItem.substatus).concat(Fiori.ObjectItem.substatusCumulative))
+        } else {
+            _substatus.modifier(substatusModifier.concat(Fiori.ObjectItem.substatus))
+        }
     }
-	var detailImage: some View {
-        _detailImage.modifier(detailImageModifier.concat(Fiori.ObjectItem.detailImage))
+	@ViewBuilder var detailImage: some View {
+        if isModelInit {
+            _detailImage.modifier(detailImageModifier.concat(Fiori.ObjectItem.detailImage).concat(Fiori.ObjectItem.detailImageCumulative))
+        } else {
+            _detailImage.modifier(detailImageModifier.concat(Fiori.ObjectItem.detailImage))
+        }
     }
 	var icons: some View {
         _icons
     }
-	var actionText: some View {
-        _actionText.modifier(actionTextModifier.concat(Fiori.ObjectItem.actionText))
+	@ViewBuilder var actionText: some View {
+        if isModelInit {
+            _actionText.modifier(actionTextModifier.concat(Fiori.ObjectItem.actionText).concat(Fiori.ObjectItem.actionTextCumulative))
+        } else {
+            _actionText.modifier(actionTextModifier.concat(Fiori.ObjectItem.actionText))
+        }
     }
     
 	var isSubtitleEmptyView: Bool {

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/API/ProfileHeader+API.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/API/ProfileHeader+API.generated.swift
@@ -39,20 +39,40 @@ public struct ProfileHeader<Title: View, Subtitle: View, Footnote: View, Descrip
 			self._actionItems = actionItems()
     }
 
-    var title: some View {
-        _title.modifier(titleModifier.concat(Fiori.ProfileHeader.title))
+    @ViewBuilder var title: some View {
+        if isModelInit {
+            _title.modifier(titleModifier.concat(Fiori.ProfileHeader.title).concat(Fiori.ProfileHeader.titleCumulative))
+        } else {
+            _title.modifier(titleModifier.concat(Fiori.ProfileHeader.title))
+        }
     }
-	var subtitle: some View {
-        _subtitle.modifier(subtitleModifier.concat(Fiori.ProfileHeader.subtitle))
+	@ViewBuilder var subtitle: some View {
+        if isModelInit {
+            _subtitle.modifier(subtitleModifier.concat(Fiori.ProfileHeader.subtitle).concat(Fiori.ProfileHeader.subtitleCumulative))
+        } else {
+            _subtitle.modifier(subtitleModifier.concat(Fiori.ProfileHeader.subtitle))
+        }
     }
-	var footnote: some View {
-        _footnote.modifier(footnoteModifier.concat(Fiori.ProfileHeader.footnote))
+	@ViewBuilder var footnote: some View {
+        if isModelInit {
+            _footnote.modifier(footnoteModifier.concat(Fiori.ProfileHeader.footnote).concat(Fiori.ProfileHeader.footnoteCumulative))
+        } else {
+            _footnote.modifier(footnoteModifier.concat(Fiori.ProfileHeader.footnote))
+        }
     }
-	var descriptionText: some View {
-        _descriptionText.modifier(descriptionTextModifier.concat(Fiori.ProfileHeader.descriptionText))
+	@ViewBuilder var descriptionText: some View {
+        if isModelInit {
+            _descriptionText.modifier(descriptionTextModifier.concat(Fiori.ProfileHeader.descriptionText).concat(Fiori.ProfileHeader.descriptionTextCumulative))
+        } else {
+            _descriptionText.modifier(descriptionTextModifier.concat(Fiori.ProfileHeader.descriptionText))
+        }
     }
-	var detailImage: some View {
-        _detailImage.modifier(detailImageModifier.concat(Fiori.ProfileHeader.detailImage))
+	@ViewBuilder var detailImage: some View {
+        if isModelInit {
+            _detailImage.modifier(detailImageModifier.concat(Fiori.ProfileHeader.detailImage).concat(Fiori.ProfileHeader.detailImageCumulative))
+        } else {
+            _detailImage.modifier(detailImageModifier.concat(Fiori.ProfileHeader.detailImage))
+        }
     }
     var actionItems: some View {
         _actionItems

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/API/SectionHeader+API.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/API/SectionHeader+API.generated.swift
@@ -21,11 +21,19 @@ public struct SectionHeader<Title: View, Attribute: View> {
 			self._attribute = attribute()
     }
 
-    var title: some View {
-        _title.modifier(titleModifier.concat(Fiori.SectionHeader.title))
+    @ViewBuilder var title: some View {
+        if isModelInit {
+            _title.modifier(titleModifier.concat(Fiori.SectionHeader.title).concat(Fiori.SectionHeader.titleCumulative))
+        } else {
+            _title.modifier(titleModifier.concat(Fiori.SectionHeader.title))
+        }
     }
-	var attribute: some View {
-        _attribute.modifier(attributeModifier.concat(Fiori.SectionHeader.attribute))
+	@ViewBuilder var attribute: some View {
+        if isModelInit {
+            _attribute.modifier(attributeModifier.concat(Fiori.SectionHeader.attribute).concat(Fiori.SectionHeader.attributeCumulative))
+        } else {
+            _attribute.modifier(attributeModifier.concat(Fiori.SectionHeader.attribute))
+        }
     }
     
 	var isAttributeEmptyView: Bool {

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/API/TimelineGridItem+API.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/API/TimelineGridItem+API.generated.swift
@@ -25,14 +25,26 @@ public struct TimelineGridItem<Title: View, Timestamp: View, Status: View> {
 			self._status = status()
     }
 
-    var title: some View {
-        _title.modifier(titleModifier.concat(Fiori.TimelineGridItem.title))
+    @ViewBuilder var title: some View {
+        if isModelInit {
+            _title.modifier(titleModifier.concat(Fiori.TimelineGridItem.title).concat(Fiori.TimelineGridItem.titleCumulative))
+        } else {
+            _title.modifier(titleModifier.concat(Fiori.TimelineGridItem.title))
+        }
     }
-	var timestamp: some View {
-        _timestamp.modifier(timestampModifier.concat(Fiori.TimelineGridItem.timestamp))
+	@ViewBuilder var timestamp: some View {
+        if isModelInit {
+            _timestamp.modifier(timestampModifier.concat(Fiori.TimelineGridItem.timestamp).concat(Fiori.TimelineGridItem.timestampCumulative))
+        } else {
+            _timestamp.modifier(timestampModifier.concat(Fiori.TimelineGridItem.timestamp))
+        }
     }
-	var status: some View {
-        _status.modifier(statusModifier.concat(Fiori.TimelineGridItem.status))
+	@ViewBuilder var status: some View {
+        if isModelInit {
+            _status.modifier(statusModifier.concat(Fiori.TimelineGridItem.status).concat(Fiori.TimelineGridItem.statusCumulative))
+        } else {
+            _status.modifier(statusModifier.concat(Fiori.TimelineGridItem.status))
+        }
     }
     
 	var isTimestampEmptyView: Bool {

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/API/TimelineItem+API.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/API/TimelineItem+API.generated.swift
@@ -55,32 +55,68 @@ public struct TimelineItem<Title: View, Subtitle: View, Footnote: View, Attribut
 			self._substatus = substatus()
     }
 
-    var title: some View {
-        _title.modifier(titleModifier.concat(Fiori.TimelineItem.title))
+    @ViewBuilder var title: some View {
+        if isModelInit {
+            _title.modifier(titleModifier.concat(Fiori.TimelineItem.title).concat(Fiori.TimelineItem.titleCumulative))
+        } else {
+            _title.modifier(titleModifier.concat(Fiori.TimelineItem.title))
+        }
     }
-	var subtitle: some View {
-        _subtitle.modifier(subtitleModifier.concat(Fiori.TimelineItem.subtitle))
+	@ViewBuilder var subtitle: some View {
+        if isModelInit {
+            _subtitle.modifier(subtitleModifier.concat(Fiori.TimelineItem.subtitle).concat(Fiori.TimelineItem.subtitleCumulative))
+        } else {
+            _subtitle.modifier(subtitleModifier.concat(Fiori.TimelineItem.subtitle))
+        }
     }
-	var footnote: some View {
-        _footnote.modifier(footnoteModifier.concat(Fiori.TimelineItem.footnote))
+	@ViewBuilder var footnote: some View {
+        if isModelInit {
+            _footnote.modifier(footnoteModifier.concat(Fiori.TimelineItem.footnote).concat(Fiori.TimelineItem.footnoteCumulative))
+        } else {
+            _footnote.modifier(footnoteModifier.concat(Fiori.TimelineItem.footnote))
+        }
     }
-	var attribute: some View {
-        _attribute.modifier(attributeModifier.concat(Fiori.TimelineItem.attribute))
+	@ViewBuilder var attribute: some View {
+        if isModelInit {
+            _attribute.modifier(attributeModifier.concat(Fiori.TimelineItem.attribute).concat(Fiori.TimelineItem.attributeCumulative))
+        } else {
+            _attribute.modifier(attributeModifier.concat(Fiori.TimelineItem.attribute))
+        }
     }
-	var secondaryAttribute: some View {
-        _secondaryAttribute.modifier(secondaryAttributeModifier.concat(Fiori.TimelineItem.secondaryAttribute))
+	@ViewBuilder var secondaryAttribute: some View {
+        if isModelInit {
+            _secondaryAttribute.modifier(secondaryAttributeModifier.concat(Fiori.TimelineItem.secondaryAttribute).concat(Fiori.TimelineItem.secondaryAttributeCumulative))
+        } else {
+            _secondaryAttribute.modifier(secondaryAttributeModifier.concat(Fiori.TimelineItem.secondaryAttribute))
+        }
     }
-	var timestamp: some View {
-        _timestamp.modifier(timestampModifier.concat(Fiori.TimelineItem.timestamp))
+	@ViewBuilder var timestamp: some View {
+        if isModelInit {
+            _timestamp.modifier(timestampModifier.concat(Fiori.TimelineItem.timestamp).concat(Fiori.TimelineItem.timestampCumulative))
+        } else {
+            _timestamp.modifier(timestampModifier.concat(Fiori.TimelineItem.timestamp))
+        }
     }
-	var secondaryTimestamp: some View {
-        _secondaryTimestamp.modifier(secondaryTimestampModifier.concat(Fiori.TimelineItem.secondaryTimestamp))
+	@ViewBuilder var secondaryTimestamp: some View {
+        if isModelInit {
+            _secondaryTimestamp.modifier(secondaryTimestampModifier.concat(Fiori.TimelineItem.secondaryTimestamp).concat(Fiori.TimelineItem.secondaryTimestampCumulative))
+        } else {
+            _secondaryTimestamp.modifier(secondaryTimestampModifier.concat(Fiori.TimelineItem.secondaryTimestamp))
+        }
     }
-	var status: some View {
-        _status.modifier(statusModifier.concat(Fiori.TimelineItem.status))
+	@ViewBuilder var status: some View {
+        if isModelInit {
+            _status.modifier(statusModifier.concat(Fiori.TimelineItem.status).concat(Fiori.TimelineItem.statusCumulative))
+        } else {
+            _status.modifier(statusModifier.concat(Fiori.TimelineItem.status))
+        }
     }
-	var substatus: some View {
-        _substatus.modifier(substatusModifier.concat(Fiori.TimelineItem.substatus))
+	@ViewBuilder var substatus: some View {
+        if isModelInit {
+            _substatus.modifier(substatusModifier.concat(Fiori.TimelineItem.substatus).concat(Fiori.TimelineItem.substatusCumulative))
+        } else {
+            _substatus.modifier(substatusModifier.concat(Fiori.TimelineItem.substatus))
+        }
     }
     
 	var isSubtitleEmptyView: Bool {

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/API/WelcomeScreen+API.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/API/WelcomeScreen+API.generated.swift
@@ -47,26 +47,54 @@ public struct WelcomeScreen<Title: View, DescriptionText: View, ActionText: View
 			self._icon = icon()
     }
 
-    var title: some View {
-        _title.modifier(titleModifier.concat(Fiori.WelcomeScreen.title))
+    @ViewBuilder var title: some View {
+        if isModelInit {
+            _title.modifier(titleModifier.concat(Fiori.WelcomeScreen.title).concat(Fiori.WelcomeScreen.titleCumulative))
+        } else {
+            _title.modifier(titleModifier.concat(Fiori.WelcomeScreen.title))
+        }
     }
-	var descriptionText: some View {
-        _descriptionText.modifier(descriptionTextModifier.concat(Fiori.WelcomeScreen.descriptionText))
+	@ViewBuilder var descriptionText: some View {
+        if isModelInit {
+            _descriptionText.modifier(descriptionTextModifier.concat(Fiori.WelcomeScreen.descriptionText).concat(Fiori.WelcomeScreen.descriptionTextCumulative))
+        } else {
+            _descriptionText.modifier(descriptionTextModifier.concat(Fiori.WelcomeScreen.descriptionText))
+        }
     }
-	var actionText: some View {
-        _actionText.modifier(actionTextModifier.concat(Fiori.WelcomeScreen.actionText))
+	@ViewBuilder var actionText: some View {
+        if isModelInit {
+            _actionText.modifier(actionTextModifier.concat(Fiori.WelcomeScreen.actionText).concat(Fiori.WelcomeScreen.actionTextCumulative))
+        } else {
+            _actionText.modifier(actionTextModifier.concat(Fiori.WelcomeScreen.actionText))
+        }
     }
-	var subtitle: some View {
-        _subtitle.modifier(subtitleModifier.concat(Fiori.WelcomeScreen.subtitle))
+	@ViewBuilder var subtitle: some View {
+        if isModelInit {
+            _subtitle.modifier(subtitleModifier.concat(Fiori.WelcomeScreen.subtitle).concat(Fiori.WelcomeScreen.subtitleCumulative))
+        } else {
+            _subtitle.modifier(subtitleModifier.concat(Fiori.WelcomeScreen.subtitle))
+        }
     }
-	var footnote: some View {
-        _footnote.modifier(footnoteModifier.concat(Fiori.WelcomeScreen.footnote))
+	@ViewBuilder var footnote: some View {
+        if isModelInit {
+            _footnote.modifier(footnoteModifier.concat(Fiori.WelcomeScreen.footnote).concat(Fiori.WelcomeScreen.footnoteCumulative))
+        } else {
+            _footnote.modifier(footnoteModifier.concat(Fiori.WelcomeScreen.footnote))
+        }
     }
-	var secondaryActionText: some View {
-        _secondaryActionText.modifier(secondaryActionTextModifier.concat(Fiori.WelcomeScreen.secondaryActionText))
+	@ViewBuilder var secondaryActionText: some View {
+        if isModelInit {
+            _secondaryActionText.modifier(secondaryActionTextModifier.concat(Fiori.WelcomeScreen.secondaryActionText).concat(Fiori.WelcomeScreen.secondaryActionTextCumulative))
+        } else {
+            _secondaryActionText.modifier(secondaryActionTextModifier.concat(Fiori.WelcomeScreen.secondaryActionText))
+        }
     }
-	var icon: some View {
-        _icon.modifier(iconModifier.concat(Fiori.WelcomeScreen.icon))
+	@ViewBuilder var icon: some View {
+        if isModelInit {
+            _icon.modifier(iconModifier.concat(Fiori.WelcomeScreen.icon).concat(Fiori.WelcomeScreen.iconCumulative))
+        } else {
+            _icon.modifier(iconModifier.concat(Fiori.WelcomeScreen.icon))
+        }
     }
     
 	var isDescriptionTextEmptyView: Bool {

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/Boilerplate/ActivationScreen+View.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/Boilerplate/ActivationScreen+View.generated.swift
@@ -18,11 +18,17 @@ import SwiftUI
 extension Fiori {
     enum ActivationScreen {
         typealias Title = EmptyModifier
+        typealias TitleCumulative = EmptyModifier
 		typealias DescriptionText = EmptyModifier
+        typealias DescriptionTextCumulative = EmptyModifier
 		typealias TextFilled = EmptyModifier
+        typealias TextFilledCumulative = EmptyModifier
 		typealias ActionText = EmptyModifier
+        typealias ActionTextCumulative = EmptyModifier
 		typealias Footnote = EmptyModifier
+        typealias FootnoteCumulative = EmptyModifier
 		typealias SecondaryActionText = EmptyModifier
+        typealias SecondaryActionTextCumulative = EmptyModifier
 
         // TODO: - substitute type-specific ViewModifier for EmptyModifier
         /*
@@ -42,6 +48,12 @@ extension Fiori {
 		static let actionText = ActionText()
 		static let footnote = Footnote()
 		static let secondaryActionText = SecondaryActionText()
+        static let titleCumulative = TitleCumulative()
+		static let descriptionTextCumulative = DescriptionTextCumulative()
+		static let textFilledCumulative = TextFilledCumulative()
+		static let actionTextCumulative = ActionTextCumulative()
+		static let footnoteCumulative = FootnoteCumulative()
+		static let secondaryActionTextCumulative = SecondaryActionTextCumulative()
     }
 }
 

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/Boilerplate/ActivityItem+View.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/Boilerplate/ActivityItem+View.generated.swift
@@ -18,7 +18,9 @@ import SwiftUI
 extension Fiori {
     enum ActivityItem {
         typealias Icon = EmptyModifier
+        typealias IconCumulative = EmptyModifier
 		typealias Subtitle = EmptyModifier
+        typealias SubtitleCumulative = EmptyModifier
 
         // TODO: - substitute type-specific ViewModifier for EmptyModifier
         /*
@@ -34,6 +36,8 @@ extension Fiori {
         */
         static let icon = Icon()
 		static let subtitle = Subtitle()
+        static let iconCumulative = IconCumulative()
+		static let subtitleCumulative = SubtitleCumulative()
     }
 }
 

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/Boilerplate/ChartFloorplan+View.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/Boilerplate/ChartFloorplan+View.generated.swift
@@ -18,11 +18,17 @@ import SwiftUI
 extension Fiori {
     enum ChartFloorplan {
         typealias Title = EmptyModifier
+        typealias TitleCumulative = EmptyModifier
 		typealias Subtitle = EmptyModifier
+        typealias SubtitleCumulative = EmptyModifier
 		typealias Status = EmptyModifier
+        typealias StatusCumulative = EmptyModifier
 		typealias ValueAxisTitle = EmptyModifier
+        typealias ValueAxisTitleCumulative = EmptyModifier
 		typealias SeriesTitles = EmptyModifier
+        typealias SeriesTitlesCumulative = EmptyModifier
 		typealias CategoryAxisTitle = EmptyModifier
+        typealias CategoryAxisTitleCumulative = EmptyModifier
 
         // TODO: - substitute type-specific ViewModifier for EmptyModifier
         /*
@@ -42,6 +48,12 @@ extension Fiori {
 		static let valueAxisTitle = ValueAxisTitle()
 		static let seriesTitles = SeriesTitles()
 		static let categoryAxisTitle = CategoryAxisTitle()
+        static let titleCumulative = TitleCumulative()
+		static let subtitleCumulative = SubtitleCumulative()
+		static let statusCumulative = StatusCumulative()
+		static let valueAxisTitleCumulative = ValueAxisTitleCumulative()
+		static let seriesTitlesCumulative = SeriesTitlesCumulative()
+		static let categoryAxisTitleCumulative = CategoryAxisTitleCumulative()
     }
 }
 

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/Boilerplate/CollectionItem+View.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/Boilerplate/CollectionItem+View.generated.swift
@@ -18,8 +18,11 @@ import SwiftUI
 extension Fiori {
     enum CollectionItem {
         typealias DetailImage = EmptyModifier
+        typealias DetailImageCumulative = EmptyModifier
 		typealias Title = EmptyModifier
+        typealias TitleCumulative = EmptyModifier
 		typealias Subtitle = EmptyModifier
+        typealias SubtitleCumulative = EmptyModifier
 
         // TODO: - substitute type-specific ViewModifier for EmptyModifier
         /*
@@ -36,6 +39,9 @@ extension Fiori {
         static let detailImage = DetailImage()
 		static let title = Title()
 		static let subtitle = Subtitle()
+        static let detailImageCumulative = DetailImageCumulative()
+		static let titleCumulative = TitleCumulative()
+		static let subtitleCumulative = SubtitleCumulative()
     }
 }
 

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/Boilerplate/ContactItem+View.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/Boilerplate/ContactItem+View.generated.swift
@@ -18,11 +18,17 @@ import SwiftUI
 extension Fiori {
     enum ContactItem {
         typealias Title = EmptyModifier
+        typealias TitleCumulative = EmptyModifier
 		typealias Subtitle = EmptyModifier
+        typealias SubtitleCumulative = EmptyModifier
 		typealias Footnote = EmptyModifier
+        typealias FootnoteCumulative = EmptyModifier
 		typealias DescriptionText = EmptyModifier
+        typealias DescriptionTextCumulative = EmptyModifier
 		typealias DetailImage = EmptyModifier
+        typealias DetailImageCumulative = EmptyModifier
 		typealias ActionItems = EmptyModifier
+        typealias ActionItemsCumulative = EmptyModifier
 
         // TODO: - substitute type-specific ViewModifier for EmptyModifier
         /*
@@ -42,6 +48,12 @@ extension Fiori {
 		static let descriptionText = DescriptionText()
 		static let detailImage = DetailImage()
 		static let actionItems = ActionItems()
+        static let titleCumulative = TitleCumulative()
+		static let subtitleCumulative = SubtitleCumulative()
+		static let footnoteCumulative = FootnoteCumulative()
+		static let descriptionTextCumulative = DescriptionTextCumulative()
+		static let detailImageCumulative = DetailImageCumulative()
+		static let actionItemsCumulative = ActionItemsCumulative()
     }
 }
 

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/Boilerplate/HeaderChart+View.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/Boilerplate/HeaderChart+View.generated.swift
@@ -18,9 +18,13 @@ import SwiftUI
 extension Fiori {
     enum HeaderChart {
         typealias Title = EmptyModifier
+        typealias TitleCumulative = EmptyModifier
 		typealias Subtitle = EmptyModifier
+        typealias SubtitleCumulative = EmptyModifier
 		typealias Trend = EmptyModifier
+        typealias TrendCumulative = EmptyModifier
 		typealias Kpi = EmptyModifier
+        typealias KpiCumulative = EmptyModifier
 
         // TODO: - substitute type-specific ViewModifier for EmptyModifier
         /*
@@ -38,6 +42,10 @@ extension Fiori {
 		static let subtitle = Subtitle()
 		static let trend = Trend()
 		static let kpi = Kpi()
+        static let titleCumulative = TitleCumulative()
+		static let subtitleCumulative = SubtitleCumulative()
+		static let trendCumulative = TrendCumulative()
+		static let kpiCumulative = KpiCumulative()
     }
 }
 

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/Boilerplate/KPIItem+View.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/Boilerplate/KPIItem+View.generated.swift
@@ -18,7 +18,9 @@ import SwiftUI
 extension Fiori {
     enum KPIItem {
         typealias Kpi = EmptyModifier
+        typealias KpiCumulative = EmptyModifier
 		typealias Subtitle = EmptyModifier
+        typealias SubtitleCumulative = EmptyModifier
 
         // TODO: - substitute type-specific ViewModifier for EmptyModifier
         /*
@@ -34,6 +36,8 @@ extension Fiori {
         */
         static let kpi = Kpi()
 		static let subtitle = Subtitle()
+        static let kpiCumulative = KpiCumulative()
+		static let subtitleCumulative = SubtitleCumulative()
     }
 }
 

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/Boilerplate/KeyValueItem+View.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/Boilerplate/KeyValueItem+View.generated.swift
@@ -18,7 +18,9 @@ import SwiftUI
 extension Fiori {
     enum KeyValueItem {
         typealias Key = EmptyModifier
+        typealias KeyCumulative = EmptyModifier
 		typealias Value = EmptyModifier
+        typealias ValueCumulative = EmptyModifier
 
         // TODO: - substitute type-specific ViewModifier for EmptyModifier
         /*
@@ -34,6 +36,8 @@ extension Fiori {
         */
         static let key = Key()
 		static let value = Value()
+        static let keyCumulative = KeyCumulative()
+		static let valueCumulative = ValueCumulative()
     }
 }
 

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/Boilerplate/ListPickerItem+View.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/Boilerplate/ListPickerItem+View.generated.swift
@@ -18,7 +18,9 @@ import SwiftUI
 extension Fiori {
     enum ListPickerItem {
         typealias Key = EmptyModifier
+        typealias KeyCumulative = EmptyModifier
 		typealias Value = EmptyModifier
+        typealias ValueCumulative = EmptyModifier
 
         // TODO: - substitute type-specific ViewModifier for EmptyModifier
         /*
@@ -34,6 +36,8 @@ extension Fiori {
         */
         static let key = Key()
 		static let value = Value()
+        static let keyCumulative = KeyCumulative()
+		static let valueCumulative = ValueCumulative()
     }
 }
 

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/Boilerplate/ObjectHeader+View.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/Boilerplate/ObjectHeader+View.generated.swift
@@ -18,12 +18,19 @@ import SwiftUI
 extension Fiori {
     enum ObjectHeader {
         typealias Title = EmptyModifier
+        typealias TitleCumulative = EmptyModifier
 		typealias Subtitle = EmptyModifier
+        typealias SubtitleCumulative = EmptyModifier
 		typealias Footnote = EmptyModifier
+        typealias FootnoteCumulative = EmptyModifier
 		typealias DescriptionText = EmptyModifier
+        typealias DescriptionTextCumulative = EmptyModifier
 		typealias Status = EmptyModifier
+        typealias StatusCumulative = EmptyModifier
 		typealias Substatus = EmptyModifier
+        typealias SubstatusCumulative = EmptyModifier
 		typealias DetailImage = EmptyModifier
+        typealias DetailImageCumulative = EmptyModifier
 
         // TODO: - substitute type-specific ViewModifier for EmptyModifier
         /*
@@ -44,6 +51,13 @@ extension Fiori {
 		static let status = Status()
 		static let substatus = Substatus()
 		static let detailImage = DetailImage()
+        static let titleCumulative = TitleCumulative()
+		static let subtitleCumulative = SubtitleCumulative()
+		static let footnoteCumulative = FootnoteCumulative()
+		static let descriptionTextCumulative = DescriptionTextCumulative()
+		static let statusCumulative = StatusCumulative()
+		static let substatusCumulative = SubstatusCumulative()
+		static let detailImageCumulative = DetailImageCumulative()
     }
 }
 

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/Boilerplate/ObjectItem+View.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/Boilerplate/ObjectItem+View.generated.swift
@@ -18,14 +18,23 @@ import SwiftUI
 extension Fiori {
     enum ObjectItem {
         typealias Title = EmptyModifier
+        typealias TitleCumulative = EmptyModifier
 		typealias Subtitle = EmptyModifier
+        typealias SubtitleCumulative = EmptyModifier
 		typealias Footnote = EmptyModifier
+        typealias FootnoteCumulative = EmptyModifier
 		typealias DescriptionText = EmptyModifier
+        typealias DescriptionTextCumulative = EmptyModifier
 		typealias Status = EmptyModifier
+        typealias StatusCumulative = EmptyModifier
 		typealias Substatus = EmptyModifier
+        typealias SubstatusCumulative = EmptyModifier
 		typealias DetailImage = EmptyModifier
+        typealias DetailImageCumulative = EmptyModifier
 		typealias Icons = EmptyModifier
+        typealias IconsCumulative = EmptyModifier
 		typealias ActionText = EmptyModifier
+        typealias ActionTextCumulative = EmptyModifier
 
         // TODO: - substitute type-specific ViewModifier for EmptyModifier
         /*
@@ -48,6 +57,15 @@ extension Fiori {
 		static let detailImage = DetailImage()
 		static let icons = Icons()
 		static let actionText = ActionText()
+        static let titleCumulative = TitleCumulative()
+		static let subtitleCumulative = SubtitleCumulative()
+		static let footnoteCumulative = FootnoteCumulative()
+		static let descriptionTextCumulative = DescriptionTextCumulative()
+		static let statusCumulative = StatusCumulative()
+		static let substatusCumulative = SubstatusCumulative()
+		static let detailImageCumulative = DetailImageCumulative()
+		static let iconsCumulative = IconsCumulative()
+		static let actionTextCumulative = ActionTextCumulative()
     }
 }
 

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/Boilerplate/ProfileHeader+View.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/Boilerplate/ProfileHeader+View.generated.swift
@@ -18,10 +18,15 @@ import SwiftUI
 extension Fiori {
     enum ProfileHeader {
         typealias Title = EmptyModifier
+        typealias TitleCumulative = EmptyModifier
 		typealias Subtitle = EmptyModifier
+        typealias SubtitleCumulative = EmptyModifier
 		typealias Footnote = EmptyModifier
+        typealias FootnoteCumulative = EmptyModifier
 		typealias DescriptionText = EmptyModifier
+        typealias DescriptionTextCumulative = EmptyModifier
 		typealias DetailImage = EmptyModifier
+        typealias DetailImageCumulative = EmptyModifier
 
         // TODO: - substitute type-specific ViewModifier for EmptyModifier
         /*
@@ -40,6 +45,11 @@ extension Fiori {
 		static let footnote = Footnote()
 		static let descriptionText = DescriptionText()
 		static let detailImage = DetailImage()
+        static let titleCumulative = TitleCumulative()
+		static let subtitleCumulative = SubtitleCumulative()
+		static let footnoteCumulative = FootnoteCumulative()
+		static let descriptionTextCumulative = DescriptionTextCumulative()
+		static let detailImageCumulative = DetailImageCumulative()
     }
 }
 

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/Boilerplate/SectionHeader+View.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/Boilerplate/SectionHeader+View.generated.swift
@@ -18,7 +18,9 @@ import SwiftUI
 extension Fiori {
     enum SectionHeader {
         typealias Title = EmptyModifier
+        typealias TitleCumulative = EmptyModifier
 		typealias Attribute = EmptyModifier
+        typealias AttributeCumulative = EmptyModifier
 
         // TODO: - substitute type-specific ViewModifier for EmptyModifier
         /*
@@ -34,6 +36,8 @@ extension Fiori {
         */
         static let title = Title()
 		static let attribute = Attribute()
+        static let titleCumulative = TitleCumulative()
+		static let attributeCumulative = AttributeCumulative()
     }
 }
 

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/Boilerplate/TimelineGridItem+View.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/Boilerplate/TimelineGridItem+View.generated.swift
@@ -18,8 +18,11 @@ import SwiftUI
 extension Fiori {
     enum TimelineGridItem {
         typealias Title = EmptyModifier
+        typealias TitleCumulative = EmptyModifier
 		typealias Timestamp = EmptyModifier
+        typealias TimestampCumulative = EmptyModifier
 		typealias Status = EmptyModifier
+        typealias StatusCumulative = EmptyModifier
 
         // TODO: - substitute type-specific ViewModifier for EmptyModifier
         /*
@@ -36,6 +39,9 @@ extension Fiori {
         static let title = Title()
 		static let timestamp = Timestamp()
 		static let status = Status()
+        static let titleCumulative = TitleCumulative()
+		static let timestampCumulative = TimestampCumulative()
+		static let statusCumulative = StatusCumulative()
     }
 }
 

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/Boilerplate/TimelineItem+View.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/Boilerplate/TimelineItem+View.generated.swift
@@ -18,14 +18,23 @@ import SwiftUI
 extension Fiori {
     enum TimelineItem {
         typealias Title = EmptyModifier
+        typealias TitleCumulative = EmptyModifier
 		typealias Subtitle = EmptyModifier
+        typealias SubtitleCumulative = EmptyModifier
 		typealias Footnote = EmptyModifier
+        typealias FootnoteCumulative = EmptyModifier
 		typealias Attribute = EmptyModifier
+        typealias AttributeCumulative = EmptyModifier
 		typealias SecondaryAttribute = EmptyModifier
+        typealias SecondaryAttributeCumulative = EmptyModifier
 		typealias Timestamp = EmptyModifier
+        typealias TimestampCumulative = EmptyModifier
 		typealias SecondaryTimestamp = EmptyModifier
+        typealias SecondaryTimestampCumulative = EmptyModifier
 		typealias Status = EmptyModifier
+        typealias StatusCumulative = EmptyModifier
 		typealias Substatus = EmptyModifier
+        typealias SubstatusCumulative = EmptyModifier
 
         // TODO: - substitute type-specific ViewModifier for EmptyModifier
         /*
@@ -48,6 +57,15 @@ extension Fiori {
 		static let secondaryTimestamp = SecondaryTimestamp()
 		static let status = Status()
 		static let substatus = Substatus()
+        static let titleCumulative = TitleCumulative()
+		static let subtitleCumulative = SubtitleCumulative()
+		static let footnoteCumulative = FootnoteCumulative()
+		static let attributeCumulative = AttributeCumulative()
+		static let secondaryAttributeCumulative = SecondaryAttributeCumulative()
+		static let timestampCumulative = TimestampCumulative()
+		static let secondaryTimestampCumulative = SecondaryTimestampCumulative()
+		static let statusCumulative = StatusCumulative()
+		static let substatusCumulative = SubstatusCumulative()
     }
 }
 

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/Boilerplate/WelcomeScreen+View.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/Boilerplate/WelcomeScreen+View.generated.swift
@@ -18,12 +18,19 @@ import SwiftUI
 extension Fiori {
     enum WelcomeScreen {
         typealias Title = EmptyModifier
+        typealias TitleCumulative = EmptyModifier
 		typealias DescriptionText = EmptyModifier
+        typealias DescriptionTextCumulative = EmptyModifier
 		typealias ActionText = EmptyModifier
+        typealias ActionTextCumulative = EmptyModifier
 		typealias Subtitle = EmptyModifier
+        typealias SubtitleCumulative = EmptyModifier
 		typealias Footnote = EmptyModifier
+        typealias FootnoteCumulative = EmptyModifier
 		typealias SecondaryActionText = EmptyModifier
+        typealias SecondaryActionTextCumulative = EmptyModifier
 		typealias Icon = EmptyModifier
+        typealias IconCumulative = EmptyModifier
 
         // TODO: - substitute type-specific ViewModifier for EmptyModifier
         /*
@@ -44,6 +51,13 @@ extension Fiori {
 		static let footnote = Footnote()
 		static let secondaryActionText = SecondaryActionText()
 		static let icon = Icon()
+        static let titleCumulative = TitleCumulative()
+		static let descriptionTextCumulative = DescriptionTextCumulative()
+		static let actionTextCumulative = ActionTextCumulative()
+		static let subtitleCumulative = SubtitleCumulative()
+		static let footnoteCumulative = FootnoteCumulative()
+		static let secondaryActionTextCumulative = SecondaryActionTextCumulative()
+		static let iconCumulative = IconCumulative()
     }
 }
 

--- a/sourcery/.lib/Sources/utils/Array+Variable.swift
+++ b/sourcery/.lib/Sources/utils/Array+Variable.swift
@@ -183,8 +183,15 @@ extension Array where Element: Variable {
         map { "static let \($0.trimmedName) = \($0.trimmedName.capitalizingFirst())()" }.joined(separator: "\n\t\t")
     }
 
+    var staticViewModifierCumulativePropertyDecls: String {
+        map { "static let \($0.trimmedName)Cumulative = \($0.trimmedName.capitalizingFirst())Cumulative()" }.joined(separator: "\n\t\t")
+    }
+
     var typealiasViewModifierDecls: String {
-        map { "typealias \($0.trimmedName.capitalizingFirst()) = EmptyModifier" }.joined(separator: "\n\t\t")
+        map { """
+        typealias \($0.trimmedName.capitalizingFirst()) = EmptyModifier
+                typealias \($0.trimmedName.capitalizingFirst())Cumulative = EmptyModifier
+        """ }.joined(separator: "\n\t\t")
     }
 
     public var extensionContrainedWhereEmptyView: String {

--- a/sourcery/.lib/Sources/utils/Type+Extensions.swift
+++ b/sourcery/.lib/Sources/utils/Type+Extensions.swift
@@ -145,6 +145,7 @@ public extension Type {
                     }
                 */
                 \(componentProperties.staticViewModifierPropertyDecls)
+                \(componentProperties.staticViewModifierCumulativePropertyDecls)
             }
         }
         """

--- a/sourcery/.lib/Sources/utils/Variable+Extensions.swift
+++ b/sourcery/.lib/Sources/utils/Variable+Extensions.swift
@@ -90,8 +90,12 @@ public extension Variable {
     func resolvedViewModifierChain(type: Type) -> String {
         if annotations.keys.contains("no_style") == false {
             return """
-            var \(self.trimmedName): some View {
-                    _\(self.trimmedName).modifier(\(self.trimmedName)Modifier.concat(Fiori.\(type.componentName).\(self.trimmedName)))
+            @ViewBuilder var \(self.trimmedName): some View {
+                    if isModelInit {
+                        _\(self.trimmedName).modifier(\(self.trimmedName)Modifier.concat(Fiori.\(type.componentName).\(self.trimmedName)).concat(Fiori.\(type.componentName).\(self.trimmedName)Cumulative))
+                    } else {
+                        _\(self.trimmedName).modifier(\(self.trimmedName)Modifier.concat(Fiori.\(type.componentName).\(self.trimmedName)))
+                    }
                 }
             """
         } else {


### PR DESCRIPTION
Component maintainers shall place cumulative styling,
e.g. `.padding()` or `.overlay()`, in the respective
ViewModifiers with suffix `Cumulative`. Those
ViewModifiers will only be applied if the model or
content-based initializer are used during runtime.
Only non-cumulative styling, e.g. `.font()` or
`.lineLimit()`, will be applied as Default Fiori
Styling. This avoids side effects in case an app
developer supplies an own view.