### PR TITLE
fix: 🐛 stroke not smooth problem and 2 new APIs

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/SignatureView/SignatureCaptureViewExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/SignatureView/SignatureCaptureViewExample.swift
@@ -36,6 +36,8 @@ struct SignatureCaptureViewExample2: View {
             .drawingViewBackgroundColor(.yellow)
             .xmarkColor(.green)
             .signatureLineColor(.orange)
+            .hidesXmark(false)
+            .hidesSignatureLine(true)
             ._drawingViewMaxHeight(300)
             .restartActionModifier {
                 $0.font(.callout).foregroundColor(.red)

--- a/Sources/FioriSwiftUICore/SignatureView/ScribbleView.swift
+++ b/Sources/FioriSwiftUICore/SignatureView/ScribbleView.swift
@@ -27,7 +27,8 @@ public struct ScribbleView: View {
                 }
                 self.add(drawing: self.currentDrawing, toPath: &path)
             }
-            .stroke(self.strokeColor, lineWidth: self.strokeWidth)
+            .stroke(style: StrokeStyle(lineWidth: self.strokeWidth, lineCap: .round, lineJoin: .round))
+            .foregroundColor(self.strokeColor)
             .background(self.drawingViewBackgroundColor.cornerRadius(10))
             .gesture(
                 DragGesture(minimumDistance: 0.1)

--- a/Sources/FioriSwiftUICore/SignatureView/SignatureCaptureView+API.generated.swift
+++ b/Sources/FioriSwiftUICore/SignatureView/SignatureCaptureView+API.generated.swift
@@ -19,23 +19,25 @@ public struct SignatureCaptureView<StartActionView: View, RestartActionView: Vie
     let _signatureImage: UIImage?
     let _onSave: ((UIImage) -> Void)?
     let _onDelete: (() -> Void)?
-    var cropsImage = false
-    @State var fullSignatureImage: UIImage?
-    var titleColor = Color.preferredColor(.primaryLabel)
-    public private(set) var _heightDidChangePublisher = CurrentValueSubject<CGFloat, Never>(0)
-    var titleFont = Font.subheadline.weight(Font.Weight.semibold)
-    @State var isEditing = false
-    var strokeColor = Color.preferredColor(.primaryLabel)
-    var xmarkColor = Color.preferredColor(.quarternaryLabel)
     var signatureLineColor = Color.preferredColor(.quarternaryLabel)
-    var strokeWidth: CGFloat = 3.0
-    @State var drawings = [Drawing]()
-    @State var isReenterTapped = false
-    var _drawingViewMaxHeight: CGFloat?
-    @State var isSaved = false
-    let _drawingViewMinHeight: CGFloat = 256
+    public private(set) var _heightDidChangePublisher = CurrentValueSubject<CGFloat, Never>(0)
     var drawingViewBackgroundColor = Color.preferredColor(.primaryBackground)
+    var xmarkColor = Color.preferredColor(.quarternaryLabel)
+    var hidesXmark = false
+    @State var isEditing = false
+    let _drawingViewMinHeight: CGFloat = 256
+    var _drawingViewMaxHeight: CGFloat?
+    @State var fullSignatureImage: UIImage?
+    var cropsImage = false
+    @State var isSaved = false
+    var hidesSignatureLine = false
     @State var currentDrawing = Drawing()
+    var strokeColor = Color.preferredColor(.primaryLabel)
+    var titleColor = Color.preferredColor(.primaryLabel)
+    var strokeWidth: CGFloat = 3.0
+    @State var isReenterTapped = false
+    var titleFont = Font.subheadline.weight(Font.Weight.semibold)
+    @State var drawings = [Drawing]()
 
     private var isModelInit: Bool = false
     private var isTitleNil: Bool = false
@@ -109,7 +111,7 @@ public struct SignatureCaptureView<StartActionView: View, RestartActionView: Vie
             _saveAction.modifier(saveActionModifier.concat(Fiori.SignatureCaptureView.saveAction))
         }
     }
-    
+
     var isStartActionEmptyView: Bool {
         ((self.isModelInit && self.isStartActionNil) || StartActionView.self == EmptyView.self) ? true : false
     }

--- a/Sources/FioriSwiftUICore/SignatureView/SignatureHelper.swift
+++ b/Sources/FioriSwiftUICore/SignatureView/SignatureHelper.swift
@@ -22,6 +22,8 @@ extension UIView {
 func createUIBezierPath(drawings: [Drawing], lineWidth: CGFloat) -> UIBezierPath {
     let bezierPath = UIBezierPath()
     bezierPath.lineWidth = lineWidth
+    bezierPath.lineJoinStyle = .round
+    bezierPath.lineCapStyle = .round
     for dr in drawings {
         for (index, point) in dr.points.enumerated() {
             if index == 0 {

--- a/Sources/FioriSwiftUICore/Views/SignatureCaptureView+View.swift
+++ b/Sources/FioriSwiftUICore/Views/SignatureCaptureView+View.swift
@@ -172,9 +172,11 @@ extension SignatureCaptureView: View {
                     Image(systemName: "xmark")
                         .foregroundColor(xmarkColor)
                         .font(.body)
+                        .setHidden(self.hidesXmark)
                     Rectangle()
                         .foregroundColor(signatureLineColor)
                         .frame(height: 1)
+                        .setHidden(self.hidesSignatureLine)
                 }
                 .padding([.leading, .trailing]).padding(.bottom, 30)
             }
@@ -197,9 +199,11 @@ extension SignatureCaptureView: View {
                     Image(systemName: "xmark")
                         .foregroundColor(xmarkColor.opacity(0.4))
                         .font(.body)
+                        .setHidden(self.hidesXmark)
                     Rectangle()
                         .foregroundColor(signatureLineColor.opacity(0.4))
                         .frame(height: 1)
+                        .setHidden(self.hidesSignatureLine)
                 }
                 .padding([.leading, .trailing]).padding(.bottom, 30)
             }
@@ -348,6 +352,28 @@ public extension SignatureCaptureView {
         newSelf.signatureLineColor = color
         return newSelf
     }
+
+    /**
+     A view modify to indicate to hide XMark or not.
+
+     - parameter hidesXmark: Set this to true to hide the X Mark.
+     */
+    func hidesXmark(_ hidesXmark: Bool) -> Self {
+        var newSelf = self
+        newSelf.hidesXmark = hidesXmark
+        return newSelf
+    }
+
+    /**
+     A view modify to indicate to hide XMark or not.
+
+     - parameter hidesSignatureLine: Set this to true to hide the signature line.
+     */
+    func hidesSignatureLine(_ hidesSignatureLine: Bool) -> Self {
+        var newSelf = self
+        newSelf.hidesSignatureLine = hidesSignatureLine
+        return newSelf
+    }
 }
 
 private struct VStackPreferenceKey: PreferenceKey {
@@ -364,6 +390,16 @@ private struct VStackPreferenceSetter: View {
                 .fill(Color.clear)
                 .preference(key: VStackPreferenceKey.self,
                             value: [geometry.size.height])
+        }
+    }
+}
+
+extension View {
+    @ViewBuilder func setHidden(_ isHidden: Bool) -> some View {
+        if isHidden {
+            self.hidden()
+        } else {
+            self
         }
     }
 }


### PR DESCRIPTION
Fix stroke not smooth problem when stroke width is large and 2 new APIs
to hide X mark and signature line

Cherry-picked from main