### PR TITLE
fix: 🐛 [BCP:0] SignatureCaptureView display image color issue

### DIFF
--- a/Sources/FioriSwiftUICore/Models/ModelDefinitions.swift
+++ b/Sources/FioriSwiftUICore/Models/ModelDefinitions.swift
@@ -291,6 +291,7 @@ public protocol UserConsentPageModel: TitleComponent, BodyAttributedTextComponen
 // sourcery: virtualPropWatermarkTextAlignment = "var watermarkTextAlignment: NSTextAlignment = .natural"
 // sourcery: virtualPropWatermarkTextFont = "var watermarkTextFont: UIFont = .preferredFont(forTextStyle: .caption1)"
 // sourcery: virtualPropWatermarkTextColor = "var watermarkTextColor: Color = .preferredColor(.tertiaryLabel)"
+// sourcery: virtualPropAppliesTintColorToImage = "var appliesTintColorToImage = true"
 // sourcery: generated_component_composite
 public protocol SignatureCaptureViewModel: AnyObject {
     // sourcery: default.value = nil

--- a/Sources/FioriSwiftUICore/SignatureView/ScribbleView.swift
+++ b/Sources/FioriSwiftUICore/SignatureView/ScribbleView.swift
@@ -108,15 +108,11 @@ extension ScribbleView {
             imageSize.height += extraHeight
             path.apply(CGAffineTransform(translationX: 0, y: -extraHeight))
         }
+        let lightTraitCollection = UITraitCollection(userInterfaceStyle: .light)
 
         UIGraphicsBeginImageContextWithOptions(imageSize, false, 1)
-        if #available(iOS 14.0, *) {
-            let color = UIColor(self.drawingViewBackgroundColor)
-            color.setFill()
-        } else {
-            let color = self.drawingViewBackgroundColor.uiColor()
-            color.setFill()
-        }
+        let color = UIColor.clear
+        color.setFill()
 
         if let origin = origin {
             path.apply(CGAffineTransform(translationX: -1 * origin.x, y: -1 * origin.y))
@@ -128,10 +124,10 @@ extension ScribbleView {
 
         UIRectFill(CGRect(origin: .zero, size: imageSize))
         if #available(iOS 14.0, *) {
-            let color = UIColor(self.strokeColor)
+            let color = UIColor(self.strokeColor).resolvedColor(with: lightTraitCollection)
             color.setStroke()
         } else {
-            let color = self.strokeColor.uiColor()
+            let color = self.strokeColor.uiColor().resolvedColor(with: lightTraitCollection)
             color.setStroke()
         }
         path.stroke()

--- a/Sources/FioriSwiftUICore/Views/SignatureCaptureView+View.swift
+++ b/Sources/FioriSwiftUICore/Views/SignatureCaptureView+View.swift
@@ -89,13 +89,29 @@ extension SignatureCaptureView: View {
             if fullSignatureImage != nil || (_signatureImage != nil && !isReenterTapped) {
                 ZStack {
                     if let uiImage = fullSignatureImage {
-                        Image(uiImage: uiImage)
-                            .frame(minHeight: _drawingViewMinHeight, maxHeight: imageMaxHeight())
-                            .cornerRadius(10)
-                            .padding(.zero)
+                        if appliesTintColorToImage {
+                            Image(uiImage: uiImage)
+                                .renderingMode(.template)
+                                .foregroundColor(strokeColor)
+                                .frame(minHeight: _drawingViewMinHeight, maxHeight: imageMaxHeight())
+                                .cornerRadius(10)
+                                .padding(.zero)
+                        } else {
+                            Image(uiImage: uiImage)
+                                .frame(minHeight: _drawingViewMinHeight, maxHeight: imageMaxHeight())
+                                .cornerRadius(10)
+                                .padding(.zero)
+                        }
                     } else if let signature = _signatureImage {
-                        Image(uiImage: signature)
-                            .padding(.zero)
+                        if appliesTintColorToImage {
+                            Image(uiImage: signature)
+                                .renderingMode(.template)
+                                .foregroundColor(strokeColor)
+                                .padding(.zero)
+                        } else {
+                            Image(uiImage: signature)
+                                .padding(.zero)
+                        }
                     }
                     RoundedRectangle(cornerRadius: 10)
                         .stroke(Color.preferredColor(.separator), lineWidth: 1)
@@ -455,6 +471,18 @@ public extension SignatureCaptureView {
     func watermarkTextColor(_ watermarkTextColor: Color) -> Self {
         var newSelf = self
         newSelf.watermarkTextColor = watermarkTextColor
+        return newSelf
+    }
+
+    /**
+     A view modifier to indicate if stroke color is to be applied when displaying a saved signature image.
+
+     - parameter appliesTintColorToImage: A boolean variable to indicate if stroke color is to be applied when displaying a saved signature image.
+        The default is true.
+     */
+    func appliesTintColorToImage(_ appliesTintColorToImage: Bool) -> Self {
+        var newSelf = self
+        newSelf.appliesTintColorToImage = appliesTintColorToImage
         return newSelf
     }
 }

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/API/SignatureCaptureView+API.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/API/SignatureCaptureView+API.generated.swift
@@ -19,31 +19,32 @@ public struct SignatureCaptureView<StartActionView: View, RestartActionView: Vie
 	let _signatureImage: UIImage?
 	let _onSave: ((UIImage) -> Void)?
 	let _onDelete: (() -> Void)?
-	let _drawingViewMinHeight: CGFloat = 256
-	public private(set) var _heightDidChangePublisher = CurrentValueSubject<CGFloat, Never>(0)
-	var hidesXmark = false
-	var watermarkTextColor: Color = .preferredColor(.tertiaryLabel)
-	@State var isReenterTapped = false
-	var drawingViewBackgroundColor = Color.preferredColor(.primaryBackground)
-	@State var fullSignatureImage: UIImage?
-	@State var isEditing = false
-	var strokeColor = Color.preferredColor(.primaryLabel)
-	var xmarkColor = Color.preferredColor(.quarternaryLabel)
-	@State var drawings = [Drawing]()
-	var signatureLineColor = Color.preferredColor(.quarternaryLabel)
-	var watermarkText: String?
-	var watermarkTextAlignment: NSTextAlignment = .natural
-	var addsTimestampInImage: Bool = false
-	var _drawingViewMaxHeight: CGFloat?
+	var timestampFormatter: DateFormatter?
 	@State var currentDrawing = Drawing()
 	var titleColor = Color.preferredColor(.primaryLabel)
-	var watermarkTextFont: UIFont = .preferredFont(forTextStyle: .caption1)
+	var hidesXmark = false
+	@State var fullSignatureImage: UIImage?
 	var strokeWidth: CGFloat = 3.0
-	@State var isSaved = false
-	var hidesSignatureLine = false
+	public private(set) var _heightDidChangePublisher = CurrentValueSubject<CGFloat, Never>(0)
+	var addsTimestampInImage: Bool = false
+	var strokeColor = Color.preferredColor(.primaryLabel)
+	var drawingViewBackgroundColor = Color.preferredColor(.primaryBackground)
+	var watermarkTextFont: UIFont = .preferredFont(forTextStyle: .caption1)
 	var cropsImage = false
+	var _drawingViewMaxHeight: CGFloat?
+	var watermarkTextColor: Color = .preferredColor(.tertiaryLabel)
+	var signatureLineColor = Color.preferredColor(.quarternaryLabel)
+	var appliesTintColorToImage = true
+	@State var isSaved = false
+	let _drawingViewMinHeight: CGFloat = 256
+	@State var isReenterTapped = false
+	var watermarkTextAlignment: NSTextAlignment = .natural
+	var watermarkText: String?
 	var titleFont = Font.fiori(forTextStyle: .subheadline).weight(.semibold)
-	var timestampFormatter: DateFormatter?
+	@State var isEditing = false
+	var hidesSignatureLine = false
+	var xmarkColor = Color.preferredColor(.quarternaryLabel)
+	@State var drawings = [Drawing]()
 
     private var isModelInit: Bool = false
 	private var isTitleNil: Bool = false


### PR DESCRIPTION
The saved signature can now be display in both light and dark modes
Similar changes to the FUISignatureCaptureController
Cherry-picked from integrationSAPFiori7.0