### PR TITLE
chore: 🤖 1.0.0 release

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -1,5 +1,6 @@
-module: cloud-sdk-ios-fiori
+module: FioriSwiftUI
 author: SAP SE
 author_url: https://www.sap.com
 theme: jony
-copyright: '© 2020 [https://github.com/SAP/cloud-sdk-ios-fiori](https://github.com/SAP/cloud-sdk-ios-fiori) under Apache-2.0.'
+copyright: '© 2020 - 2021 [https://github.com/SAP/cloud-sdk-ios-fiori](https://github.com/SAP/cloud-sdk-ios-fiori) under Apache-2.0.'
+hide_documentation_coverage: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.0.0](https://github.com/SAP/cloud-sdk-ios-fiori/compare/0.9.0...1.0.0) (2021-06-18)
+
+🎸 Introducing `FioriThemeManager`: This module provides a [color palette](https://experience.sap.com/fiori-design-ios/article/colors/) conforming to [Fiori Design Language](https://experience.sap.com/fiori-design-ios/). It is adopted by all the Fiori components in both this package and SAPFiori.
+
+🎸 Introducing  `FioriSwiftUICore`: This module contains SwiftUI implementation for those UIKit-based components existing in [SAPFiori](https://help.sap.com/doc/978e4f6c968c4cc5a30f9d324aa4b1d7/Latest/en-US/Documents/Frameworks/SAPFiori/index.html). It provides you with an easy way to migrate your UIKit project to SwiftUI while delivering the same experience as before.
+
+We plan to progressively bring more Fiori UI components into this module in the future releases.
+
+| FioriSwiftUICore | Available |
+| - | - |
+| ObjectItem | :white_check_mark: | 
+| ObjectHeader | :white_check_mark: | 
+| KPIItem | :white_check_mark: | 
+| FioriButton | :white_check_mark: |
+| ListPickerItem | :white_check_mark: |
+| DimensionSelector | :white_check_mark: |
+| SideBar | :white_check_mark: |
+| DataTable | :white_check_mark: |
+| WelcomeScreen | :white_check_mark: |
+| ActivationScreen | :white_check_mark: |
+| InfoView | :white_check_mark: |
+
+### Other Features
+
+* 🎸 integration cards: support ContentType.List.maxItems & GET parameters ([b9a1fe1](https://github.com/SAP/cloud-sdk-ios-fiori/commit/b9a1fe158a8eb71548d2cd98b8cce58255fd44f0))
+* 🎸 integration cards: support list with icons ([#179](https://github.com/SAP/cloud-sdk-ios-fiori/issues/179)) ([9b6756b](https://github.com/SAP/cloud-sdk-ios-fiori/commit/9b6756bc1f9761bfe9d4cb8f4adf24954c526a11))
+* 🎸 integration cards: support list with numeric header ([#180](https://github.com/SAP/cloud-sdk-ios-fiori/issues/180)) ([7d7c82c](https://github.com/SAP/cloud-sdk-ios-fiori/commit/7d7c82c8e0fca6fc27e596673c76b60ec30a029c))
+* 🎸 integration cards: support owner/ownerImage in timeline ([1deca96](https://github.com/SAP/cloud-sdk-ios-fiori/commit/1deca96252606b01d6eeaf1ad46af4be230daea7))
+* 🎸 support manifest parameters for integration cards ([c615a29](https://github.com/SAP/cloud-sdk-ios-fiori/commit/c615a29c65e17c51f9c07d13124d98668a8a95e2))
+
+
+### Bug Fixes
+
+* 🐛 eliminate dependency on TinyNetworking package ([926625e](https://github.com/SAP/cloud-sdk-ios-fiori/commit/926625e6271c58b35ed8cb0dc861c595a13cfe89))
+
 ## [0.9.0](https://github.com/SAP/cloud-sdk-ios-fiori/compare/0.5.6...0.9.0) (2020-11-10)
 
 

--- a/jazzy/Overview_README.md
+++ b/jazzy/Overview_README.md
@@ -1,14 +1,15 @@
-# Welcome to the API documentation of cloud-sdk-ios-fiori
+# Welcome to the API documentation of FioriSwiftUI
 
-![](https://github.com/SAP/cloud-sdk-ios-fiori/workflows/CI/badge.svg)
-![](https://github.com/SAP/cloud-sdk-ios-fiori/workflows/SwiftLint/badge.svg)
+This project is the SwiftUI implementation of the [SAP Fiori for iOS Design Language](https://experience.sap.com/fiori-design-ios/), and is meant to augment and in some cases replace the UIKit-based implementation contained in the SAPFiori framework of the [SAP BTP SDK for iOS](https://developers.sap.com/topics/sap-btp-sdk-for-ios.html).
 
-![](https://github.com/SAP/cloud-sdk-ios-fiori/blob/images/Resources/Images/Team.png?raw=true)
+<p align="center">
+<img src="https://user-images.githubusercontent.com/4176826/85931303-3ac81980-b878-11ea-8e7f-9b10ed380f2d.gif" alt="alt text" width="300" height="500" align="center">
+</p>
 
-This project is the SwiftUI implementation of the SAP Fiori for iOS Design Language, and is meant to augment and in some cases replace the UIKit-based implementation contained in the **SAPFiori** framework of the [SAP Cloud Platform SDK for iOS](https://developers.sap.com/topics/cloud-platform-sdk-for-ios.html).
+This project currently contains four modules: `FioriThemeManager`, `FioriSwiftUICore`, `FioriCharts`, and `FioriIntegrationCards`.
 
-This project currently contains two modules: **FioriCharts** and **FioriIntegrationCards**.
-
+- FioriThemeManager (*API documentation coming soon*)
+- FioriSwiftUICore (*API documentation coming soon*)
 - [FioriCharts](./charts/index.html)
 - [FioriIntegrationCards](./integrationCards/index.html)
 


### PR DESCRIPTION
After merging this commit we should tag commit with 1.0.0 and create a respective 1.0.0 release

No API documentation for `FioriSwiftUICore` and `FioriThemeManager` yet as too many symbols are not yet properly documented 