### PR TITLE
fix: 🐛 fix crash when using custom palette

### DIFF
--- a/Sources/FioriThemeManager/ThemeManager.swift
+++ b/Sources/FioriThemeManager/ThemeManager.swift
@@ -51,7 +51,7 @@ public class ThemeManager {
     
     /// Merges deprecated styles till the `current` palette.
     private func mergedDeprecatedDefinitions() -> [ColorStyle: HexColor] {
-        guard let paletteVersion = paletteVersion else { return [ColorStyle: HexColor]() }
+        guard let paletteVersion = paletteVersion else { return self.palette.colorDefinitions }
         var current = paletteVersion
         var result = paletteVersion.rawValue.colorDefinitions
         var cumulative = [ColorStyle: HexColor]()


### PR DESCRIPTION
Before this fix, setting a custom palette

```swift
ThemeManager.shared.setPalette(aCustomPalette)
```
caused a crash when calling `Color.preferredColor(_:background:interface:display:)` because

```swift
    internal func color(for style: ColorStyle, background scheme: BackgroundColorScheme?, interface level: InterfaceLevel?, display mode: ColorDisplayMode?) -> Color {
        let uiColor = self.uiColor(for: style, background: scheme, interface: level, display: mode) // <== returned UIPlaceholderColor
        let color = Color(uiColor)
        return color
    }
```
