### PR TITLE
fix: 🐛 support chart for iOS Widget

### DIFF
--- a/Sources/FioriCharts/Charts/Common/GridLinesAndChartView.swift
+++ b/Sources/FioriCharts/Charts/Common/GridLinesAndChartView.swift
@@ -135,37 +135,39 @@ struct GridLinesAndChartView<Content: View, Indicator: View>: View {
             
             indicatorView
             
-            Background(tappedCallback: { point, chartRect, _ in
-                if !self.model.selectionEnabled {
-                    return
-                }
-                
-                let item = self.chartContext.closestSelectedPlotItem(self.model, atPoint: point, rect: chartRect, layoutDirection: self.layoutDirection)
-                ChartUtility.updateSelections(self.model, selectedPlotItems: [item], isTap: true)
-            }, doubleTappedCallback: { _, _, _ in
-                if !self.model.selectionEnabled {
-                    return
-                }
-                
-                // clear selections
-                if self.model.selections != nil {
-                    self.model.selections = nil
-                }
-            }) { points, chartRect, state in
-                if !self.model.selectionEnabled {
-                    return
-                }
-                
-                if self.model.selectionMode == .single || self.model.numOfSeries() == 1 || self.model.chartType == .stock, state == UIGestureRecognizer.State.began.rawValue {
-                    let items = self.chartContext.closestSelectedPlotItems(self.model, atPoints: [points.0, points.1],
-                                                                           rect: chartRect,
-                                                                           layoutDirection: self.layoutDirection)
+            if self.model.userInteractionEnabled {
+                Background(tappedCallback: { point, chartRect, _ in
+                    if !self.model.selectionEnabled {
+                        return
+                    }
                     
-                    ChartUtility.updateSelections(self.model, selectedPlotItems: items, isTap: false)
+                    let item = self.chartContext.closestSelectedPlotItem(self.model, atPoint: point, rect: chartRect, layoutDirection: self.layoutDirection)
+                    ChartUtility.updateSelections(self.model, selectedPlotItems: [item], isTap: true)
+                }, doubleTappedCallback: { _, _, _ in
+                    if !self.model.selectionEnabled {
+                        return
+                    }
+                    
+                    // clear selections
+                    if self.model.selections != nil {
+                        self.model.selections = nil
+                    }
+                }) { points, chartRect, state in
+                    if !self.model.selectionEnabled {
+                        return
+                    }
+                    
+                    if self.model.selectionMode == .single || self.model.numOfSeries() == 1 || self.model.chartType == .stock, state == UIGestureRecognizer.State.began.rawValue {
+                        let items = self.chartContext.closestSelectedPlotItems(self.model, atPoints: [points.0, points.1],
+                                                                               rect: chartRect,
+                                                                               layoutDirection: self.layoutDirection)
+                        
+                        ChartUtility.updateSelections(self.model, selectedPlotItems: items, isTap: false)
+                    }
                 }
+                .gesture(drag)
+                .gesture(mag)
             }
-            .gesture(drag)
-            .gesture(mag)
         }.disabled(!self.model.userInteractionEnabled)
     }
     

--- a/Sources/FioriCharts/Charts/Common/XYAxisChart.swift
+++ b/Sources/FioriCharts/Charts/Common/XYAxisChart.swift
@@ -81,7 +81,7 @@ struct XYAxisChart<Content: View, Indicator: View>: View {
                     }
                     
                     Spacer(minLength: 0)
-                }.frame(width: yAxisRect.size.width, height: rect.size.height - insets.top - insets.bottom)
+                }.frame(width: yAxisRect.size.width, height: max(0, rect.size.height - insets.top - insets.bottom))
                 
                 // plot view
                 VStack(alignment: .leading, spacing: 0) {
@@ -127,7 +127,7 @@ struct XYAxisChart<Content: View, Indicator: View>: View {
                     }
                     
                     Spacer(minLength: 0)
-                }.frame(width: secondaryYAxisRect.size.width, height: rect.size.height - insets.top - insets.bottom)
+                }.frame(width: secondaryYAxisRect.size.width, height: max(0, rect.size.height - insets.top - insets.bottom))
                 
                 Spacer().frame(width: insets.trailing)
             }

--- a/Sources/FioriCharts/Model/ChartModel.swift
+++ b/Sources/FioriCharts/Model/ChartModel.swift
@@ -203,6 +203,7 @@ public class ChartModel: ObservableObject, Identifiable, NSCopying {
     public var numericAxisLabelFormatHandler: NumericAxisLabelFormatHandler?
     
     /// enable or disable user interaction
+    /// Do not set this property to true if the chart is used as an iOS Widget. Otherwise it will be an empty view
     @Published public var userInteractionEnabled: Bool = false
     
     /// snap to point when dragging a chart


### PR DESCRIPTION
the root cause is iOS Widget view has to be pure swiftui view. but the chart uses a few ui gesture recognizers from UIKit since gestures from swiftui are not powerful enough. Because iOS Widget doesn’t need to support user interaction so it is fine to turn off those part of code.