### PR TITLE
chore: 🤖 change add_view_builder_params from private to internal

### DIFF
--- a/Sources/FioriSwiftUICore/_generated/ViewModels/API/ProfileHeader+API.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/API/ProfileHeader+API.generated.swift
@@ -15,7 +15,7 @@ public struct ProfileHeader<Title: View, Subtitle: View, Footnote: View, Descrip
 	let _footnote: Footnote
 	let _descriptionText: DescriptionText
 	let _detailImage: DetailImage
-	private let _actionItems: ActionItems
+	let _actionItems: ActionItems
 	
     private var isModelInit: Bool = false
 	private var isSubtitleNil: Bool = false

--- a/sourcery/.lib/Sources/utils/Type+Extensions.swift
+++ b/sourcery/.lib/Sources/utils/Type+Extensions.swift
@@ -56,7 +56,7 @@ public extension Type {
     
     var add_view_builder_paramsViewBuilderPropertyDecls: [String] {
         self.resolvedAnnotations("add_view_builder_params")
-            .map { "private let _\($0): \($0.capitalizingFirst())" }
+            .map { "let _\($0): \($0.capitalizingFirst())" }
     }
     
     var add_view_builder_paramsViewBuilderInitParams: [String] {


### PR DESCRIPTION
Fixes the issue that `// sourcery: add_view_builder_params = “detailContent”` still generates `private let _detailContent: DetailContent` while other properties are internal (since https://github.com/SAP/cloud-sdk-ios-fiori/pull/243)