### PR TITLE
chore: apply backingComponent type also for String, [String] or Image

### DIFF
--- a/sourcery/.lib/Sources/utils/Variable+Extensions.swift
+++ b/sourcery/.lib/Sources/utils/Variable+Extensions.swift
@@ -33,19 +33,14 @@ public extension Variable {
         }
     }
 
-    var conditionalAssignmentBacked: String {
-        if isOptional {
-            return "\(self.trimmedName) != nil ? ViewBuilder.buildEither(first: \(self.toSwiftUIBacked)) : ViewBuilder.buildEither(second: EmptyView())"
-        } else {
-            return self.toSwiftUIBacked
-        }
-    }
-
     var backingSwiftUIComponent: String? {
         self.definedInType?.resolvedAnnotations("backingComponent").first ?? resolvedAnnotations("backingComponent").first
     }
 
     var toSwiftUI: String {
+        if self.backingSwiftUIComponent != nil {
+            return "\(self.swiftUITypeName)(\(self.trimmedName): \(self.trimmedName))"
+        }
         switch self.typeName.unwrappedTypeName {
         case "String":
             return isOptional ? "Text(\(self.trimmedName)!)" : "Text(\(self.trimmedName))"
@@ -55,19 +50,6 @@ public extension Variable {
             return isOptional ? "\(self.trimmedName)!" : self.trimmedName
         default:
             return "\(self.swiftUITypeName)(\(self.trimmedName): \(self.trimmedName))"
-        }
-    }
-
-    var toSwiftUIBacked: String {
-        switch self.typeName.unwrappedTypeName {
-        case "String":
-            return isOptional ? "Text(\(self.trimmedName)!)" : "Text(\(self.trimmedName))"
-        case "[String]":
-            return "Text(\(self.trimmedName).joined(separator: \", \"))"
-        case "Image":
-            return isOptional ? "\(self.trimmedName)!" : self.trimmedName
-        default:
-            return "\(self.swiftUITypeNameBacked)(\(self.trimmedName))"
         }
     }
 


### PR DESCRIPTION
Fix to apply backingComponent type properly if property data type is `[String]?` or `String` / `Image`

Assuming:

```swift
    // sourcery: no_style
    // sourcery: backingComponent=TagStack
    let tags_: [String]?
```

Correct:

```swift
self._tags = tags != nil ? ViewBuilder.buildEither(first: Tag(tags: tags)) : ViewBuilder.buildEither(second: EmptyView())
```
Incorrect:

```swift
self._tags = tags != nil ? ViewBuilder.buildEither(first: Text(tags.joined(separator: “, “))) : ViewBuilder.buildEither(second: EmptyView())
```
