### PR TITLE
fix: 🐛 [BCP: 2280078347] Fix color for high constrast, elevated

### DIFF
--- a/Sources/FioriThemeManager/Colors/HexColor.swift
+++ b/Sources/FioriThemeManager/Colors/HexColor.swift
@@ -59,7 +59,6 @@ public struct HexColor: Hashable {
         
         if let color = elevatedContrastLightColor {
             self.colors.updateValue(color, forKey: .elevatedContrastLight)
-            self.colors.updateValue(color, forKey: .elevatedContrastDark)
         }
         
         if let color = elevatedContrastDarkColor {

--- a/Sources/FioriThemeManager/Colors/HexColor.swift
+++ b/Sources/FioriThemeManager/Colors/HexColor.swift
@@ -50,7 +50,6 @@ public struct HexColor: Hashable {
         
         if let color = contrastLightColor {
             self.colors.updateValue(color, forKey: .contrastLight)
-            self.colors.updateValue(color, forKey: .contrastDark)
         }
         
         if let color = contrastDarkColor {


### PR DESCRIPTION
I spoke with Flash over the color issue. Apparently the elevated trait is a [dark mode concept from a design perspective](https://developer.apple.com/design/human-interface-guidelines/ios/visual-design/dark-mode). Which is why there isn’t a light mode color for it. **However it seems as though the system can have scenarios where dark mode is false and elevated is true.** Such as when a modal is presented in light mode.

If the color does not have a value for the variant it defaults to different values.

How we currently handle that is all the color variants are given the value of `darkColor` which is used for Light Mode seen [here](https://github.com/SAP/cloud-sdk-ios-fiori/blob/801ce943d29c0265c023d5320e3755dfa3b877d9/Sources/FioriThemeManager/Colors/HexColor.swift#L34).

As you can see [here](https://github.com/SAP/cloud-sdk-ios-fiori/blob/801ce943d29c0265c023d5320e3755dfa3b877d9/Sources/FioriThemeManager/Palettes/PaletteV6.swift#L97). `.secondaryGroupedBackground` does not have an `elevated Light Mode Color` and does not fall into [this if let](https://github.com/SAP/cloud-sdk-ios-fiori/blob/801ce943d29c0265c023d5320e3755dfa3b877d9/Sources/FioriThemeManager/Colors/HexColor.swift#L46), so it defaults to the standard `darkColor` or again the standard variant used for Light Mode.

An assumption is the same thing should happen for high contrast while in light mode. However it seems to be mistakenly set [here](https://github.com/SAP/cloud-sdk-ios-fiori/blob/801ce943d29c0265c023d5320e3755dfa3b877d9/Sources/FioriThemeManager/Colors/HexColor.swift#L62) as the `elevatedContrastLightColor` which is the color used for high contrast in dark mode. Instead of falling back on the standard default white color. Which results in the effect below. Removing this line is a potential fix.

<img width="250" alt="contrastIssue" src="https://user-images.githubusercontent.com/77754056/156276136-05805df5-bd32-4b3f-8c9e-8d49ab220e3a.png">