### PR TITLE
fix: 🐛 Use labels to show KPIItem when action is not set

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/KPI/KPIViewExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/KPI/KPIViewExample.swift
@@ -21,7 +21,7 @@ public struct KPIExample: View {
     
     public var body: some View {
         VStack(spacing: 16) {
-            KPIItem(data: .components([.unit("$"), .metric("121.98"), .unit("USD")]), subtitle: "Average Spending")
+            KPIItem(data: .components([.unit("$"), .metric("121.98"), .unit("USD")]), subtitle: "Average Spending", action: { print("KPI tapped") })
                 .subtitleModifier { content in
                     content
                         .foregroundColor(.yellow)

--- a/Sources/FioriSwiftUICore/Views/KPIItem+View.swift
+++ b/Sources/FioriSwiftUICore/Views/KPIItem+View.swift
@@ -34,13 +34,21 @@ extension Fiori {
 
 extension KPIItem: View {
     public var body: some View {
-        Button(action: action ?? {}) {
+        if let buttonAction = action {
+            Button(action: buttonAction) {
+                VStack(alignment: .center, spacing: 2) {
+                    kpi
+                    subtitle
+                }
+                .frame(maxWidth: 216)
+            }.buttonStyle(ButtonContainerStyle())
+        } else {
             VStack(alignment: .center, spacing: 2) {
                 kpi
                 subtitle
             }
             .frame(maxWidth: 216)
-        }.buttonStyle(ButtonContainerStyle())
+        }
     }
 }
 


### PR DESCRIPTION
Fix the issue in #436