### PR TITLE
fix: 🐛 allows displaying a existing signature image

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/SignatureView/SignatureCaptureView.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/SignatureView/SignatureCaptureView.swift
@@ -8,6 +8,9 @@ struct SignatureCaptureView_Example: View {
             let imgSaver = ImageSaver()
             imgSaver.writeToPhotoAlbum(image: result.uiImage)
         })
+            .cropsImage(true)
+            .drawingViewBackgroundColor(.yellow)
+            .signatureImage(UIImage(systemName: "scribble")!)
     }
 }
 

--- a/Sources/FioriSwiftUICore/SignatureView/DrawingPad.swift
+++ b/Sources/FioriSwiftUICore/SignatureView/DrawingPad.swift
@@ -38,7 +38,7 @@ struct DrawingPad: View {
     @Binding var isSave: Bool
     @Binding var uiImage: UIImage?
     @Binding var savedSignatureImage: UIImage?
-    @Binding var drawingPadSize: CGSize?
+    @Binding var drawingPadSize: CGSize
 
     var onSave: ((SignatureCaptureView.Result) -> Void)?
     var strokeColor: Color
@@ -78,7 +78,7 @@ struct DrawingPad: View {
         }
         if self.isSave && uiImage == nil {
             let path = createUIBezierPath(drawings: drawings, lineWidth: self.lineWidth)
-            guard let originalImage = createImage(path, size: self.drawingPadSize!, origin: nil) else {
+            guard let originalImage = createImage(path, size: self.drawingPadSize, origin: nil) else {
                 return v
             }
             var signature = originalImage

--- a/Sources/FioriSwiftUICore/SignatureView/DrawingPad.swift
+++ b/Sources/FioriSwiftUICore/SignatureView/DrawingPad.swift
@@ -78,12 +78,16 @@ struct DrawingPad: View {
         }
         if self.isSave && uiImage == nil {
             let path = createUIBezierPath(drawings: drawings, lineWidth: self.lineWidth)
-            let originalImage = createImage(path, size: self.drawingPadSize!, origin: nil)
+            guard let originalImage = createImage(path, size: self.drawingPadSize!, origin: nil) else {
+                return v
+            }
             var signature = originalImage
             if self.cropsImage {
                 let size = CGSize(width: path.bounds.size.width + signaturePadding.leading + signaturePadding.trailing, height: path.bounds.size.height + signaturePadding.top + signaturePadding.bottom)
                 let origin = CGPoint(x: path.bounds.origin.x - signaturePadding.leading, y: path.bounds.origin.y - signaturePadding.top)
-                signature = createImage(path, size: size, origin: origin)
+                if let cropedImage = createImage(path, size: size, origin: origin) {
+                    signature = cropedImage
+                }
             }
 
             let image = Image(uiImage: signature)
@@ -108,7 +112,7 @@ struct DrawingPad: View {
         }
     }
 
-    func createImage(_ path: UIBezierPath, size: CGSize, origin: CGPoint?) -> UIImage {
+    func createImage(_ path: UIBezierPath, size: CGSize, origin: CGPoint?) -> UIImage? {
         UIGraphicsBeginImageContextWithOptions(size, false, 1)
         if #available(iOS 14.0, *) {
             let color = UIColor(self.backgroundColor)
@@ -132,7 +136,7 @@ struct DrawingPad: View {
         }
         path.stroke()
 
-        let image = UIGraphicsGetImageFromCurrentImageContext()!
+        let image = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
         return image
     }

--- a/Sources/FioriSwiftUICore/SignatureView/DrawingPad.swift
+++ b/Sources/FioriSwiftUICore/SignatureView/DrawingPad.swift
@@ -36,11 +36,16 @@ struct DrawingPad: View {
     @Binding var currentDrawing: Drawing
     @Binding var drawings: [Drawing]
     @Binding var isSave: Bool
+    @Binding var uiImage: UIImage?
+    @Binding var savedSignatureImage: UIImage?
+    @Binding var drawingPadSize: CGSize?
+
     var onSave: ((SignatureCaptureView.Result) -> Void)?
     var strokeColor: Color
     var lineWidth: CGFloat
     var backgroundColor: Color
     let signaturePadding = EdgeInsets(top: 10, leading: 10, bottom: 10, trailing: 10)
+    var cropsImage: Bool
     
     var body: some View {
         let v = GeometryReader { geometry in
@@ -67,36 +72,25 @@ struct DrawingPad: View {
                     .onEnded { _ in
                         self.drawings.append(self.currentDrawing)
                         self.currentDrawing = Drawing()
+                        self.drawingPadSize = geometry.size
                     }
             )
         }
-        if self.isSave {
+        if self.isSave && uiImage == nil {
             let path = createUIBezierPath(drawings: drawings, lineWidth: self.lineWidth)
-            let size = CGSize(width: path.bounds.size.width + signaturePadding.leading + signaturePadding.trailing, height: path.bounds.size.height + signaturePadding.top + signaturePadding.bottom)
-            UIGraphicsBeginImageContextWithOptions(size, false, 1)
-            if #available(iOS 14.0, *) {
-                let color = UIColor(self.backgroundColor)
-                color.setFill()
-            } else {
-                let color = self.backgroundColor.uiColor()
-                color.setFill()
+            let originalImage = createImage(path, size: self.drawingPadSize!, origin: nil)
+            var signature = originalImage
+            if self.cropsImage {
+                let size = CGSize(width: path.bounds.size.width + signaturePadding.leading + signaturePadding.trailing, height: path.bounds.size.height + signaturePadding.top + signaturePadding.bottom)
+                let origin = CGPoint(x: path.bounds.origin.x - signaturePadding.leading, y: path.bounds.origin.y - signaturePadding.top)
+                signature = createImage(path, size: size, origin: origin)
             }
 
-            let origin = CGPoint(x: path.bounds.origin.x - signaturePadding.leading, y: path.bounds.origin.y - signaturePadding.top)
-            path.apply(CGAffineTransform(translationX: -1 * origin.x, y: -1 * origin.y))
-            UIRectFill(CGRect(origin: .zero, size: size))
-            if #available(iOS 14.0, *) {
-                let color = UIColor(self.strokeColor)
-                color.setStroke()
-            } else {
-                let color = self.strokeColor.uiColor()
-                color.setStroke()
-            }
-            path.stroke()
-
-            guard let signature = UIGraphicsGetImageFromCurrentImageContext() else { return v }
-            UIGraphicsEndImageContext()
             let image = Image(uiImage: signature)
+            DispatchQueue.main.async {
+                self.uiImage = originalImage
+                self.savedSignatureImage = originalImage
+            }
             self.onSave?(SignatureCaptureView.Result(image: image, uiImage: signature))
         }
         return v
@@ -112,5 +106,34 @@ struct DrawingPad: View {
                 path.addLine(to: next)
             }
         }
+    }
+
+    func createImage(_ path: UIBezierPath, size: CGSize, origin: CGPoint?) -> UIImage {
+        UIGraphicsBeginImageContextWithOptions(size, false, 1)
+        if #available(iOS 14.0, *) {
+            let color = UIColor(self.backgroundColor)
+            color.setFill()
+        } else {
+            let color = self.backgroundColor.uiColor()
+            color.setFill()
+        }
+
+        if let origin = origin {
+            path.apply(CGAffineTransform(translationX: -1 * origin.x, y: -1 * origin.y))
+        }
+
+        UIRectFill(CGRect(origin: .zero, size: size))
+        if #available(iOS 14.0, *) {
+            let color = UIColor(self.strokeColor)
+            color.setStroke()
+        } else {
+            let color = self.strokeColor.uiColor()
+            color.setStroke()
+        }
+        path.stroke()
+
+        let image = UIGraphicsGetImageFromCurrentImageContext()!
+        UIGraphicsEndImageContext()
+        return image
     }
 }

--- a/Sources/FioriSwiftUICore/SignatureView/SignatureCaptureView.swift
+++ b/Sources/FioriSwiftUICore/SignatureView/SignatureCaptureView.swift
@@ -12,9 +12,6 @@ public struct SignatureCaptureView: View {
     /// An optional closure for handling save button tap action
     public var onSave: ((Result) -> Void)?
     
-    /// An optional closure for handling cancel button tap action
-    public var onCancel: (() -> Void)?
-    
     /// :nodoc:
     public private(set) var _heightDidChangePublisher = CurrentValueSubject<CGFloat, Never>(0)
     
@@ -24,7 +21,13 @@ public struct SignatureCaptureView: View {
     ///   - onCancel: The block to be executed when  user tapped the "Cancel" button.
     public init(onSave: ((Result) -> Void)? = nil, onCancel: (() -> Void)? = nil) {
         self.onSave = onSave
-        self.onCancel = onCancel
+    }
+
+    /// Initializes and returns a `SignatureCaptureView`.
+    /// - Parameters:
+    ///   - onSave: The block to be executed when user tapped the "Save" button.
+    public init(onSave: ((Result) -> Void)? = nil) {
+        self.onSave = onSave
     }
     
     struct VStackPreferenceKey: PreferenceKey {
@@ -49,6 +52,10 @@ public struct SignatureCaptureView: View {
     @State private var drawings = [Drawing]()
     @State private var isEditing = false
     @State private var isSaved = false
+    @State private var uiImage: UIImage? = nil
+    @State private var savedSignatureImage: UIImage? = nil
+    @State private var drawingPadSize: CGSize? = nil
+    @State private var displaysSignatureImage = true
 
     // use internal properties so that the unit test could access them
     let _drawingViewMinHeight: CGFloat = 256
@@ -56,10 +63,12 @@ public struct SignatureCaptureView: View {
     var strokeWidth: CGFloat = 3.0
     var strokeColor = Color.preferredColor(.primaryLabel)
     var drawingViewBackgroundColor = Color.preferredColor(.primaryBackground)
+    var cropsImage = false
+    var signatureImage: UIImage?
 
     public var body: some View {
         VStack {
-            if !self.isEditing {
+            if !self.isEditing && !showsSignatureImage() {
                 VStack {
                     HStack {
                         Text("Signature", tableName: tableName, bundle: bundle)
@@ -85,36 +94,49 @@ public struct SignatureCaptureView: View {
                     HStack {
                         Text("Signature", tableName: tableName, bundle: bundle)
                         Spacer()
-                        if !self.isSaved {
+                        if !self.isSaved && !showsImage() {
                             Button(action: {
                                 self.drawings.removeAll()
                                 self.isSaved = false
-                                self.onCancel?()
                                 self.isEditing = false
+                                self.uiImage = savedSignatureImage
+                                self.displaysSignatureImage = true
                             }) {
                                 Text("Cancel", tableName: tableName, bundle: bundle)
                             }
                         }
                     }
                     ZStack {
-                        ZStack(alignment: .bottom) {
-                            DrawingPad(currentDrawing: self.$currentDrawing,
-                                       drawings: self.$drawings,
-                                       isSave: self.$isSaved,
-                                       onSave: self.onSave,
-                                       strokeColor: self.strokeColor,
-                                       lineWidth: self.strokeWidth,
-                                       backgroundColor: self.drawingViewBackgroundColor)
-                                .foregroundColor(Color.preferredColor(.cellBackground))
-                                .frame(minHeight: _drawingViewMinHeight, maxHeight: _drawingViewMaxHeight)
-                            if !self.isSaved {
-                                HStack {
-                                    Image(systemName: "xmark")
-                                        .foregroundColor(Color.preferredColor(.quarternaryLabel))
-                                        .font(.body)
-                                        .opacity(0.4)
-                                    Rectangle().background(Color.preferredColor(.quarternaryLabel)).opacity(0.4).frame(height: 1)
-                                }.padding([.leading, .trailing]).padding(.bottom, 30)
+                        ZStack {
+                            ZStack(alignment: .bottom) {
+                                DrawingPad(currentDrawing: self.$currentDrawing,
+                                           drawings: self.$drawings,
+                                           isSave: self.$isSaved,
+                                           uiImage: self.$uiImage,
+                                           savedSignatureImage: self.$savedSignatureImage,
+                                           drawingPadSize: self.$drawingPadSize,
+                                           onSave: self.onSave,
+                                           strokeColor: self.strokeColor,
+                                           lineWidth: self.strokeWidth,
+                                           backgroundColor: self.drawingViewBackgroundColor,
+                                           cropsImage: self.cropsImage)
+                                    .foregroundColor(Color.preferredColor(.cellBackground))
+                                    .frame(minHeight: _drawingViewMinHeight, maxHeight: _drawingViewMaxHeight)
+                                if !self.isSaved {
+                                    HStack {
+                                        Image(systemName: "xmark")
+                                            .foregroundColor(Color.preferredColor(.quarternaryLabel))
+                                            .font(.body)
+                                            .opacity(0.4)
+                                        Rectangle().background(Color.preferredColor(.quarternaryLabel)).opacity(0.4).frame(height: 1)
+                                    }.padding([.leading, .trailing]).padding(.bottom, 30)
+                                }
+                            }.setHidden(showsImage())
+                            if let image = savedSignatureImage ?? (displaysSignatureImage ? signatureImage : nil) {
+                                Image(uiImage: image)
+                                    .frame(minHeight: _drawingViewMinHeight, maxHeight: _drawingViewMaxHeight)
+                                    .cornerRadius(10)
+                                    .setHidden(!showsImage())
                             }
                         }
                         
@@ -130,7 +152,7 @@ public struct SignatureCaptureView: View {
                         }
                     }
                     HStack {
-                        if !self.isSaved {
+                        if !self.isSaved && !showsImage() {
                             Button(action: {
                                 self.drawings.removeAll()
                             }) {
@@ -148,8 +170,10 @@ public struct SignatureCaptureView: View {
                             Button(action: {
                                 withAnimation {
                                     self.drawings.removeAll()
-                                    self.onCancel?()
                                     self.isSaved = false
+                                    self.isEditing = true
+                                    self.uiImage = nil
+                                    self.displaysSignatureImage = false
                                 }
                             }) {
                                 Text("Re-enter Signature", tableName: tableName, bundle: bundle)
@@ -166,6 +190,14 @@ public struct SignatureCaptureView: View {
             }
             self._heightDidChangePublisher.send(height)
         }
+    }
+
+    func showsSignatureImage() -> Bool {
+        self.displaysSignatureImage && self.signatureImage != nil
+    }
+
+    func showsImage() -> Bool {
+        self.uiImage != nil || self.showsSignatureImage()
     }
 }
 
@@ -221,6 +253,28 @@ public extension SignatureCaptureView {
 
         return newSelf
     }
+
+    /**
+     A view modifier to set if the saved image should crop the extra spaces or not. The default is not to crop.
+
+     - parameter cropsImage: Indicates if the saved image should crop the extra spaces or not.
+     */
+    func cropsImage(_ cropsImage: Bool) -> Self {
+        var newSelf = self
+        newSelf.cropsImage = cropsImage
+        return newSelf
+    }
+
+    /**
+     A view modifier to set the signature image.
+
+     - parameter image: The existing signature image.
+     */
+    func signatureImage(_ image: UIImage) -> Self {
+        var newSelf = self
+        newSelf.signatureImage = image
+        return newSelf
+    }
 }
 
 public extension SignatureCaptureView {
@@ -230,5 +284,15 @@ public extension SignatureCaptureView {
         public let image: Image
         /// SIgnature UIImage
         public let uiImage: UIImage
+    }
+}
+
+extension View {
+    @ViewBuilder func setHidden(_ isHidden: Bool) -> some View {
+        if isHidden {
+            self.hidden()
+        } else {
+            self
+        }
     }
 }

--- a/Sources/FioriSwiftUICore/SignatureView/SignatureCaptureView.swift
+++ b/Sources/FioriSwiftUICore/SignatureView/SignatureCaptureView.swift
@@ -54,7 +54,7 @@ public struct SignatureCaptureView: View {
     @State private var isSaved = false
     @State private var uiImage: UIImage? = nil
     @State private var savedSignatureImage: UIImage? = nil
-    @State private var drawingPadSize: CGSize? = nil
+    @State private var drawingPadSize: CGSize = .zero
     @State private var displaysSignatureImage = true
 
     // use internal properties so that the unit test could access them
@@ -68,7 +68,7 @@ public struct SignatureCaptureView: View {
 
     public var body: some View {
         VStack {
-            if !self.isEditing && !showsSignatureImage() {
+            if !self.isEditing && !showsSignatureImage() && !showsSavedSignatureImage() {
                 VStack {
                     HStack {
                         Text("Signature", tableName: tableName, bundle: bundle)
@@ -198,6 +198,10 @@ public struct SignatureCaptureView: View {
 
     func showsImage() -> Bool {
         self.uiImage != nil || self.showsSignatureImage()
+    }
+
+    func showsSavedSignatureImage() -> Bool {
+        self.savedSignatureImage != nil || self.showsSignatureImage()
     }
 }
 

--- a/Sources/FioriSwiftUICore/SignatureView/SignatureView.swift
+++ b/Sources/FioriSwiftUICore/SignatureView/SignatureView.swift
@@ -19,6 +19,10 @@ struct SignatureView: View {
     @State private var rect1: CGRect = .zero
     @State private var shouldRemoveWhitespace = true
     @State private var isSaved = false
+    @State private var uiImage: UIImage? = nil
+    @State private var savedSignatureImage: UIImage? = nil
+    @State private var drawingPadSize: CGSize? = nil
+    private var cropsImage = false
     
     init(strokeWidth: CGFloat = 3.0, imageStrokeColor: Color = Color.preferredColor(.primaryLabel), backgroundColor: Color = Color.preferredColor(.primaryBackground), onSave: ((SignatureCaptureView.Result) -> Void)? = nil, onCancel: (() -> Void)? = nil) {
         self.strokeWidth = strokeWidth
@@ -71,10 +75,14 @@ struct SignatureView: View {
                 DrawingPad(currentDrawing: self.$currentDrawing,
                            drawings: self.$drawings,
                            isSave: self.$isSaved,
+                           uiImage: self.$uiImage,
+                           savedSignatureImage: self.$savedSignatureImage,
+                           drawingPadSize: self.$drawingPadSize,
                            onSave: self.onSave,
                            strokeColor: self.imageStrokeColor,
                            lineWidth: self.strokeWidth,
-                           backgroundColor: self.backgroundColor)
+                           backgroundColor: self.backgroundColor,
+                           cropsImage: self.cropsImage)
                     .background(RectGetter(rect: self.$rect1))
                 HStack {
                     Text("X")

--- a/Sources/FioriSwiftUICore/SignatureView/SignatureView.swift
+++ b/Sources/FioriSwiftUICore/SignatureView/SignatureView.swift
@@ -21,7 +21,7 @@ struct SignatureView: View {
     @State private var isSaved = false
     @State private var uiImage: UIImage? = nil
     @State private var savedSignatureImage: UIImage? = nil
-    @State private var drawingPadSize: CGSize? = nil
+    @State private var drawingPadSize: CGSize = .zero
     private var cropsImage = false
     
     init(strokeWidth: CGFloat = 3.0, imageStrokeColor: Color = Color.preferredColor(.primaryLabel), backgroundColor: Color = Color.preferredColor(.primaryBackground), onSave: ((SignatureCaptureView.Result) -> Void)? = nil, onCancel: (() -> Void)? = nil) {

--- a/Tests/FioriSwiftUITests/FioriSwiftUICore/SignatureCaptureViewTests.swift
+++ b/Tests/FioriSwiftUITests/FioriSwiftUICore/SignatureCaptureViewTests.swift
@@ -6,7 +6,6 @@ import XCTest
 
 class SignatureCaptureTests: XCTestCase {
     var isOnSaveCalled = false
-    var isOnCancelCalled = false
 
     override func setUpWithError() throws {
         // Put setup code here. This method is called before the invocation of each test method in the class.
@@ -17,7 +16,7 @@ class SignatureCaptureTests: XCTestCase {
     }
 
     func testBasic() throws {
-        let signagureCaptureView = SignatureCaptureView(onSave: self.onSave, onCancel: self.onCancel)
+        let signagureCaptureView = SignatureCaptureView(onSave: self.onSave)
 
         XCTAssertEqual(signagureCaptureView.bundle, Bundle.module)
         XCTAssertEqual(signagureCaptureView.tableName, "FioriSwiftUICore")
@@ -35,14 +34,10 @@ class SignatureCaptureTests: XCTestCase {
         let result = SignatureCaptureView.Result(image: image, uiImage: uiImage)
         signagureCaptureView.onSave?(result)
         XCTAssertTrue(self.isOnSaveCalled)
-
-        self.isOnCancelCalled = false
-        signagureCaptureView.onCancel?()
-        XCTAssertTrue(self.isOnCancelCalled)
     }
 
     func testModifiers() throws {
-        let signagureCaptureView = SignatureCaptureView(onSave: self.onSave, onCancel: self.onCancel)
+        let signagureCaptureView = SignatureCaptureView(onSave: self.onSave)
             ._drawingViewMaxHeight(256)
             .strokeWidth(10)
             .strokeColor(.blue)
@@ -56,9 +51,5 @@ class SignatureCaptureTests: XCTestCase {
 
     func onSave(_ result: SignatureCaptureView.Result) {
         self.isOnSaveCalled = true
-    }
-
-    func onCancel() {
-        self.isOnCancelCalled = true
     }
 }


### PR DESCRIPTION
Developer may display an existing signature and user can re-sign

BREAKING CHANGE: 🧨 remove onCancel in constructor