### PR TITLE
API Reference: ensure building and add FioriThemeManager

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -2,5 +2,4 @@ module: FioriSwiftUI
 author: SAP SE
 author_url: https://www.sap.com
 theme: jony
-copyright: '© 2020 - 2021 [https://github.com/SAP/cloud-sdk-ios-fiori](https://github.com/SAP/cloud-sdk-ios-fiori) under Apache-2.0.'
 hide_documentation_coverage: true

--- a/jazzy/FioriThemeManager_README.md
+++ b/jazzy/FioriThemeManager_README.md
@@ -1,0 +1,9 @@
+# FioriThemeManager
+
+This module provides a [color palette](https://experience.sap.com/fiori-design-ios/article/colors/) and a new font family [SAP 72](https://experience.sap.com/72/) that conform to [Fiori Design Language](https://experience.sap.com/fiori-design-ios/). It is adopted by all the Fiori components in both this package and SAPFiori.
+
+All Fiori Colors are dynamic colors, which means they will adjust based on iOS Appearance settings (Light/Dark). Accessing Fiori Color using `Color.preferredFioriColor(forStyle:)`.
+
+72 is a SAP patent typeface that delivers great reading experience to our users. You can get these fonts using `Font.fiori(forTextStyle:)` or `Font.fioriCondensed(forTextStyle:)`. Note that these fonts support Dynamic Type out of the box. If you want the fonts with fixed size, use `Font.fiori(fixedSize:)` or `Font.fioriCondensed(fixedSize:)` instead.
+
+> Custom fonts need to be loaded and registered during App's runtime. Make sure you call `Font.registerFioriFonts()` inside `application(_:didFinishLaunchingWithOptions:)` of your `AppDelegate`.

--- a/jazzy/Overview_README.md
+++ b/jazzy/Overview_README.md
@@ -8,7 +8,7 @@ This project is the SwiftUI implementation of the [SAP Fiori for iOS Design Lang
 
 This project currently contains four modules: `FioriThemeManager`, `FioriSwiftUICore`, `FioriCharts`, and `FioriIntegrationCards`.
 
-- FioriThemeManager (*API documentation coming soon*)
+- [FioriThemeManager](./themeManager/index.html)
 - FioriSwiftUICore (*API documentation coming soon*)
 - [FioriCharts](./charts/index.html)
 - [FioriIntegrationCards](./integrationCards/index.html)

--- a/scripts/generateDocumentation.sh
+++ b/scripts/generateDocumentation.sh
@@ -1,8 +1,8 @@
 # generate overview page
 jazzy --sourcekitten-sourcefile ./jazzy/empty.json --clean --readme=./jazzy/Overview_README.md --disable-search --hide-documentation-coverage
 # generate FioriCharts documentation
-sourcekitten doc --module-name FioriCharts -- -scheme FioriSwiftUI-Package -sdk iphonesimulator > charts.json
+sourcekitten doc --module-name FioriCharts -- -scheme FioriSwiftUI-Package -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 13' > charts.json
 jazzy --sourcekitten-sourcefile charts.json --output docs/charts --readme=./jazzy/FioriCharts_README.md --module "FioriCharts"
 # generate FioriIntegrationCards documentation
-sourcekitten doc --module-name FioriIntegrationCards -- -scheme FioriSwiftUI-Package -sdk iphonesimulator > integrationCards.json
+sourcekitten doc --module-name FioriIntegrationCards -- -scheme FioriSwiftUI-Package -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 13' > integrationCards.json
 jazzy --sourcekitten-sourcefile integrationCards.json --output docs/integrationCards --readme=./jazzy/FioriIntegrationCards_README.md --module "FioriIntegrationCards"

--- a/scripts/generateDocumentation.sh
+++ b/scripts/generateDocumentation.sh
@@ -1,5 +1,8 @@
 # generate overview page
 jazzy --sourcekitten-sourcefile ./jazzy/empty.json --clean --readme=./jazzy/Overview_README.md --disable-search --hide-documentation-coverage
+# generate FioriThemeManager documentation
+sourcekitten doc --module-name FioriThemeManager -- -scheme FioriSwiftUI-Package -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 13' > theme.json
+jazzy --sourcekitten-sourcefile theme.json --output docs/themeManager --readme=./jazzy/FioriThemeManager_README.md --module "FioriThemeManager"
 # generate FioriCharts documentation
 sourcekitten doc --module-name FioriCharts -- -scheme FioriSwiftUI-Package -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 13' > charts.json
 jazzy --sourcekitten-sourcefile charts.json --output docs/charts --readme=./jazzy/FioriCharts_README.md --module "FioriCharts"


### PR DESCRIPTION
API Documentation was not build to due ambiguous destination.

```
--- xcodebuild: WARNING: Using the first of multiple matching destinations:
{ platform:iOS Simulator, id:dvtdevice-DVTiOSDeviceSimulatorPlaceholder-iphonesimulator:placeholder, name:Any iOS Simulator Device }
{ platform:iOS Simulator, id:0[9](https://github.com/SAP/cloud-sdk-ios-fiori/runs/4513325548?check_suite_focus=true#step:4:9)4DB82D-7F2E-4111-89F3-D963B3A066C8, OS:15.0, name:iPad (7th generation) }
{ platform:iOS Simulator, id:EBD0871A-A099-47CC-905E-A9CFA7BA6D7D, OS:15.0, name:iPad (8th generation) }
{ platform:iOS Simulator, id:28003E16-EB1E-440C-B9FD-7044F17DFD95, OS:15.0, name:iPad (9th generation) }
{ platform:iOS Simulator, id:A45049DA-374D-4300-9124-70A603CFEF0C, OS:15.0, name:iPad Air (3rd generation) }
{ platform:iOS Simulator, id:E8F42ED6-2418-4DE3-A787-EFA0FC655D62, OS:15.0, name:iPad Air (4th generation) }
{ platform:iOS Simulator, id:51B2EEFA-04BC-4959-A238-CF6815548F43, OS:15.0, name:iPad Pro (9.7-inch) }
{ platform:iOS Simulator, id:9B5A34AB-E3E1-44E1-836F-E296C382DF8F, OS:15.0, name:iPad Pro (11-inch) (2nd generation) }
{ platform:iOS Simulator, id:3571D262-19BE-43F7-B6F2-16262A696208, OS:15.0, name:iPad Pro (11-inch) (3rd generation) }
{ platform:iOS Simulator, id:4C5B7E77-0970-4972-803A-EBD78D5DA8F4, OS:15.0, name:iPad Pro (12.9-inch) (4th generation) }
{ platform:iOS Simulator, id:8C040D68-7A87-4591-B36A-1BBE05361B79, OS:15.0, name:iPad Pro (12.9-inch) (5th generation) }
{ platform:iOS Simulator, id:D4451DE2-0977-47C9-807E-A7C365C60DC4, OS:15.0, name:iPad mini (6th generation) }
{ platform:iOS Simulator, id:81886699-C64E-4FEF-A9C1-C699BE13AA63, OS:15.0, name:iPhone 8 }
{ platform:iOS Simulator, id:307FE34E-C3A7-4B79-8126-A1B0F13A6B7F, OS:15.0, name:iPhone 8 Plus }
{ platform:iOS Simulator, id:0CE3FD66-16FF-49[10](https://github.com/SAP/cloud-sdk-ios-fiori/runs/4513325548?check_suite_focus=true#step:4:10)-BC80-0719C0C51E28, OS:15.0, name:iPhone [11](https://github.com/SAP/cloud-sdk-ios-fiori/runs/4513325548?check_suite_focus=true#step:4:11) }
{ platform:iOS Simulator, id:5077E463-C56F-4E88-87A1-13E2E745A9[12](https://github.com/SAP/cloud-sdk-ios-fiori/runs/4513325548?check_suite_focus=true#step:4:12), OS:15.0, name:iPhone 11 Pro }
{ platform:iOS Simulator, id:85243055-BD4C-4DF3-8275-5ED82C794A34, OS:15.0, name:iPhone 11 Pro Max }
{ platform:iOS Simulator, id:DB495AF7-1A47-4D58-A30F-D15E2FB00FB5, OS:15.0, name:iPhone 12 }
{ platform:iOS Simulator, id:94D0263D-48F5-4D1B-840A-D4A963844315, OS:15.0, name:iPhone 12 Pro }
{ platform:iOS Simulator, id:C73E4F73-EB62-48E4-B006-89F2A5007840, OS:15.0, name:iPhone 12 Pro Max }
{ platform:iOS Simulator, id:39564828-B421-4FC6-BA80-E4763B642EA6, OS:15.0, name:iPhone 12 mini }
{ platform:iOS Simulator, id:CE31BAFD-A2D5-4995-9732-0B9B105BDF09, OS:15.0, name:iPhone [13](https://github.com/SAP/cloud-sdk-ios-fiori/runs/4513325548?check_suite_focus=true#step:4:13) }
{ platform:iOS Simulator, id:35AE3EB5-E27D-44B9-8C5F-D3E966B3CBE2, OS:15.0, name:iPhone 13 Pro }
{ platform:iOS Simulator, id:DC9A058C-4715-4A8D-BC0D-C2D7BD168577, OS:15.0, name:iPhone 13 Pro Max }
{ platform:iOS Simulator, id:8405D3BB-24AA-4526-B6FE-67F8BFE743FE, OS:15.0, name:iPhone 13 mini }
{ platform:iOS Simulator, id:58433786-864E-4527-B8F8-A45DB22683F2, OS:15.0, name:iPhone SE (2nd generation) }
{ platform:iOS Simulator, id:FCC04312-8C1D-4183-885A-4F39A1168C69, OS:15.0, name:iPod touch (7th generation) }
{ platform:macOS, arch:x86_64, id:4203018E-580F-C1B5-9525-B745CECA79EB }
{ platform:macOS, arch:x86_64, variant:Mac Catalyst, id:4203018E-580F-C1B5-9525-B745CECA79EB }
{ platform:macOS, arch:x86_64, variant:DriverKit, id:4203018E-580F-C1B5-9525-B745CECA79EB }
{ platform:DriverKit, name:Any DriverKit Host }
{ platform:iOS, id:dvtdevice-DVTiPhonePlaceholder-iphoneos:placeholder, name:Any iOS Device }
{ platform:macOS, name:Any Mac }
{ platform:macOS, variant:Mac Catalyst, name:Any Mac }
{ platform:tvOS, id:dvtdevice-DVTiOSDevicePlaceholder-appletvos:placeholder, name:Any tvOS Device }
{ platform:tvOS Simulator, id:dvtdevice-DVTiOSDeviceSimulatorPlaceholder-appletvsimulator:placeholder, name:Any tvOS Simulator Device }
{ platform:watchOS, id:dvtdevice-DVTiOSDevicePlaceholder-watchos:placeholder, name:Any watchOS Device }
{ platform:watchOS Simulator, id:dvtdevice-DVTiOSDeviceSimulatorPlaceholder-watchsimulator:placeholder, name:Any watchOS Simulator Device }
{ platform:tvOS Simulator, id:E04B8778-1EB1-405C-8BDC-BCEDB051B9F6, OS:15.0, name:Apple TV }
{ platform:tvOS Simulator, id:5A909CB2-EC5D-45E7-83A8-43D0[14](https://github.com/SAP/cloud-sdk-ios-fiori/runs/4513325548?check_suite_focus=true#step:4:14)7432D0, OS:[15](https://github.com/SAP/cloud-sdk-ios-fiori/runs/4513325548?check_suite_focus=true#step:4:15).0, name:Apple TV 4K }
{ platform:tvOS Simulator, id:00DF2D62-75B7-459E-8FDE-7D094EB90688, OS:15.0, name:Apple TV 4K (2nd generation) }
{ platform:tvOS Simulator, id:B4A8EA80-C47A-4FDE-A7D4-7A9B73BD5F15, OS:15.0, name:Apple TV 4K (at 1080p) }
{ platform:tvOS Simulator, id:C[18](https://github.com/SAP/cloud-sdk-ios-fiori/runs/4513325548?check_suite_focus=true#step:4:18)DC6C8-EA74-4B86-8993-F5[19](https://github.com/SAP/cloud-sdk-ios-fiori/runs/4513325548?check_suite_focus=true#step:4:19)788CC75E, OS:15.0, name:Apple TV 4K (at 1080p) (2nd generation) }
{ platform:watchOS Simulator, id:EF615F1D-4FE7-4065-9B40-F557DD6A1969, OS:8.0, name:Apple Watch Series 4 - 40mm }
{ platform:watchOS Simulator, id:4CD5B950-CC5E-4FB5-9CB4-32E3F5962D18, OS:8.0, name:Apple Watch Series 4 - 44mm }
{ platform:watchOS Simulator, id:97D0B195-768D-40DE-B8C5-8B2CE7A2EB7F, OS:8.0, name:Apple Watch Series 5 - 40mm }
{ platform:watchOS Simulator, id:A72410BD-0[20](https://github.com/SAP/cloud-sdk-ios-fiori/runs/4513325548?check_suite_focus=true#step:4:20)A-49BD-A434-4EE113BE0350, OS:8.0, name:Apple Watch Series 5 - 44mm }
{ platform:watchOS Simulator, id:99684488-F50C-4D2D-B53A-1ED9FE846BFB, OS:8.0, name:Apple Watch Series 6 - 40mm }
{ platform:watchOS Simulator, id:826E9763-AE85-4778-95B9-BC37B53[21](https://github.com/SAP/cloud-sdk-ios-fiori/runs/4513325548?check_suite_focus=true#step:4:21)26A, OS:8.0, name:Apple Watch Series 6 - 44mm }
{ platform:watchOS Simulator, id:9A7144EF-FD0A-4100-B85E-4F0AB6B7FB67, OS:8.0, name:Apple Watch Series 7 - 41mm }
{ platform:watchOS Simulator, id:AF638A5E-40A0-4B43-8DD3-46A35A9B3FE8, OS:8.0, name:Apple Watch Series 7 - 45mm }
Running xcodebuild
Could not successfully run `xcodebuild`.
Please check the build arguments.
Saved `xcodebuild` log file: /var/folders/[24](https://github.com/SAP/cloud-sdk-ios-fiori/runs/4513325548?check_suite_focus=true#step:4:24)/8k48jl6d249_n_qfxwsl6xvm0000gn/T/xcodebuild-88548BE3-CB[25](https://github.com/SAP/cloud-sdk-ios-fiori/runs/4513325548?check_suite_focus=true#step:4:25)-4A87-8F8B-C9[66](https://github.com/SAP/cloud-sdk-ios-fiori/runs/4513325548?check_suite_focus=true#step:4:66)F995A9B7.log
Error: Failed to generate documentation
building site
building search index
Using config file /Users/runner/work/cloud-sdk-ios-fiori/cloud-sdk-ios-fiori/.jazzy.yaml
0% documentation coverage with 0 undocumented symbols
jam out ♪♫ to your fresh new docs in `docs/charts`
```

I changed this by specifying a destination explictly.

Also I added the generation of API reference for FioriThemeManager (~ 85% coverage).

Finally I remove the custom copyright attribute in `.jazzy.yml` to get the `Last updated` timestamp for free :)