### PR TITLE
chore: codeGen for comp. property not representable as view (no_view)

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,50 @@ The generated ViewModel initializer in `<Model>+API.generated.swift` as well as 
 		}
 ```
 
+### Advanced: component property not representable as view
+
+Use sourcery annotation `// sourcery: no_view` on a property which shall not be represented as a view. The property will still be used in the initializers but does not have the @ViewBuilder property wrapper and is declared with its original data type.
+
+```swift
+internal protocol _KpiProgress: KpiComponent, _ComponentMultiPropGenerating {
+    // sourcery: no_view
+    var fraction_: Double? { get }
+}
+```
+
+Result:
+
+```swift
+public struct KPIProgressItem<Kpi: View, Subtitle: View, Footnote: View> { // no `Fraction: View` !
+    @Environment(\.kpiModifier) private var kpiModifier
+	@Environment(\.subtitleModifier) private var subtitleModifier
+	@Environment(\.footnoteModifier) private var footnoteModifier
+
+    private let _kpi: Kpi
+	private let _fraction: Double? // data type is used!
+	private let _subtitle: Subtitle
+	private let _footnote: Footnote
+	
+    private var isModelInit: Bool = false
+	private var isKpiNil: Bool = false
+	private var isSubtitleNil: Bool = false
+	private var isFootnoteNil: Bool = false
+
+    public init(
+        @ViewBuilder kpi: @escaping () -> Kpi,
+		fraction: Double?, // data type is used!
+		@ViewBuilder subtitle: @escaping () -> Subtitle,
+		@ViewBuilder footnote: @escaping () -> Footnote
+        ) {
+            self._kpi = kpi()
+			self._fraction = fraction // direct assignment
+			self._subtitle = subtitle()
+			self._footnote = footnote()
+    }
+    // ...
+}
+```
+
 ### Next Steps
 For now, feel free to prototype with this pattern to add & modify your own controls, and propose enhancements or changes in the Issues tab.   
 

--- a/Sources/FioriSwiftUICore/Components/MultiPropertyComponents.swift
+++ b/Sources/FioriSwiftUICore/Components/MultiPropertyComponents.swift
@@ -27,3 +27,8 @@ internal protocol _TextInput: _ComponentMultiPropGenerating {
     var textFilled_: String? { get }
     func onCommit() // action handler
 }
+
+internal protocol _KpiProgress: KpiComponent, _ComponentMultiPropGenerating {
+    // sourcery: no_view
+    var fraction_: Double? { get }
+}

--- a/Sources/FioriSwiftUICore/Models/ModelDefinitions.swift
+++ b/Sources/FioriSwiftUICore/Models/ModelDefinitions.swift
@@ -45,6 +45,9 @@ public protocol SectionHeaderModel: TitleComponent, AttributeComponent {}
 public protocol KPIItemModel: KpiComponent, SubtitleComponent {}
 
 // sourcery: generated_component
+public protocol KPIProgressItemModel: KpiProgressComponent, SubtitleComponent, FootnoteComponent {}
+
+// sourcery: generated_component
 public protocol KeyValueItemModel: KeyComponent, ValueComponent {}
 
 // sourcery: generated_component_not_configurable

--- a/Sources/FioriSwiftUICore/Views/KPIProgressItem+View.swift
+++ b/Sources/FioriSwiftUICore/Views/KPIProgressItem+View.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+extension Fiori {
+    enum KPIProgressItem {
+        typealias Kpi = EmptyModifier
+        typealias KpiCumulative = EmptyModifier
+        typealias Subtitle = EmptyModifier
+        typealias SubtitleCumulative = EmptyModifier
+        typealias Footnote = EmptyModifier
+        typealias FootnoteCumulative = EmptyModifier
+
+        // TODO: - substitute type-specific ViewModifier for EmptyModifier
+        /*
+             // replace `typealias Subtitle = EmptyModifier` with:
+
+             struct Subtitle: ViewModifier {
+                 func body(content: Content) -> some View {
+                     content
+                         .font(.body)
+                         .foregroundColor(.preferredColor(.primary3))
+                 }
+             }
+         */
+        static let kpi = Kpi()
+        static let subtitle = Subtitle()
+        static let footnote = Footnote()
+        static let kpiCumulative = KpiCumulative()
+        static let subtitleCumulative = SubtitleCumulative()
+        static let footnoteCumulative = FootnoteCumulative()
+    }
+}
+
+// FIXME: - Implement KPIProgressItem View body
+
+extension KPIProgressItem: View {
+    public var body: some View {
+        Text("TODO")
+    }
+}
+
+// FIXME: - Implement KPIProgressItem specific LibraryContentProvider
+
+// @available(iOS 14.0, *)
+// struct KPIProgressItemLibraryContent: LibraryContentProvider {
+//    @LibraryContentBuilder
+//    var views: [LibraryItem] {
+//        LibraryItem(KPIProgressItem(model: LibraryPreviewData.Person.laurelosborn),
+//                    category: .control)
+//    }
+// }

