### PR TITLE
fix: 🐛 Xcode 13 compilation error in TimelineItemView

### DIFF
--- a/Sources/FioriIntegrationCards/Components/Timeline/UI/TimelineItemView.swift
+++ b/Sources/FioriIntegrationCards/Components/Timeline/UI/TimelineItemView.swift
@@ -50,7 +50,7 @@ struct TimelineItemView: View {
             .frame(maxWidth: .greatestFiniteMagnitude, alignment: .leading)
             .padding(8)
             .overlay(Bubble(borderColor: Color.lightGray))
-            .alignmentGuide(.center) { (dimension) -> CGFloat in
+            .alignmentGuide(VerticalAlignment.center) { (dimension) -> CGFloat in
                 DispatchQueue.main.async {
                     self.lineHeight = dimension.height
                 }


### PR DESCRIPTION
fixes compilation error when using Xcode 13 due to 'ambiguous use of
.center'
