### PR TITLE
fix: 🐛 compilation error for MacCatalyst due to Zip package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/Flight-School/AnyCodable.git", from: "0.2.3"),
         .package(name: "ObservableArray", url: "https://github.com/sstadelman/observable-array.git", from: "1.2.0"),
-        .package(url: "https://github.com/marmelroy/Zip.git", from: "2.0.0")
+        .package(url: "https://github.com/maparoni/Zip.git", .revisionItem("059e7346082d02de16220cd79df7db18ddeba8c3"))
     ],
     targets: [
         .target(


### PR DESCRIPTION
After merging let's create release 1.0.3 on `rel-1.0` branch and cherry-pick change to `main` branch.

BCP/SNOW: 708765/2021