--- a/Sources/FioriSwiftUICore/_generated/Components/Component+Protocols.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/Components/Component+Protocols.generated.swift
@@ -136,6 +136,11 @@ public protocol ActionItemsComponent {
 	func didSelectActivityItem(_ activityItem: ActivityItemDataType) -> Void
 }
 
+public protocol KpiProgressComponent : KpiComponent {
+	// sourcery: no_view
+    var fraction_: Double? { get }
+}
+
 // sourcery: backingComponent=SecondaryAction
 public protocol SecondaryActionComponent {
     var secondaryActionText_: String? { get }

--- a/Sources/FioriSwiftUICore/_generated/Components/EnvironmentValues+Styles.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/Components/EnvironmentValues+Styles.generated.swift
@@ -1244,6 +1244,13 @@ public extension View {
 
 
 	extension EnvironmentValues {
+	}
+
+	public extension View {
+	}
+
+
+	extension EnvironmentValues {
 		public var secondaryActionTextStyle: TextStyle {
 			get { return self[SecondaryActionTextStyleKey.self] }
 			set { self[SecondaryActionTextStyleKey.self] = newValue }

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/API/KPIProgressItem+API.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/API/KPIProgressItem+API.generated.swift
@@ -1,0 +1,86 @@
+// Generated using Sourcery 1.1.1 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+import SwiftUI
+
+public struct KPIProgressItem<Kpi: View, Subtitle: View, Footnote: View> {
+    @Environment(\.kpiModifier) private var kpiModifier
+	@Environment(\.subtitleModifier) private var subtitleModifier
+	@Environment(\.footnoteModifier) private var footnoteModifier
+
+    private let _kpi: Kpi
+	private let _fraction: Double?
+	private let _subtitle: Subtitle
+	private let _footnote: Footnote
+	
+    private var isModelInit: Bool = false
+	private var isKpiNil: Bool = false
+	private var isSubtitleNil: Bool = false
+	private var isFootnoteNil: Bool = false
+
+    public init(
+        @ViewBuilder kpi: @escaping () -> Kpi,
+		fraction: Double?,
+		@ViewBuilder subtitle: @escaping () -> Subtitle,
+		@ViewBuilder footnote: @escaping () -> Footnote
+        ) {
+            self._kpi = kpi()
+			self._fraction = fraction
+			self._subtitle = subtitle()
+			self._footnote = footnote()
+    }
+
+    @ViewBuilder var kpi: some View {
+        if isModelInit {
+            _kpi.modifier(kpiModifier.concat(Fiori.KPIProgressItem.kpi).concat(Fiori.KPIProgressItem.kpiCumulative))
+        } else {
+            _kpi.modifier(kpiModifier.concat(Fiori.KPIProgressItem.kpi))
+        }
+    }
+	@ViewBuilder var subtitle: some View {
+        if isModelInit {
+            _subtitle.modifier(subtitleModifier.concat(Fiori.KPIProgressItem.subtitle).concat(Fiori.KPIProgressItem.subtitleCumulative))
+        } else {
+            _subtitle.modifier(subtitleModifier.concat(Fiori.KPIProgressItem.subtitle))
+        }
+    }
+	@ViewBuilder var footnote: some View {
+        if isModelInit {
+            _footnote.modifier(footnoteModifier.concat(Fiori.KPIProgressItem.footnote).concat(Fiori.KPIProgressItem.footnoteCumulative))
+        } else {
+            _footnote.modifier(footnoteModifier.concat(Fiori.KPIProgressItem.footnote))
+        }
+    }
+    
+	var isKpiEmptyView: Bool {
+        ((isModelInit && isKpiNil) || Kpi.self == EmptyView.self) ? true : false
+    }
+
+	var isSubtitleEmptyView: Bool {
+        ((isModelInit && isSubtitleNil) || Subtitle.self == EmptyView.self) ? true : false
+    }
+
+	var isFootnoteEmptyView: Bool {
+        ((isModelInit && isFootnoteNil) || Footnote.self == EmptyView.self) ? true : false
+    }
+}
+
+extension KPIProgressItem where Kpi == _ConditionalContent<Text, EmptyView>,
+		Subtitle == _ConditionalContent<Text, EmptyView>,
+		Footnote == _ConditionalContent<Text, EmptyView> {
+
+    public init(model: KPIProgressItemModel) {
+        self.init(kpi: model.kpi_, fraction: model.fraction_, subtitle: model.subtitle_, footnote: model.footnote_)
+    }
+
+    public init(kpi: String? = nil, fraction: Double? = nil, subtitle: String? = nil, footnote: String? = nil) {
+        self._kpi = kpi != nil ? ViewBuilder.buildEither(first: Text(kpi!)) : ViewBuilder.buildEither(second: EmptyView())
+		self._fraction = fraction
+		self._subtitle = subtitle != nil ? ViewBuilder.buildEither(first: Text(subtitle!)) : ViewBuilder.buildEither(second: EmptyView())
+		self._footnote = footnote != nil ? ViewBuilder.buildEither(first: Text(footnote!)) : ViewBuilder.buildEither(second: EmptyView())
+
+		isModelInit = true
+		isKpiNil = kpi == nil ? true : false
+		isSubtitleNil = subtitle == nil ? true : false
+		isFootnoteNil = footnote == nil ? true : false
+    }
+}

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/Boilerplate/KPIProgressItem+View.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/Boilerplate/KPIProgressItem+View.generated.swift
@@ -1,0 +1,66 @@
+// Generated using Sourcery 1.1.1 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+//TODO: Copy commented code to new file: `FioriSwiftUICore/Views/KPIProgressItem+View.swift`
+//TODO: Implement default Fiori style definitions as `ViewModifier`
+//TODO: Implement KPIProgressItem `View` body
+//TODO: Implement LibraryContentProvider
+
+/// - Important: to make `@Environment` properties (e.g. `horizontalSizeClass`), internally accessible
+/// to extensions, add as sourcery annotation in `FioriSwiftUICore/Models/ModelDefinitions.swift`
+/// to declare a wrapped property
+/// e.g.:  `// sourcery: add_env_props = ["horizontalSizeClass"]`
+
+/*
+import SwiftUI
+
+// FIXME: - Implement Fiori style definitions
+
+extension Fiori {
+    enum KPIProgressItem {
+        typealias Kpi = EmptyModifier
+        typealias KpiCumulative = EmptyModifier
+		typealias Subtitle = EmptyModifier
+        typealias SubtitleCumulative = EmptyModifier
+		typealias Footnote = EmptyModifier
+        typealias FootnoteCumulative = EmptyModifier
+
+        // TODO: - substitute type-specific ViewModifier for EmptyModifier
+        /*
+            // replace `typealias Subtitle = EmptyModifier` with:
+
+            struct Subtitle: ViewModifier {
+                func body(content: Content) -> some View {
+                    content
+                        .font(.body)
+                        .foregroundColor(.preferredColor(.primary3))
+                }
+            }
+        */
+        static let kpi = Kpi()
+		static let subtitle = Subtitle()
+		static let footnote = Footnote()
+        static let kpiCumulative = KpiCumulative()
+		static let subtitleCumulative = SubtitleCumulative()
+		static let footnoteCumulative = FootnoteCumulative()
+    }
+}
+
+// FIXME: - Implement KPIProgressItem View body
+
+extension KPIProgressItem: View {
+    public var body: some View {
+        <# View body #>
+    }
+}
+
+// FIXME: - Implement KPIProgressItem specific LibraryContentProvider
+
+@available(iOS 14.0, *)
+struct KPIProgressItemLibraryContent: LibraryContentProvider {
+    @LibraryContentBuilder
+    var views: [LibraryItem] {
+        LibraryItem(KPIProgressItem(model: LibraryPreviewData.Person.laurelosborn),
+                    category: .control)
+    }
+}
+*/

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/Init+Extensions/KPIProgressItem+Init.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/Init+Extensions/KPIProgressItem+Init.generated.swift
@@ -1,0 +1,90 @@
+// Generated using Sourcery 1.1.1 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+import SwiftUI
+
+extension KPIProgressItem where Footnote == EmptyView {
+    public init(
+    @ViewBuilder kpi: @escaping () -> Kpi,
+		fraction: Double?,
+		@ViewBuilder subtitle: @escaping () -> Subtitle
+    ) {
+        self.init(
+            kpi: kpi,
+			fraction: fraction,
+			subtitle: subtitle,
+			footnote: { EmptyView() }
+        )
+    }
+}
+
+extension KPIProgressItem where Kpi == EmptyView {
+    public init(
+    fraction: Double?,
+		@ViewBuilder subtitle: @escaping () -> Subtitle,
+		@ViewBuilder footnote: @escaping () -> Footnote
+    ) {
+        self.init(
+            kpi: { EmptyView() },
+			fraction: fraction,
+			subtitle: subtitle,
+			footnote: footnote
+        )
+    }
+}
+
+extension KPIProgressItem where Subtitle == EmptyView {
+    public init(
+    @ViewBuilder kpi: @escaping () -> Kpi,
+		fraction: Double?,
+		@ViewBuilder footnote: @escaping () -> Footnote
+    ) {
+        self.init(
+            kpi: kpi,
+			fraction: fraction,
+			subtitle: { EmptyView() },
+			footnote: footnote
+        )
+    }
+}
+
+extension KPIProgressItem where Footnote == EmptyView, Kpi == EmptyView {
+    public init(
+    fraction: Double?,
+		@ViewBuilder subtitle: @escaping () -> Subtitle
+    ) {
+        self.init(
+            kpi: { EmptyView() },
+			fraction: fraction,
+			subtitle: subtitle,
+			footnote: { EmptyView() }
+        )
+    }
+}
+
+extension KPIProgressItem where Footnote == EmptyView, Subtitle == EmptyView {
+    public init(
+    @ViewBuilder kpi: @escaping () -> Kpi,
+		fraction: Double?
+    ) {
+        self.init(
+            kpi: kpi,
+			fraction: fraction,
+			subtitle: { EmptyView() },
+			footnote: { EmptyView() }
+        )
+    }
+}
+
+extension KPIProgressItem where Kpi == EmptyView, Subtitle == EmptyView {
+    public init(
+    fraction: Double?,
+		@ViewBuilder footnote: @escaping () -> Footnote
+    ) {
+        self.init(
+            kpi: { EmptyView() },
+			fraction: fraction,
+			subtitle: { EmptyView() },
+			footnote: footnote
+        )
+    }
+}

--- a/sourcery/.lib/Sources/utils/Array+Variable.swift
+++ b/sourcery/.lib/Sources/utils/Array+Variable.swift
@@ -42,6 +42,16 @@ public extension Array where Element == Variable {
         map { "private let _\($0.trimmedName): \($0.trimmedName.capitalizingFirst())" }
     }
 
+    var miscPropertyDecls: [String] {
+        map {
+            if $0.isRepresentableByView == false {
+                return "private let _\($0.trimmedName): \($0.typeName)"
+            } else {
+                return "private let _\($0.trimmedName): \($0.trimmedName.capitalizingFirst())"
+            }
+        }
+    }
+
     /**
      Creates internal "is<View>Nil" properties, related to optional component properties, as utilities to be used in to compute "is<View>EmptyView>" properties
      ```
@@ -58,7 +68,7 @@ public extension Array where Element == Variable {
      Creates internal computed "is<View>EmptyView>" properties, related to optional component properties, to compute the information if `EmptyView` is used nor not
      ```
      var isSubtitleEmptyView: Bool {
-         ((isModelInit && isSubtitleNil) || Subtitle.self == EmptyView.self) ? true : false
+     ((isModelInit && isSubtitleNil) || Subtitle.self == EmptyView.self) ? true : false
      }
      ...
      ```
@@ -93,8 +103,8 @@ public extension Array where Element == Variable {
      Formats list of init ViewBuilder parameters
      ```
      public init( // starts here =>
-         @ViewBuilder title: @escaping () -> Title,
-         @ViewBuilder subtitle: @escaping () -> Subtitle, ...
+     @ViewBuilder title: @escaping () -> Title,
+     @ViewBuilder subtitle: @escaping () -> Subtitle, ...
      ```
      */
     var viewBuilderInitParams: [String] {
@@ -108,30 +118,58 @@ public extension Array where Element == Variable {
     }
 
     /**
+     Formats list of either  init ViewBuilder parameters or regular properties
+     ```
+     public init( // starts here =>
+     @ViewBuilder kpi: @escaping () -> Kpi,
+     fraction: Double?, ...
+     ```
+     */
+    var miscInitParams: [String] {
+        map {
+            if $0.isRepresentableByView == false {
+                return $0.propDecl
+            } else {
+                return $0.viewBuilderDecl
+            }
+        }
+    }
+
+    /**
      Formats the assignment from init params to caching stored properties
      ```
      public init(
-         /* ... */
-         ) { // starts here =>
-             self._title = title
-             self._subtitle = subtitle
-            ...
+     /* ... */
+     ) { // starts here =>
+     self._title = title
+     self._subtitle = subtitle
+     ...
      ```
      */
     var viewBuilderInitParamAssignment: [String] {
         map { "self._\($0.trimmedName) = \($0.trimmedName)()" }
     }
 
-    /**
-      Responsible for resolving view modifiers from default styling, and Environment property
+    var miscInitParamAssignment: [String] {
+        map {
+            if $0.isRepresentableByView == false {
+                return "self._\($0.trimmedName) = \($0.trimmedName)"
+            } else {
+                return "self._\($0.trimmedName) = \($0.trimmedName)()"
+            }
+        }
+    }
 
-        Generates as follows:
-       ```
-       var title: some View {
-           _title().modifier(titleModifier.concat(Fiori.ChartFloorplan.title))
-       }
-       ```
-       - important: This is the ONLY view which should be used by developers in the layout construction
+    /**
+     Responsible for resolving view modifiers from default styling, and Environment property
+
+     Generates as follows:
+     ```
+     var title: some View {
+     _title().modifier(titleModifier.concat(Fiori.ChartFloorplan.title))
+     }
+     ```
+     - important: This is the ONLY view which should be used by developers in the layout construction
      */
     func resolvedViewModifierChain(type: Type) -> String {
         map { $0.resolvedViewModifierChain(type: type) }.joined(separator: "\n\t")
@@ -147,18 +185,24 @@ public extension Array where Element: Variable {
      Uses `ViewBuilder.buildEither` to account for nil content injected via this API
      ```
      init( /* ... */ ) { // starts here =>
-        // Where content is non-optional
-        self._title = { Text(title) }()
+     // Where content is non-optional
+     self._title = { Text(title) }()
 
-        // Where content is optional (e.g. String?)
-        self._subtitle = { subtitle != nil ?
-            ViewBuilder.buildEither(first: Text(subtitle!)) :
-            ViewBuilder.buildEither(second: EmptyView())
-        }()
+     // Where content is optional (e.g. String?)
+     self._subtitle = { subtitle != nil ?
+     ViewBuilder.buildEither(first: Text(subtitle!)) :
+     ViewBuilder.buildEither(second: EmptyView())
+     }()
      ```
      */
     var extensionModelInitParamsAssignments: [String] {
-        map { "self._\($0.trimmedName) = \($0.conditionalAssignment)" }
+        map {
+            if $0.isRepresentableByView {
+                return "self._\($0.trimmedName) = \($0.conditionalAssignment)"
+            } else {
+                return "self._\($0.trimmedName) = \($0.trimmedName)"
+            }
+        }
     }
 
     var extensionModelInitParamsDataTypeAssignments: [String] {
@@ -235,10 +279,14 @@ extension Array where Element: Variable {
         var output: [String] = []
         for variable in self {
             if !scenario.contains(variable) {
-                if let cfb = variable.resolvedAnnotations("customFunctionBuilder").first {
-                    output.append("@\(cfb) \(variable.trimmedName): @escaping () -> \(variable.trimmedName.capitalizingFirst())")
+                if variable.isRepresentableByView {
+                    if let cfb = variable.resolvedAnnotations("customFunctionBuilder").first {
+                        output.append("@\(cfb) \(variable.trimmedName): @escaping () -> \(variable.trimmedName.capitalizingFirst())")
+                    } else {
+                        output.append("@ViewBuilder \(variable.trimmedName): @escaping () -> \(variable.trimmedName.capitalizingFirst())")
+                    }
                 } else {
-                    output.append("@ViewBuilder \(variable.trimmedName): @escaping () -> \(variable.trimmedName.capitalizingFirst())")
+                    output.append("\(variable.trimmedName): \(variable.typeName)")
                 }
             }
         }
@@ -248,7 +296,7 @@ extension Array where Element: Variable {
     public func extensionInitParamAssignmentWhereEmptyView(scenario: [Element]) -> [String] {
         var output: [String] = []
         for variable in self {
-            if scenario.contains(variable) {
+            if scenario.contains(variable), variable.isRepresentableByView {
                 if variable.resolvedAnnotations("customFunctionBuilder").first != nil {
                     output.append("\(variable.trimmedName): { }")
                 } else {
@@ -283,5 +331,9 @@ extension Array where Element: Variable {
 
     var extensionModelInitClosureParamsAssignments: [String] {
         map { "self._\($0.trimmedName) = \($0.trimmedName)" }
+    }
+
+    public var representableByView: [Variable] {
+        filter { $0.isRepresentableByView }
     }
 }

--- a/sourcery/.lib/Sources/utils/Type+Extensions.swift
+++ b/sourcery/.lib/Sources/utils/Type+Extensions.swift
@@ -34,7 +34,7 @@ public extension Type {
     }
 
     func flattenedComponentProperties(contextType: [String: Type]) -> [Variable] {
-        inheritedTypes.compactMap { contextType[$0] }.flatMap { $0.allVariables }
+        inheritedTypes.compactMap { contextType[$0] }.flatMap { $0.allVariables.reversed() }
     }
 
     // add_view_builder_params are no Swift properties and therefore `Variable` property values are faked and cannot be relied on other than `name`
@@ -75,7 +75,7 @@ public extension Type {
 
     func optionalPropertySequences(includingAddViewBuilderParams: Bool = true) -> [[Variable]] {
         var sequences: [[Variable]] = []
-        var optionalProperties = self.allVariables.filter { $0.isOptional }
+        var optionalProperties = self.allVariables.filter { $0.isRepresentableByView }.filter { $0.isOptional }
         if includingAddViewBuilderParams {
             optionalProperties.append(contentsOf: self.addViewBuilderParamsAsVariables)
         }

--- a/sourcery/.lib/Sources/utils/Variable+Extensions.swift
+++ b/sourcery/.lib/Sources/utils/Variable+Extensions.swift
@@ -117,3 +117,21 @@ public extension Variable {
         }
     }
 }
+
+public extension Variable {
+    var isRepresentableByView: Bool {
+        !annotations.keys.contains("no_view")
+    }
+
+    var viewBuilderDecl: String {
+        if let cfb = self.resolvedAnnotations("customFunctionBuilder").first {
+            return "@\(cfb) \(self.trimmedName): @escaping () -> \(self.trimmedName.capitalizingFirst())"
+        } else {
+            return "@ViewBuilder \(self.trimmedName): @escaping () -> \(self.trimmedName.capitalizingFirst())"
+        }
+    }
+
+    var propDecl: String {
+        "\(self.trimmedName): \(self.typeName)"
+    }
+}

--- a/sourcery/README.md
+++ b/sourcery/README.md
@@ -27,3 +27,43 @@ For Swift templates you can outsource logic to a local utility Swift package loc
 
 - Sourcery built-in daemon (`--watch`) does not work properly for Swift templates
 - To uptake changes in utility Swift package run Sourcery with `--disableCache` option
+- To quickly trigger code generation from VSCode as a task to run (Command+R) you can create `.vscode/tasks.json` in root folder
+	```
+	{
+		"version": "2.0.0",
+		"tasks": [
+			{
+				"label": "Generate everything",
+				"type": "shell",
+				"command": "bash allPhasesNoCache.sh",
+				"options": {
+					"cwd": "${workspaceFolder}/sourcery"
+				}
+			},
+			{
+				"label": "Generate Pre-Phase (Components)",
+				"type": "shell",
+				"command": "sourcery --config .phase_pre_sourcery.yml --disableCache",
+				"options": {
+					"cwd": "${workspaceFolder}/sourcery"
+				}
+			},
+			{
+				"label": "Generate Main-Phase (Models)",
+				"type": "shell",
+				"command": "sourcery --config .phase_main_sourcery.yml --disableCache",
+				"options": {
+					"cwd": "${workspaceFolder}/sourcery"
+				}
+			},
+			{
+				"label": "Generate Post-Phase (Composites)",
+				"type": "shell",
+				"command": "sourcery --config .phase_post_sourcery.yml --disableCache",
+				"options": {
+					"cwd": "${workspaceFolder}/sourcery"
+				}
+			}
+		]
+	}
+	```

--- a/sourcery/stencils/main_phase/model_decl_base.swifttemplate
+++ b/sourcery/stencils/main_phase/model_decl_base.swifttemplate
@@ -17,34 +17,34 @@ for model in models {
     let styleName = model.componentStyleName
 
     let templateParameterDecls = [
-        componentProperties.templateParameterDecls,
+        componentProperties.representableByView.templateParameterDecls,
         model.add_view_builder_paramsTemplateParameterDecls
     ].flatMap { $0 }.joined(separator: ", ")
 
     let environmentPropertyDecls = [
-        componentProperties.viewModifierPropertyDecls,
+        componentProperties.representableByView.viewModifierPropertyDecls,
         model.add_env_propsDecls
     ].flatMap { $0 }.joined(separator: "\n\t")
 
     let privatePropertyDecls = [
-        componentProperties.viewBuilderPropertyDecls,
+        componentProperties.miscPropertyDecls,
         closureProperties.privateClosurePropModelDecls,
         model.add_view_builder_paramsViewBuilderPropertyDecls
     ].flatMap { $0 }.joined(separator: "\n\t")
 
-	let viewBuilderNilPropertyDecls = componentProperties.viewBuilderNilPropertyDecls.joined(separator: "\n\t")
-	let viewBuilderEmptyViewPropertyDecls = componentProperties.viewBuilderEmptyViewPropertyDecls.joined(separator: "\n\n\t")
-	let viewBuilderNilPropertyAssignment = componentProperties.viewBuilderNilPropertyAssignment.joined(separator: "\n\t\t")
+	let viewBuilderNilPropertyDecls = componentProperties.representableByView.viewBuilderNilPropertyDecls.joined(separator: "\n\t")
+	let viewBuilderEmptyViewPropertyDecls = componentProperties.representableByView.viewBuilderEmptyViewPropertyDecls.joined(separator: "\n\n\t")
+	let viewBuilderNilPropertyAssignment = componentProperties.representableByView.viewBuilderNilPropertyAssignment.joined(separator: "\n\t\t")
 
 	let virtualPropertyDecls = model.virtualPropertyDecls.joined(separator: "\n\t")
 
     let viewBuilderInitParams = [
-        componentProperties.viewBuilderInitParams,
+        componentProperties.miscInitParams,
         model.add_view_builder_paramsViewBuilderInitParams
     ].flatMap { $0 }.joined(separator: ",\n\t\t")
 
     let viewBuilderInitParamAssignment = [
-        componentProperties.viewBuilderInitParamAssignment,
+        componentProperties.miscInitParamAssignment,
         model.add_view_builder_paramsViewBuilderInitParamAssignment
     ].flatMap { $0 }.joined(separator: "\n\t\t\t")
 
@@ -94,12 +94,12 @@ public struct <%= model.componentName %><<%= templateParameterDecls %>> {
             <%= viewBuilderInitParamAssignment  %>
     }
 
-    <%= componentProperties.resolvedViewModifierChain(type: model) %>
+    <%= componentProperties.representableByView.resolvedViewModifierChain(type: model) %>
     <%= model.add_view_builder_paramsResolvedViewModifierChain.joined(separator: "\n\t") %>
 	<%= viewBuilderEmptyViewPropertyDecls %>
 }
 
-extension <%= model.componentName %> where <%= componentProperties.extensionConstrainedWhereConditionalContent %> {
+extension <%= model.componentName %> where <%= componentProperties.representableByView.extensionConstrainedWhereConditionalContent %> {
 
     public init(<%= modelInitParams %>) {
         self.init(<%= extensionModelInitParamsChaining %>)
@@ -130,7 +130,7 @@ import SwiftUI
 
 // FIXME: - Implement Fiori style definitions
 
-<%= model.fioriStyleImplEnumDecl(componentProperties: componentProperties) %>
+<%= model.fioriStyleImplEnumDecl(componentProperties: componentProperties.representableByView) %>
 
 // FIXME: - Implement <%= model.componentName %> View body
 

--- a/sourcery/stencils/pre_phase/component_decl.stencil
+++ b/sourcery/stencils/pre_phase/component_decl.stencil
@@ -24,12 +24,17 @@ public protocol {{NAME | upperFirstLetter}}Component {
 {% endfor %}
 
 {% for type in types.implementing._ComponentMultiPropGenerating %}
+{% set inheritedTypes %}{% for inheritedType in type.inheritedTypes where inheritedType|!hasPrefix:"_" %}{{ inheritedType }}{% if forloop.last == false %}, {% endif %}{% endfor %}{% endset %}
 {% set NAME %}{{ type.name|replace:'_','' }}{% endset %}
 
 {% for annotationKey, annotationValue in type.annotations %}
 // sourcery: {{ annotationKey }}={{ annotationValue }}
 {% endfor %}
+{% if inheritedTypes %}
+public protocol {{NAME | upperFirstLetter}}Component : {{ inheritedTypes }} {
+{% else %}
 public protocol {{NAME | upperFirstLetter}}Component {
+{% endif %}
 {% for variable in type.variables where variable %}
 {% include "partials/comp_decl_pvar.stencil" %}
 {% endfor %}

--- a/sourcery/stencils/pre_phase/component_decl_environment_key.stencil
+++ b/sourcery/stencils/pre_phase/component_decl_environment_key.stencil
@@ -13,7 +13,7 @@ NothingStyle
 // sourcery:file:EnvironmentKey+Styles.generated.swift
 import SwiftUI
 {% for type in types.implementing._ComponentGenerating %}
-{% for variable in type.variables where variable|!annotated:"no_style" %}
+{% for variable in type.variables where variable|!annotated:"no_style" and variable|!annotated:"no_view" %}
 {% set AStyle %}{% call StyleType variable.typeName.unwrappedTypeName %}{% endset %}
 {% set NAME %}{{ variable.name|replace:'_','' }}{% endset %}
 
@@ -37,7 +37,7 @@ struct {{NAME | upperFirstLetter }}StyleClassModifierKey: EnvironmentKey {
 {% endfor %}
 
 {% for type in types.implementing._ComponentMultiPropGenerating %}
-	{% for variable in type.variables where variable|!annotated:"no_style" %}
+	{% for variable in type.variables where variable|!annotated:"no_style" and variable|!annotated:"no_view" %}
 	{% set AStyle %}{% call StyleType variable.typeName.unwrappedTypeName %}{% endset %}
 	{% set NAME %}{{ variable.name|replace:'_','' }}{% endset %}
 

--- a/sourcery/stencils/pre_phase/component_decl_environment_values.stencil
+++ b/sourcery/stencils/pre_phase/component_decl_environment_values.stencil
@@ -15,7 +15,7 @@ import SwiftUI
 {% for type in types.implementing._ComponentGenerating %}
 
 extension EnvironmentValues {
-{% for variable in type.variables where variable|!annotated:"no_style" %}
+{% for variable in type.variables where variable|!annotated:"no_style" and variable|!annotated:"no_view" %}
 {% set NAME %}{{ variable.name|replace:'_','' }}{% endset %}
 {% set keyname %}{{NAME | upperFirstLetter }}StyleKey{% endset %}
 {% set AStyle %}{% call StyleType variable.typeName.unwrappedTypeName %}{% endset %}
@@ -33,7 +33,7 @@ extension EnvironmentValues {
 }
 
 public extension View {
-{% for variable in type.variables where variable|!annotated:"no_style" %}
+{% for variable in type.variables where variable|!annotated:"no_style" and variable|!annotated:"no_view" %}
 {% set NAME %}{{ variable.name|replace:'_','' }}{% endset %}
 {% set AStyle %}{% call StyleType variable.typeName.unwrappedTypeName %}{% endset %}
 
@@ -77,7 +77,7 @@ public extension View {
 {% for type in types.implementing._ComponentMultiPropGenerating %}
 
 	extension EnvironmentValues {
-	{% for variable in type.variables where variable|!annotated:"no_style" %}
+	{% for variable in type.variables where variable|!annotated:"no_style" and variable||!annotated:"no_view" %}
 	{% set NAME %}{{ variable.name|replace:'_','' }}{% endset %}
 	{% set keyname %}{{NAME | upperFirstLetter }}StyleKey{% endset %}
 	{% set AStyle %}{% call StyleType variable.typeName.unwrappedTypeName %}{% endset %}
@@ -95,7 +95,7 @@ public extension View {
 	}
 
 	public extension View {
-	{% for variable in type.variables where variable|!annotated:"no_style" %}
+	{% for variable in type.variables where variable|!annotated:"no_style" and variable||!annotated:"no_view" %}
 	{% set NAME %}{{ variable.name|replace:'_','' }}{% endset %}
 	{% set AStyle %}{% call StyleType variable.typeName.unwrappedTypeName %}{% endset %}
 


### PR DESCRIPTION
Use sourcery annotation `// sourcery: no_view` on a property which shall not be represented as a view. The property will still be used in the initializers but does not have the @ViewBuilder property wrapper and is declared with its original data type.

```swift
internal protocol _KpiProgress: KpiComponent, _ComponentMultiPropGenerating {
    // sourcery: no_view
    var fraction_: Double? { get }
}
```

Result:

```swift
public struct KPIProgressItem<Kpi: View, Subtitle: View, Footnote: View> { // no `Fraction: View` !
    @Environment(\.kpiModifier) private var kpiModifier
	@Environment(\.subtitleModifier) private var subtitleModifier
	@Environment(\.footnoteModifier) private var footnoteModifier

    private let _kpi: Kpi
	private let _fraction: Double? // data type is used!
	private let _subtitle: Subtitle
	private let _footnote: Footnote
	
    private var isModelInit: Bool = false
	private var isKpiNil: Bool = false
	private var isSubtitleNil: Bool = false
	private var isFootnoteNil: Bool = false

    public init(
        @ViewBuilder kpi: @escaping () -> Kpi,
		fraction: Double?, // data type is used!
		@ViewBuilder subtitle: @escaping () -> Subtitle,
		@ViewBuilder footnote: @escaping () -> Footnote
        ) {
            self._kpi = kpi()
			self._fraction = fraction // direct assignment
			self._subtitle = subtitle()
			self._footnote = footnote()
    }
    // ...
}
```