### PR TITLE
chore: declare optional multi-property component usage

### DIFF
--- a/Sources/FioriSwiftUICore/Components/MultiPropertyComponents.swift
+++ b/Sources/FioriSwiftUICore/Components/MultiPropertyComponents.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 
 /// use for component with a function and one (or more) properties
 internal protocol _ComponentMultiPropGenerating {}

--- a/sourcery/.lib/Sources/utils/Array+Variable.swift
+++ b/sourcery/.lib/Sources/utils/Array+Variable.swift
@@ -27,7 +27,13 @@ public extension Array where Element == Variable {
      */
     var viewModifierPropertyDecls: [String] {
         filter { $0.annotations.keys.contains("no_style") == false }
-            .map { "@Environment(\\.\($0.trimmedName)Modifier) private var \($0.trimmedName)Modifier" }
+            .map {
+                if $0.resolvedAnnotations("environmentValue").first != nil {
+                    return "@Environment(\\.\($0.resolvedAnnotations("environmentValue").first!)) private var \($0.trimmedName)Modifier"
+                } else {
+                    return "@Environment(\\.\($0.trimmedName)Modifier) private var \($0.trimmedName)Modifier"
+                }
+            }
     }
 
     /**
@@ -96,7 +102,13 @@ public extension Array where Element == Variable {
     }
 
     var dataTypePropertyDecls: [String] {
-        map { "var _\($0.trimmedName): \($0.typeName) = nil" }
+        map {
+            if $0.isOptional {
+                return "var _\($0.trimmedName): \($0.typeName) = nil"
+            } else {
+                return "var _\($0.trimmedName): \($0.typeName)"
+            }
+        }
     }
 
     /**

--- a/sourcery/.lib/Sources/utils/Variable+Extensions.swift
+++ b/sourcery/.lib/Sources/utils/Variable+Extensions.swift
@@ -1,6 +1,10 @@
 import Foundation
 import SourceryRuntime
 
+public enum ComponentInitializationKind: String {
+    case modelForced
+}
+
 public extension Variable {
     var swiftUITypeNameBacked: String {
         if let backingSwiftUIComponent = backingSwiftUIComponent {
@@ -37,9 +41,23 @@ public extension Variable {
         self.definedInType?.resolvedAnnotations("backingComponent").first ?? resolvedAnnotations("backingComponent").first
     }
 
+    var componentInitializationKind: ComponentInitializationKind? {
+        if let caseName = self.definedInType?.resolvedAnnotations("componentInitializationKind").first ?? resolvedAnnotations("componentInitializationKind").first {
+            return ComponentInitializationKind(rawValue: caseName)
+        }
+        return nil
+    }
+
     var toSwiftUI: String {
         if self.backingSwiftUIComponent != nil {
-            return "\(self.swiftUITypeName)(\(self.trimmedName): \(self.trimmedName))"
+            if let kind = self.componentInitializationKind {
+                switch kind {
+                case .modelForced:
+                    return "\(self.swiftUITypeName)(model: \(self.trimmedName)!)"
+                }
+            } else {
+                return "\(self.swiftUITypeName)(\(self.trimmedName): \(self.trimmedName))"
+            }
         }
         switch self.typeName.unwrappedTypeName {
         case "String":


### PR DESCRIPTION
A reusable multi-property component like `TextInputComponent`

```swift
// sourcery: backingComponent=TextInput
public protocol TextInputComponent {
    var textFilled_: Binding<String> { get }
    var defaultText_: String? { get }
	func onCommit() -> Void
}
```

can be used in a composite component by declaring its model interface directly

```swift
// sourcery: generated_component_composite
// sourcery: virtualPropEmailFilled = "@ObservedObject var emailFilled = UserInput()"
// sourcery: virtualPropButtonEnabled = "@State var buttonEnabled: Bool = false"
public protocol ActivationScreenModel: TitleComponent, DescriptionTextComponent, TextInputModel, ActionModel, FootnoteComponent, SecondaryActionModel {}
```

but an app developer has to provide an implementation for all the properties like `textFilled_` or `defaultText_` even in scenarios in which `ActivationScreen` shall not have input control.

If the reusable multi-property component is optional then it is better to create a use-case specific protocol to introduce an indirection to its model protocol

```swift
public protocol ActivationEmailTextInputModel {
    // sourcery: backingComponent=TextInput
    // sourcery: componentInitializationKind=modelForced
    // sourcery: environmentValue=textFilledModifier
    var activationEmailTextInput_: TextInputModel? { get }
}

// sourcery: generated_component_composite
// sourcery: virtualPropEmailFilled = "@ObservedObject var emailFilled = UserInput()"
// sourcery: virtualPropButtonEnabled = "@State var buttonEnabled: Bool = false"
public protocol ActivationScreenModel: TitleComponent, DescriptionTextComponent, ActivationEmailTextInputModel, ActionModel, FootnoteComponent, SecondaryActionModel {}
```

This has the advantage that an app developer does not need to provide an implementation for all `TextInputComponent` properties

```swift
class ActivationScreenDataModel: ActivationScreenModel {

    var activationEmailTextInput_: TextInputModel? = nil
}
```

but app developer easily can.

```swift
class ActivationScreenDataModel: ActivationScreenModel, TextInputModel {
    
	var activationEmailTextInput_: TextInputModel? { return self }
    
	// MARK: TextInputModel
	var textFilled_: Binding<String> = .constant("Hi")
    var defaultText_: String? = "just for testing"
```

Internally two new sourcery annotations were introduced: `// sourcery: componentInitializationKind=modelForced` and `// sourcery: environmentValue=<name of environmentValue defined by the component, e.g. textFilledModifier>`