### PR TITLE
refactor: 💡 remove redundant uiimage vars in DrawingPad

### DIFF
--- a/Sources/FioriSwiftUICore/SignatureView/DrawingPad.swift
+++ b/Sources/FioriSwiftUICore/SignatureView/DrawingPad.swift
@@ -36,8 +36,6 @@ struct DrawingPad: View {
     @Binding var currentDrawing: Drawing
     @Binding var drawings: [Drawing]
     @Binding var isSave: Bool
-    @Binding var uiImage: UIImage?
-    @Binding var savedSignatureImage: UIImage?
     @Binding var drawingPadSize: CGSize
 
     var onSave: ((SignatureCaptureView.Result) -> Void)?
@@ -76,7 +74,7 @@ struct DrawingPad: View {
                     }
             )
         }
-        if self.isSave && uiImage == nil {
+        if self.isSave {
             let path = createUIBezierPath(drawings: drawings, lineWidth: self.lineWidth)
             guard let originalImage = createImage(path, size: self.drawingPadSize, origin: nil) else {
                 return v
@@ -91,11 +89,7 @@ struct DrawingPad: View {
             }
 
             let image = Image(uiImage: signature)
-            DispatchQueue.main.async {
-                self.uiImage = originalImage
-                self.savedSignatureImage = originalImage
-            }
-            self.onSave?(SignatureCaptureView.Result(image: image, uiImage: signature))
+            self.onSave?(SignatureCaptureView.Result(image: image, uiImage: signature, originalUIImage: originalImage))
         }
         return v
     }

--- a/Sources/FioriSwiftUICore/SignatureView/SignatureCaptureView.swift
+++ b/Sources/FioriSwiftUICore/SignatureView/SignatureCaptureView.swift
@@ -110,8 +110,6 @@ public struct SignatureCaptureView: View {
                                 DrawingPad(currentDrawing: self.$currentDrawing,
                                            drawings: self.$drawings,
                                            isSave: self.$isSaved,
-                                           uiImage: self.$uiImage,
-                                           savedSignatureImage: self.$savedSignatureImage,
                                            drawingPadSize: self.$drawingPadSize,
                                            onSave: self.onSave,
                                            strokeColor: self.strokeColor,
@@ -287,8 +285,12 @@ public extension SignatureCaptureView {
     struct Result {
         /// Signature Image
         public let image: Image
+
         /// SIgnature UIImage
         public let uiImage: UIImage
+
+        // This is the original not-cropped signature image to be displayed after the image is saved
+        internal let originalUIImage: UIImage
     }
 }
 

--- a/Sources/FioriSwiftUICore/SignatureView/SignatureView.swift
+++ b/Sources/FioriSwiftUICore/SignatureView/SignatureView.swift
@@ -65,7 +65,7 @@ struct SignatureView: View {
                         let imageSaver = ImageSaver()
                         guard let uimage = UIApplication.shared.windows[0].rootViewController?.view.asImage(rect: self.rect1) else { return }
                         imageSaver.writeToPhotoAlbum(image: uimage)
-                        self.onSave?(SignatureCaptureView.Result(image: Image(uiImage: uimage), uiImage: uimage))
+                        self.onSave?(SignatureCaptureView.Result(image: Image(uiImage: uimage), uiImage: uimage, originalUIImage: uimage))
                         self.drawings.removeAll()
                     }) {
                         Text("Done")
@@ -75,8 +75,6 @@ struct SignatureView: View {
                 DrawingPad(currentDrawing: self.$currentDrawing,
                            drawings: self.$drawings,
                            isSave: self.$isSaved,
-                           uiImage: self.$uiImage,
-                           savedSignatureImage: self.$savedSignatureImage,
                            drawingPadSize: self.$drawingPadSize,
                            onSave: self.onSave,
                            strokeColor: self.imageStrokeColor,

--- a/Tests/FioriSwiftUITests/FioriSwiftUICore/SignatureCaptureViewTests.swift
+++ b/Tests/FioriSwiftUITests/FioriSwiftUICore/SignatureCaptureViewTests.swift
@@ -34,7 +34,7 @@ class SignatureCaptureTests: XCTestCase {
         self.isOnSaveCalled = false
         let uiImage = UIImage(systemName: "xmark")!
         let image = Image(uiImage: uiImage)
-        let result = SignatureCaptureView.Result(image: image, uiImage: uiImage)
+        let result = SignatureCaptureView.Result(image: image, uiImage: uiImage, originalUIImage: uiImage)
 
         self.isOnSaveCalled = false
         signagureCaptureView.onSave?(result)


### PR DESCRIPTION
Remove 2 binding vars not needed in DrawingPad