### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,11 +56,11 @@ jobs:
       run: |
         nextVersion=`npx standard-version --tag-prefix '' --dry-run | sed -n '/^---$/,/^---$/p' | grep -P -o '(\d+\.)(\d+\.)(\d)' | head -n 1`
         echo "$nextVersion"
-        echo "::set-env name=NEXT_VERSION::$nextVersion"
+        echo "NEXT_VERSION=$nextVersion" >> $GITHUB_ENV
     - name: Manually next version number
       if: github.event.inputs.releaseVersion != null
       run: |
-        echo "::set-env name=NEXT_VERSION::${{ github.event.inputs.releaseVersion }}"
+        echo "NEXT_VERSION=${{ github.event.inputs.releaseVersion }}" >> $GITHUB_ENV
         echo "${{ env.NEXT_VERSION }}"
 
     - name: bump version - DRY RUN


### PR DESCRIPTION
Fix needed due to change by GitHub

> The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

Using new environment variable (see https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable)