### PR TITLE
chore: sourcery template/lib supports ObservableObject and Binding br…

### DIFF
--- a/Sources/FioriSwiftUICore/Components/MultiPropertyComponents.swift
+++ b/Sources/FioriSwiftUICore/Components/MultiPropertyComponents.swift
@@ -24,7 +24,10 @@ internal protocol _SecondaryAction: _ComponentMultiPropGenerating {
 }
 
 // sourcery: backingComponent=TextInput
-internal protocol _TextInput: _ComponentMultiPropGenerating {
+internal protocol _TextInput: _ComponentMultiPropGenerating, ObservableObject {
+    // sourcery: gettableAndSettable
+    // sourcery: wrappedDataType=String
+    // sourcery: internalDataType=Binding<String>
     var textFilled_: Binding<String>? { get }
     func onCommit() // action handler
 }

--- a/sourcery/.lib/Sources/utils/Array+Variable.swift
+++ b/sourcery/.lib/Sources/utils/Array+Variable.swift
@@ -96,7 +96,13 @@ public extension Array where Element == Variable {
     }
 
     var dataTypePropertyDecls: [String] {
-        map { "var _\($0.trimmedName): \($0.typeName) = nil" }
+        map {
+            if $0.isOptional {
+                return "var _\($0.trimmedName): \($0.computedInternalTypeName) = nil"
+            } else {
+                return "var _\($0.trimmedName): \($0.computedInternalTypeName)"
+            }
+        }
     }
 
     /**
@@ -243,15 +249,21 @@ extension Array where Element: Variable {
     }
 
     public var extensionConstrainedWhereConditionalContent: String {
-        map { "\($0.trimmedName.capitalizingFirst()) == \($0.isOptional ? "_ConditionalContent<\($0.swiftUITypeName), EmptyView>" : $0.swiftUITypeName)" }.joined(separator: ",\n\t\t")
+        map { "\($0.trimmedName.capitalizingFirst()) == \(($0.isOptional || $0.annotations.keys.contains("internalDataType")) ? "_ConditionalContent<\($0.swiftUITypeName), EmptyView>" : $0.swiftUITypeName)" }.joined(separator: ",\n\t\t")
     }
 
     public var extensionModelInitParams: [String] {
-        map { "\($0.trimmedName): \($0.typeName.name)\($0.emptyDefault)" }
+        map { "\($0.trimmedName): \($0.computedInternalTypeName)\($0.emptyDefault)" }
     }
 
     public var extensionModelInitParamsChaining: [String] {
-        map { "\($0.trimmedName): model.\($0.name)" }
+        map {
+            if $0.annotations.keys.contains("internalDataType") == true {
+                return "\($0.trimmedName): \($0.annotations["internalDataType"] as! String)(get: { model.\($0.name) }, set: { model.\($0.name) = $0 })"
+            } else {
+                return "\($0.trimmedName): model.\($0.name)"
+            }
+        }
     }
 
     var usage: String {

--- a/sourcery/.lib/Sources/utils/Type+Extensions.swift
+++ b/sourcery/.lib/Sources/utils/Type+Extensions.swift
@@ -344,4 +344,25 @@ extension Type {
         guard let content = resolvedAnnotations("availableAttributeContent").first else { return nil }
         return "@available(\(content))"
     }
+
+    var isObservableObjectConform: Bool {
+        let context = ProcessInfo().context!
+        let contextType = context.type
+
+        if inheritedTypes.contains("ObservableObject") {
+            return true
+        } else if inheritedTypes.count > 0 {
+            let inheritedTypeDefs = inheritedTypes.compactMap { contextType[$0] }.compactMap { $0 }
+            let results = inheritedTypeDefs.map { aType in
+                aType.isObservableObjectConform
+            }
+            if results.contains(true) {
+                return true
+            } else {
+                return false
+            }
+        } else {
+            return false
+        }
+    }
 }

--- a/sourcery/.lib/Sources/utils/Variable+Extensions.swift
+++ b/sourcery/.lib/Sources/utils/Variable+Extensions.swift
@@ -116,4 +116,8 @@ public extension Variable {
     var propDecl: String {
         "\(self.trimmedName): \(self.typeName)"
     }
+
+    var computedInternalTypeName: String {
+        annotations["internalDataType"] as? String ?? self.typeName.name
+    }
 }

--- a/sourcery/stencils/main_phase/noviewbuilderbased_model_decl.swifttemplate
+++ b/sourcery/stencils/main_phase/noviewbuilderbased_model_decl.swifttemplate
@@ -58,8 +58,12 @@ public struct <%= model.componentName %> {
     <%= internalPropertyDecls %>
 	<% if !virtualPropertyDecls.isEmpty { -%><%= virtualPropertyDecls %><% } -%>
 
-    public init(<%= modelInitParams %>) {
-        self.init(<%= extensionModelInitParamsChaining %>)
+	<% if model.isObservableObjectConform == true { -%>
+public init<Model>(model: Model) where Model: <%= model.name %> {
+    <% } else { -%>
+public init(<%= modelInitParams %>) {
+    <% } -%>
+    self.init(<%= extensionModelInitParamsChaining %>)
     }
 
     public init(<%= extensionModelInitParams %>) {

--- a/sourcery/stencils/post_phase/composite_model_decl.swifttemplate
+++ b/sourcery/stencils/post_phase/composite_model_decl.swifttemplate
@@ -103,8 +103,12 @@ public struct <%= model.componentName %><<%= templateParameterDecls %>> {
 <%= modelAvailableAttribute -%>
 extension <%= model.componentName %> where <%= componentProperties.extensionConstrainedWhereConditionalContent %> {
 
-    public init(<%= modelInitParams %>) {
-        self.init(<%= extensionModelInitParamsChaining %>)
+	<% if model.isObservableObjectConform == true { -%>
+public init<Model>(model: Model) where Model: <%= model.name %> {
+    <% } else { -%>
+public init(<%= modelInitParams %>) {
+    <% } -%>
+    self.init(<%= extensionModelInitParamsChaining %>)
     }
 
     public init(<%= extensionModelInitParams %>) {

--- a/sourcery/stencils/pre_phase/partials/comp_decl_pvar.stencil
+++ b/sourcery/stencils/pre_phase/partials/comp_decl_pvar.stencil
@@ -6,4 +6,4 @@
 	// sourcery: {{key}}={{value}}
 	{% endif %}
 {% endfor %}
-    var {{variable.name}}: {{variable.typeName}} { get }
+    var {{variable.name}}: {% if variable|annotated:"wrappedDataType" %}{{ variable.annotations.wrappedDataType }}{% else %}{{variable.typeName}}{% endif %} { {% if variable|annotated:"gettableAndSettable" %}get set{% else %}get{% endif %} }


### PR DESCRIPTION
@xiaoqinggrace please include these changes into your PR https://github.com/SAP/cloud-sdk-ios-fiori/pull/242

This PR will not be merged as discussed

**Sourcery Code Changes discussed 5/25/2021**

Sourcery-based code generation shall be changed in order to 
- Being able to add ObservableObject conformance to generated component protocol 
- Add conditional initializer for ComponentName+API.generated.swift which can create Binding for an argument (in order to bridge to component’s non-binding data type )

Example usage

```swift
class ActivationScreenDataModel: ActivationScreenModel, ObservableObject {
  @Published var textFilled_: String = ""
}
struct ActivationScreenCustomizedSample: View {
  @ObservedObject var model = ActivationScreenDataModel()
}
```

Primer: Sourcery code generation for our project is based on the following metadata information:

`MultiPropertyComponents.swift`

```swift
// ATTENTION: to be changed to accomplish code changes !!!
// sourcery: backingComponent=TextInput
internal protocol _TextInput: _ComponentMultiPropGenerating {
    var textFilled_: Binding<String>? { get }
    func onCommit() // action handler
}
```

and `ModelsDefinitions.swift`

```swift
// sourcery: generated_component_not_configurable
public protocol TextInputModel: TextInputComponent {}

// sourcery: generated_component_composite
public protocol ActivationScreenModel: TitleComponent, DescriptionTextComponent, TextInputModel, ActionModel, FootnoteComponent, SecondaryActionModel {}
```

The metadata information are evaluated within templates (written either in Stencil or Swift, located cloud-sdk-ios-fiori/sourcery/stencils) with help of utility functions (located in cloud-sdk-ios-fiori/sourcery/.lib) and the templates describes the source code to be generated.

The following changes shall be accomplished:

## Component+Protocols.generated.swift

Old

```swift
// sourcery: backingComponent=TextInput
public protocol TextInputComponent {
    var textFilled_: Binding<String>? { get }
	func onCommit() -> Void
}
```

New

```swift
// sourcery: backingComponent=TextInput
public protocol TextInputComponent: ObservableObject { // conformance to ObservableObject
    // 1. non-optional data type
    // 2. data type "String" instead of "Binding <String>"
    // 3. property also settable
    var textFilled_: String { get set } 
    func onCommit() -> Void
}
```

## TextInput+API.generated.swift

Old

```swift
public struct TextInput {
    @Environment(\.textFilledModifier) private var textFilledModifier

    var _textFilled: Binding<String>? = nil
	var _onCommit: (() -> Void)? = nil
	
    public init(model: TextInputModel) {
        self.init(textFilled: model.textFilled_, onCommit: model.onCommit)
    }

    public init(textFilled: Binding<String>? = nil, onCommit: (() -> Void)? = nil) {
        self._textFilled = textFilled
		self._onCommit = onCommit
    }
}
```swift


New

``` swift
public struct TextInput {
    @Environment(\.textFilledModifier) private var textFilledModifier

    var _textFilled: Binding<String> // different, non-optional data type without setting a default value
	var _onCommit: (() -> Void)? = nil

    // conditional model initializer which bridges between String and Binding<String>
    public init<Model>(model: Model) where Model: TextInputModel {
            self.init(textFilled: Binding<String>(get: { model.textFilled_ }, set: { model.textFilled_ = $0 }), onCommit: model.onCommit)
    }

    // note: content-based initializer continues to expect Binding<String>
    public init(textFilled: Binding<String>, onCommit: (() -> Void)? = nil) {
        self._textFilled = textFilled
		self._onCommit = onCommit
    }
}
```

## ActivationScreen+API.generated.swift

Old

```swift
extension ActivationScreen where Title == Text,
		DescriptionText == _ConditionalContent<Text, EmptyView>,
		TextFilled == _ConditionalContent<TextInput, EmptyView>,
		ActionText == _ConditionalContent<Action, EmptyView>,
		Footnote == _ConditionalContent<Text, EmptyView>,
		SecondaryActionText == _ConditionalContent<SecondaryAction, EmptyView> {

    public init(model: ActivationScreenModel) {
        self.init(title: model.title_, descriptionText: model.descriptionText_, textFilled: model.textFilled_, actionText: model.actionText_, footnote: model.footnote_, secondaryActionText: model.secondaryActionText_, onCommit: model.onCommit, didSelectAction: model.didSelectAction, didSelectSecondaryAction: model.didSelectSecondaryAction)
    }

    public init(title: String, descriptionText: String? = nil, textFilled: Binding<String>? = nil, actionText: String? = nil, footnote: String? = nil, secondaryActionText: String? = nil, onCommit: (() -> Void)? = nil, didSelectAction: (() -> Void)? = nil, didSelectSecondaryAction: (() -> Void)? = nil) {
        self._title = Text(title)
		self._descriptionText = descriptionText != nil ? ViewBuilder.buildEither(first: Text(descriptionText!)) : ViewBuilder.buildEither(second: EmptyView())
		self._footnote = footnote != nil ? ViewBuilder.buildEither(first: Text(footnote!)) : ViewBuilder.buildEither(second: EmptyView())
		// handle TextInputModel
        if (textFilled != nil || onCommit != nil) {
            self._textFilled =  ViewBuilder.buildEither(first: TextInput(textFilled: textFilled,onCommit: onCommit))
        } else {
            self._textFilled = ViewBuilder.buildEither(second: EmptyView())
        }
    // ...
    }
```

New

```swift
extension ActivationScreen where Title == Text,
		DescriptionText == _ConditionalContent<Text, EmptyView>,
		TextFilled == _ConditionalContent<TextInput, EmptyView>,
		ActionText == _ConditionalContent<Action, EmptyView>,
		Footnote == _ConditionalContent<Text, EmptyView>,
		SecondaryActionText == _ConditionalContent<SecondaryAction, EmptyView> {

    // conditional model  initializer which bridges between String and Binding<String>
    public init<Model>(model: Model) where Model: ActivationScreenModel {
                self.init(title: model.title_, descriptionText: model.descriptionText_, textFilled: Binding<String>(get: { model.textFilled_ }, set: { model.textFilled_ = $0 }), actionText: model.actionText_, footnote: model.footnote_, secondaryActionText: model.secondaryActionText_, onCommit: model.onCommit, didSelectAction: model.didSelectAction, didSelectSecondaryAction: model.didSelectSecondaryAction)
    }

    // note: content-based initializer continues to expect Binding<String>
    public init(title: String, descriptionText: String? = nil, textFilled: Binding<String>, actionText: String? = nil, footnote: String? = nil, secondaryActionText: String? = nil, onCommit: (() -> Void)? = nil, didSelectAction: (() -> Void)? = nil, didSelectSecondaryAction: (() -> Void)? = nil) {
        self._title = Text(title)
		self._descriptionText = descriptionText != nil ? ViewBuilder.buildEither(first: Text(descriptionText!)) : ViewBuilder.buildEither(second: EmptyView())
		self._footnote = footnote != nil ? ViewBuilder.buildEither(first: Text(footnote!)) : ViewBuilder.buildEither(second: EmptyView())
		// handle TextInputModel
        if (textFilled != nil || onCommit != nil) {
            self._textFilled =  ViewBuilder.buildEither(first: TextInput(textFilled: textFilled,onCommit: onCommit))
        } else {
            self._textFilled = ViewBuilder.buildEither(second: EmptyView())
        }
```


# Solution

## Templates

/cloud-sdk-ios-fiori/sourcery/stencils/pre_phase/partials/comp_decl_pvar.stencil

```
{# expected to be run in a for-loop: variable in type.variables where variable #}
{% for key,value in variable.annotations %}
	{% if value == 1 %}
	// sourcery: {{key}}
	{% else %}
	// sourcery: {{key}}={{value}}
	{% endif %}
{% endfor %}
    var {{variable.name}}: {% if variable|annotated:"wrappedDataType" %}{{ variable.annotations.wrappedDataType }}{% else %}{{variable.typeName}}{% endif %} { {% if variable|annotated:"gettableAndSettable" %}get set{% else %}get{% endif %} }
```

cloud-sdk-ios-fiori/sourcery/stencils/main_phase/noviewbuilderbased_model_decl.swifttemplate

cloud-sdk-ios-fiori/sourcery/stencils/post_phase/composite_model_decl.swifttemplate


```
	<% if model.isObservableObjectConform == true { -%>
public init<Model>(model: Model) where Model: <%= model.name %> {
    <% } else { -%>
public init(<%= modelInitParams %>) {
    <% } -%>
    self.init(<%= extensionModelInitParamsChaining %>)
    }
```

Alternative: `<% if model.annotations.keys.contains("condGenModelInit") == true { -%>` which would require adding such annotation to a desired model

## Lib


Array+Variable.swift

```swift
    var dataTypePropertyDecls: [String] {
        map {
            if $0.isOptional {
                return "var _\($0.trimmedName): \($0.computedInternalTypeName) = nil"
            } else {
                return "var _\($0.trimmedName): \($0.computedInternalTypeName)"
            }
        }
    }

    public var extensionConstrainedWhereConditionalContent: String {
        map { "\($0.trimmedName.capitalizingFirst()) == \(($0.isOptional || $0.annotations.keys.contains("internalDataType")) ? "_ConditionalContent<\($0.swiftUITypeName), EmptyView>" : $0.swiftUITypeName)" }.joined(separator: ",\n\t\t")
    }

    public var extensionModelInitParams: [String] {
        map { "\($0.trimmedName): \($0.computedInternalTypeName)\($0.emptyDefault)" }
    }

    public var extensionModelInitParamsChaining: [String] {
        map {
            if $0.annotations.keys.contains("internalDataType") == true {
                return "\($0.trimmedName): \($0.annotations["internalDataType"] as! String)(get: { model.\($0.name) }, set: { model.\($0.name) = $0 })"
            } else {
                return "\($0.trimmedName): model.\($0.name)"
            }
        }
    }
```

Variable+Extensions.swift

```swift
    var computedInternalTypeName: String {
        return annotations["internalDataType"] as? String ?? self.typeName.name
    }
```

Type+Extensions.swift

```swift
    var isObservableObjectConform: Bool {

        let context = ProcessInfo().context!
        let contextType = context.type


        if inheritedTypes.contains("ObservableObject") {
            return true
        } else if inheritedTypes.count > 0 {
            let inheritedTypeDefs = inheritedTypes.compactMap { contextType[$0] }.compactMap { $0 }
            let results = inheritedTypeDefs.map { aType in
                aType.isObservableObjectConform
            }
            if results.contains(true) {
                return true
            } else {
                return false
            }
        } else {
            return false
        }
    }
```
