### PR TITLE
fix: 🐛 use FioriSwiftUI package with version-based requirement

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -21,11 +21,11 @@
       },
       {
         "package": "Zip",
-        "repositoryURL": "https://github.com/maparoni/Zip.git",
+        "repositoryURL": "https://github.com/MarcoEidinger/Zip.git",
         "state": {
           "branch": null,
           "revision": "059e7346082d02de16220cd79df7db18ddeba8c3",
-          "version": null
+          "version": "2.1.2"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/Flight-School/AnyCodable.git", from: "0.2.3"),
         .package(name: "ObservableArray", url: "https://github.com/sstadelman/observable-array.git", from: "1.2.0"),
-        .package(url: "https://github.com/maparoni/Zip.git", .revision("059e7346082d02de16220cd79df7db18ddeba8c3"))
+        .package(url: "https://github.com/MarcoEidinger/Zip.git", .upToNextMinor(from: "2.1.2"))
     ],
     targets: [
         .target(


### PR DESCRIPTION
It was not possible to specify dependency for `FioriSwiftUI` package
with `upToNextMajor(from:)` or `upToNextMinor(from:)` due to the use of
commit-based requirement for Zip dependency. Switching to a stable fork
in Package.swift will fix that.