### PR TITLE
fix: [HCPSDKFIORIUIKIT-2043] resolve UIFont instance from Swift pass to SwiftUI can't be resized and empty text disable accessibility. (#418)

### DIFF
--- a/Sources/FioriSwiftUICore/DataTable/GridTableView.swift
+++ b/Sources/FioriSwiftUICore/DataTable/GridTableView.swift
@@ -33,7 +33,7 @@ struct GridTableView: View {
         }
         
         // trigger the layout if it has been changed
-        if self.sizeCategory != self.sizeCategory {
+        if self.layoutManager.sizeCategory != self.sizeCategory {
             self.layoutManager.sizeCategory = self.sizeCategory
         }
         

--- a/Sources/FioriSwiftUICore/DataTable/ItemView.swift
+++ b/Sources/FioriSwiftUICore/DataTable/ItemView.swift
@@ -39,6 +39,7 @@ struct ItemView: View {
                     .lineLimit(dataItem.lineLimit)
                     .multilineTextAlignment(dataItem.textAlignment)
                     .frame(width: contentWidth, alignment: dataItem.textAlignment.toTextFrameAlignment())
+                    .accessibility(hidden: value.isEmpty)
             }
             
             Spacer(minLength: 0)
@@ -65,6 +66,7 @@ struct ItemView: View {
                     .lineLimit(dataItem.lineLimit)
                     .multilineTextAlignment(dataItem.textAlignment)
                     .frame(width: contentWidth, alignment: dataItem.textAlignment.toTextFrameAlignment())
+                    .accessibility(hidden: value.isEmpty)
             }
             
             Spacer(minLength: 0)

--- a/Sources/FioriSwiftUICore/DataTable/LayoutData.swift
+++ b/Sources/FioriSwiftUICore/DataTable/LayoutData.swift
@@ -143,7 +143,13 @@ class LayoutData {
                 let title = item.text
                 var uifont: UIFont
                 if let tmpUIFont = item.uifont {
-                    uifont = tmpUIFont
+                    // `item.uifont` is passed by developer, although is a preferred font but can't resize according to system in SwiftUI. So need to redefine the UIFont instance.
+                    if let styleName = tmpUIFont.fontDescriptor.fontAttributes[.textStyle] as? String {
+                        let textStyle = UIFont.TextStyle(rawValue: styleName)
+                        uifont = UIFont.preferredFont(forTextStyle: textStyle)
+                    }else {
+                        uifont = tmpUIFont
+                    }
                 } else if let _font = item.font {
                     uifont = UIFont.preferredFont(from: _font)
                 } else {
@@ -164,7 +170,7 @@ class LayoutData {
                                          firstBaselineHeight: firstBaselineHeight,
                                          pos: .zero,
                                          font: font,
-                                         uifont: item.uifont,
+                                         uifont: uifont,
                                          foregroundColor: textColor,
                                          size: size,
                                          textAlignment: textAlignment,


### PR DESCRIPTION
Co-authored-by: Bill Zhou <bill.zhou01@sap.com>