### PR TITLE
feat: 🎸 override color definitions (e.g. through style sheet)

### DIFF
--- a/Apps/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Apps/Examples/Examples.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		8A7F248125A68C5B003F19FF /* FioriSwiftUI in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 8A4A31B824E3564F00B63AF0 /* FioriSwiftUI */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		8A8B9BDA24D3DA580096000F /* AnalyticalCardSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8B9BD924D3DA580096000F /* AnalyticalCardSnapshotTests.swift */; };
 		8A8B9BDC24D3DADA0096000F /* ListCardSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A8B9BDB24D3DADA0096000F /* ListCardSnapshotTests.swift */; };
+		8AB6C01428DF6583002F32BE /* LazyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AB6C01328DF6583002F32BE /* LazyView.swift */; };
 		8ACBFA1424F7F011009233DE /* FioriSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = 8A4A31B824E3564F00B63AF0 /* FioriSwiftUI */; };
 		8ACBFA1524F7F011009233DE /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = 8A17AA2C24E211CD00ED8131 /* SnapshotTesting */; };
 		8ACBFA1624F7F011009233DE /* FioriSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = 8A4A31BB24E3568700B63AF0 /* FioriSwiftUI */; };
@@ -187,6 +188,7 @@
 		8A6DE30A28DD27F9003222E3 /* Colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Colors.swift; sourceTree = "<group>"; };
 		8A8B9BD924D3DA580096000F /* AnalyticalCardSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticalCardSnapshotTests.swift; sourceTree = "<group>"; };
 		8A8B9BDB24D3DADA0096000F /* ListCardSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListCardSnapshotTests.swift; sourceTree = "<group>"; };
+		8AB6C01328DF6583002F32BE /* LazyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyView.swift; sourceTree = "<group>"; };
 		8ACBFA1724F7F033009233DE /* ObjectCardSnapshotTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjectCardSnapshotTests.swift; sourceTree = "<group>"; };
 		8AD9DFA525D49967007448EC /* ContactItemActionItemsExample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContactItemActionItemsExample.swift; sourceTree = "<group>"; };
 		8AD9DFA625D49967007448EC /* ContactItemStateAndDataBindingExample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContactItemStateAndDataBindingExample.swift; sourceTree = "<group>"; };
@@ -352,6 +354,7 @@
 				8A55795624C1286E0098003A /* AppDelegate.swift */,
 				8A55795824C1286E0098003A /* SceneDelegate.swift */,
 				8A55795A24C1286E0098003A /* ContentView.swift */,
+				8AB6C01328DF6583002F32BE /* LazyView.swift */,
 				8A55796124C1286F0098003A /* LaunchScreen.storyboard */,
 				B8D4376725EEC5E80024EE7D /* Assets.xcassets */,
 				8A55796424C1286F0098003A /* Info.plist */,
@@ -702,6 +705,7 @@
 			files = (
 				B8101D52268BB84B00D32560 /* ContactItemTapStateExamples.swift in Sources */,
 				8A55795724C1286E0098003A /* AppDelegate.swift in Sources */,
+				8AB6C01428DF6583002F32BE /* LazyView.swift in Sources */,
 				691DE21925F2A30B00094D4A /* KPIViewExample.swift in Sources */,
 				AB988B102631270300483D87 /* DataTableExample.swift in Sources */,
 				99B6EF8C2672224D00515E8E /* UserConsentSample.swift in Sources */,

--- a/Apps/Examples/Examples/ContentView.swift
+++ b/Apps/Examples/Examples/ContentView.swift
@@ -6,7 +6,8 @@ struct ContentView: View {
         NavigationView {
             List {
                 NavigationLink(
-                    destination: ChartsContentView()) {
+                    // putting `ChartsContentView` in a `LazyView` allows to demonstrate that overriden colors will be applied by `FioriCharts` views
+                    destination: LazyView(ChartsContentView())) {
                     Text("Charts")
                 }
                 NavigationLink(

--- a/Apps/Examples/Examples/ContentView.swift
+++ b/Apps/Examples/Examples/ContentView.swift
@@ -7,7 +7,8 @@ struct ContentView: View {
             List {
                 NavigationLink(
                     // putting `ChartsContentView` in a `LazyView` allows to demonstrate that overriden colors will be applied by `FioriCharts` views
-                    destination: LazyView(ChartsContentView())) {
+                    destination: LazyView(ChartsContentView())
+                ) {
                     Text("Charts")
                 }
                 NavigationLink(

--- a/Apps/Examples/Examples/FioriThemeManager/FioriThemeManagerContentView.swift
+++ b/Apps/Examples/Examples/FioriThemeManager/FioriThemeManagerContentView.swift
@@ -13,8 +13,16 @@ struct FioriThemeManagerContentView: View {
                 Text("Colors - latest")
             }
             NavigationLink(
-                destination: CustomColors()) {
-                Text("Colors - custom example")
+                destination: CustomColors(testData: .customPalette(ColorTestData.RandomColorPaletteProvider()))) {
+                Text("Colors - custom palette (random)")
+            }
+            NavigationLink(
+                destination: CustomColors(testData: .programmatic(.green))) {
+                Text("Colors - developer override")
+            }
+            NavigationLink(
+                destination: CustomColors(testData: .styleSheet(ColorTestData.sampleStyleSheet))) {
+                Text("Colors - style sheet override")
             }
         }
     }

--- a/Apps/Examples/Examples/LazyView.swift
+++ b/Apps/Examples/Examples/LazyView.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+/* Use this view to delay the creation of the view passed into the `LazyView`
+ Otherwise such view might get constructed even when it's not going to be on screen, i.e. `NavigationLink` constructs its destination view immediately.
+ See https://www.objc.io/blog/2019/07/02/lazy-loading/ for more information
+ */
+struct LazyView<Content: View>: View {
+    let build: () -> Content
+    init(_ build: @autoclosure @escaping () -> Content) {
+        self.build = build
+    }
+
+    var body: Content {
+        self.build()
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -51,7 +51,10 @@ let package = Package(
         ),
         .testTarget(
             name: "FioriSwiftUITests",
-            dependencies: ["FioriSwiftUI"]
+            dependencies: ["FioriSwiftUI"],
+            resources: [
+                .process("FioriThemeManager/TestResources")
+            ]
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -132,7 +132,6 @@ Several functional limitations exist at present, which are planned for resolutio
 Key gaps which are present at time of open-source project launch:
 
  - **FioriCharts** requires design specifications to improve UI
- - **FioriCharts** must support theming with **NUI** nss stylesheets, as currently supported by **SAPFiori**. 
 
 ## Known Issues
 

--- a/Sources/FioriThemeManager/Colors/Color+Extension.swift
+++ b/Sources/FioriThemeManager/Colors/Color+Extension.swift
@@ -54,3 +54,59 @@ extension Color {
         ThemeManager.shared.uiColor(for: style, background: scheme, interface: level, display: mode)
     }
 }
+
+extension Color {
+    init?(hex: String) {
+        var hexSanitized = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        hexSanitized = hexSanitized.replacingOccurrences(of: "#", with: "")
+
+        var rgb: UInt64 = 0
+
+        var r: CGFloat = 0.0
+        var g: CGFloat = 0.0
+        var b: CGFloat = 0.0
+        var a: CGFloat = 1.0
+
+        let length = hexSanitized.count
+
+        guard Scanner(string: hexSanitized).scanHexInt64(&rgb) else { return nil }
+
+        if length == 6 {
+            r = CGFloat((rgb & 0xff0000) >> 16) / 255.0
+            g = CGFloat((rgb & 0x00ff00) >> 8) / 255.0
+            b = CGFloat(rgb & 0x0000ff) / 255.0
+
+        } else if length == 8 {
+            r = CGFloat((rgb & 0xff000000) >> 24) / 255.0
+            g = CGFloat((rgb & 0x00ff0000) >> 16) / 255.0
+            b = CGFloat((rgb & 0x0000ff00) >> 8) / 255.0
+            a = CGFloat(rgb & 0x000000ff) / 255.0
+
+        } else {
+            return nil
+        }
+
+        self.init(red: r, green: g, blue: b, opacity: a)
+    }
+    
+    func toHex() -> String? {
+        let uic = UIColor(self)
+        guard let components = uic.cgColor.components, components.count >= 3 else {
+            return nil
+        }
+        let r = Float(components[0])
+        let g = Float(components[1])
+        let b = Float(components[2])
+        var a = Float(1.0)
+        
+        if components.count >= 4 {
+            a = Float(components[3])
+        }
+        
+        if a != Float(1.0) {
+            return String(format: "%02lX%02lX%02lX%02lX", lroundf(r * 255), lroundf(g * 255), lroundf(b * 255), lroundf(a * 255))
+        } else {
+            return String(format: "%02lX%02lX%02lX", lroundf(r * 255), lroundf(g * 255), lroundf(b * 255))
+        }
+    }
+}

--- a/Sources/FioriThemeManager/Colors/Color+Extension.swift
+++ b/Sources/FioriThemeManager/Colors/Color+Extension.swift
@@ -57,36 +57,26 @@ extension Color {
 
 extension Color {
     init?(hex: String) {
-        var hexSanitized = hex.trimmingCharacters(in: .whitespacesAndNewlines)
-        hexSanitized = hexSanitized.replacingOccurrences(of: "#", with: "")
-
-        var rgb: UInt64 = 0
-
-        var r: CGFloat = 0.0
-        var g: CGFloat = 0.0
-        var b: CGFloat = 0.0
-        var a: CGFloat = 1.0
-
-        let length = hexSanitized.count
-
-        guard Scanner(string: hexSanitized).scanHexInt64(&rgb) else { return nil }
-
-        if length == 6 {
-            r = CGFloat((rgb & 0xff0000) >> 16) / 255.0
-            g = CGFloat((rgb & 0x00ff00) >> 8) / 255.0
-            b = CGFloat(rgb & 0x0000ff) / 255.0
-
-        } else if length == 8 {
-            r = CGFloat((rgb & 0xff000000) >> 24) / 255.0
-            g = CGFloat((rgb & 0x00ff0000) >> 16) / 255.0
-            b = CGFloat((rgb & 0x0000ff00) >> 8) / 255.0
-            a = CGFloat(rgb & 0x000000ff) / 255.0
-
-        } else {
-            return nil
+        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int: UInt64 = 0
+        Scanner(string: hex).scanHexInt64(&int)
+        let a, r, g, b: UInt64
+        switch hex.count {
+        case 6: // RGB (24-bit)
+            (r, g, b, a) = (int >> 16, int >> 8 & 0xff, int & 0xff, 255)
+        case 8: // ARGB (32-bit)
+            (r, g, b, a) = (int >> 24, int >> 16 & 0xff, int >> 8 & 0xff, int & 0xff)
+        default:
+            (r, g, b, a) = (0, 0, 0, 255)
         }
 
-        self.init(red: r, green: g, blue: b, opacity: a)
+        self.init(
+            .sRGB,
+            red: Double(r) / 255,
+            green: Double(g) / 255,
+            blue: Double(b) / 255,
+            opacity: Double(a) / 255
+        )
     }
     
     func toHex() -> String? {

--- a/Sources/FioriThemeManager/Colors/ColorStyle.swift
+++ b/Sources/FioriThemeManager/Colors/ColorStyle.swift
@@ -1,3 +1,5 @@
+import SwiftUI
+
 public enum ColorStyle: String, CaseIterable {
     // MARK: - Fiori Next Core Colors (116 Colors)
     
@@ -1273,4 +1275,28 @@ public enum ColorStyle: String, CaseIterable {
                                                 .chart5, .chart6, .chart7, .chart8, .chart9, .chart10, .chart11,
                                                 .stockUpStroke, .stockDownStroke, .map1, .map2, .map3, .map4,
                                                 .map5, .map6, .map7, .map8, .map9, .map10, .customColor1, .customColor2, .customColor3, .customColor4, .customColor5, .customColor6, .esriEdit]
+}
+
+extension ColorStyle {
+    // get color from `Color.preferredColor` given a global definition name in a style sheet, e.g. tintColor_lightBackground
+    static func color(from stringName: String) -> Color? {
+        func parseColor(from string: String) -> Color? {
+            var styleString = string
+            var optSchemeString: String?
+            
+            if let index = string.firstIndex(of: "_") {
+                styleString = String(string.prefix(upTo: index))
+                if let schemeIndex = string.index(index, offsetBy: 1, limitedBy: string.endIndex) {
+                    optSchemeString = String(string.suffix(from: schemeIndex))
+                }
+            }
+            
+            guard let style = ColorStyle(rawValue: styleString) else { return nil }
+            guard let schemeString = optSchemeString, let scheme = BackgroundColorScheme(rawValue: schemeString) else {
+                return Color.preferredColor(style)
+            }
+            return Color.preferredColor(style, background: scheme)
+        }
+        return parseColor(from: stringName)
+    }
 }

--- a/Sources/FioriThemeManager/StyleSheet/Internal/StyleSheet.swift
+++ b/Sources/FioriThemeManager/StyleSheet/Internal/StyleSheet.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+typealias StyleSheetGlobalDefinitions = [String: String]
+
+struct StyleSheet {
+    var globalDefinitions = StyleSheetGlobalDefinitions()
+}

--- a/Sources/FioriThemeManager/StyleSheet/Internal/StyleSheetConverter.swift
+++ b/Sources/FioriThemeManager/StyleSheet/Internal/StyleSheetConverter.swift
@@ -1,0 +1,114 @@
+import Foundation
+import SwiftUI
+import UIKit
+
+enum StyleSheetConverter {
+    static func toColor(value: String) -> Color? {
+        // Check standard color names
+        switch value {
+        case "black":
+            return .black
+        case "darkGray":
+            return Color(.darkGray)
+        case "lightGray":
+            return Color(.lightGray)
+        case "white":
+            return .white
+        case "gray":
+            return .gray
+        case "red":
+            return .red
+        case "green":
+            return .green
+        case "blue":
+            return .blue
+        case "cyan":
+            if #available(iOS 15.0, *) {
+                return .cyan
+            } else {
+                return Color(.cyan)
+            }
+        case "yellow":
+            return .yellow
+        case "magenta":
+            return nil
+        case "orange":
+            return .orange
+        case "purple":
+            return .purple
+        case "brown":
+            if #available(iOS 15.0, *) {
+                return .brown
+            } else {
+                return Color(.brown)
+            }
+        case "clear":
+            return .clear
+        default:
+            break
+        }
+        
+        // Check names of supported Fiori styles (e.g.:  "primary1", "primary1_lightBackground", "primary1_darkBackground")
+        if let fioriConstantColor = ColorStyle.color(from: value) {
+            return fioriConstantColor
+        }
+        
+        // Remove all whitespace.
+        let cString = value.components(
+            separatedBy: NSCharacterSet.whitespacesAndNewlines).reduce("", +).uppercased()
+        
+        let hexAlphaStrings = self.getCapturedStrings(content: cString, withPattern: "(?:0X|#)([0-9A-F]{8})")
+        // example of such a value: #1EA65395, where "1E" is 30% for alpha; "A6" is R in hex; "53" is G in hex; "95" is R in hex
+        // alpha range is 0% to 100%.  When the given value is more than 100%, the value would be automatically reset to 100%
+        // An example of online tool to convert decimal to Hex: http://www.rapidtables.com/convert/number/decimal-to-hex.htm
+        if let hexAlphaStrings = hexAlphaStrings {
+            return Color(hex: hexAlphaStrings[1])
+        }
+        
+        let hexStrings = self.getCapturedStrings(content: cString, withPattern: "(?:0X|#)([0-9A-F]{6})")
+        /// example of such a value: #A65395, where "A6" is R in hex; "53" is G in hex; "95" is R in hex; alpha is default to 1.0
+        if let hexStrings = hexStrings {
+            return Color(hex: hexStrings[1])
+        }
+        
+        return nil
+    }
+
+    /**
+     Matches the given content against the regular expression pattern, extracting
+     any captured groups into an array. Unmatched captured groups are represented
+     by an empty string instances in the returned array.
+     */
+    static func getCapturedStrings(content: String, withPattern pattern: String) -> [String]? {
+        var regex: NSRegularExpression
+        
+        do {
+            regex = try NSRegularExpression(pattern: pattern, options: NSRegularExpression.Options(rawValue: 0))
+        } catch {
+            return nil
+        }
+        
+        guard let result = regex.firstMatch(in: content, options: NSRegularExpression.MatchingOptions(rawValue: 0),
+                                            range: NSRange(location: 0, length: content.count))
+        else { return nil }
+        
+        var capturedStrings = [String]()
+        
+        for i in 0 ... regex.numberOfCaptureGroups {
+            //            let capturedRange = result.range(at: i).toRange()
+            let capturedRange = Range(result.range(at: i))
+            
+            if let capturedRange = capturedRange {
+                let start = content.index(content.startIndex, offsetBy: capturedRange.lowerBound)
+                let end = content.index(content.startIndex, offsetBy: capturedRange.upperBound)
+                let range = start ..< end
+
+                capturedStrings.append(String(content[range]))
+            } else {
+                capturedStrings.append("")
+            }
+        }
+        
+        return capturedStrings
+    }
+}

--- a/Sources/FioriThemeManager/StyleSheet/Internal/StyleSheetConverter.swift
+++ b/Sources/FioriThemeManager/StyleSheet/Internal/StyleSheetConverter.swift
@@ -23,11 +23,15 @@ enum StyleSheetConverter {
         case "blue":
             return .blue
         case "cyan":
-            if #available(iOS 15.0, *) {
-                return .cyan
-            } else {
+            #if swift(>=5.5)
+                if #available(iOS 15.0, *) {
+                    return .cyan
+                } else {
+                    return Color(.cyan)
+                }
+            #else
                 return Color(.cyan)
-            }
+            #endif
         case "yellow":
             return .yellow
         case "magenta":
@@ -37,11 +41,15 @@ enum StyleSheetConverter {
         case "purple":
             return .purple
         case "brown":
-            if #available(iOS 15.0, *) {
-                return .brown
-            } else {
+            #if swift(>=5.5)
+                if #available(iOS 15.0, *) {
+                    return .brown
+                } else {
+                    return Color(.brown)
+                }
+            #else
                 return Color(.brown)
-            }
+            #endif
         case "clear":
             return .clear
         default:

--- a/Sources/FioriThemeManager/StyleSheet/Internal/StyleSheetParser.swift
+++ b/Sources/FioriThemeManager/StyleSheet/Internal/StyleSheetParser.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+struct StyleSheetParser {
+    func loadStylesheetByString(content: String) throws -> StyleSheet {
+        guard let stylesheet = parse(content) else {
+            let errMsg = "Failed to parse stylesheet:\(content). Please check .nss file for validity."
+            throw StyleSheetParsingError.invalidStyleSheet(errMsg)
+        }
+        return stylesheet
+    }
+    
+    func loadStylesheetByURL(url: URL) throws -> StyleSheet {
+        let content = try String(contentsOf: url, encoding: String.Encoding.utf8)
+        guard let stylesheet = parse(content) else {
+            let errMsg = "Failed to parse stylesheet:\(content). Please check .nss file for validity."
+            throw StyleSheetParsingError.invalidStyleSheet(errMsg)
+        }
+        return stylesheet
+    }
+    
+    func parse(_ content: String) -> StyleSheet? {
+        var styleSheet = StyleSheet()
+        let lineArray = content.components(separatedBy: .newlines)
+        
+        for line in lineArray {
+            guard line.first == "@" else { continue } // only global definitions (example: @tintColor:#FF00F9; ) are supported by this parser
+            let globalDefinition = line.dropFirst().dropLast().components(separatedBy: ":")
+            guard let propertyName = globalDefinition.first, let value = globalDefinition.last, globalDefinition.count == 2 else { continue }
+            
+            if !styleSheet.globalDefinitions.keys.contains(propertyName) {
+                styleSheet.globalDefinitions.updateValue(value, forKey: propertyName)
+            }
+        }
+        
+        return styleSheet
+    }
+}

--- a/Sources/FioriThemeManager/StyleSheet/StyleSheetSettings.swift
+++ b/Sources/FioriThemeManager/StyleSheet/StyleSheetSettings.swift
@@ -1,0 +1,56 @@
+import Foundation
+import SwiftUI
+
+public enum StyleSheetParsingError: Error {
+    case invalidStyleSheet(String)
+}
+
+/**
+ API to load and apply style sheet information (to override color definitions)
+ 
+ Changes made to the manager affect all future calls to `Color.preferredColor(_:background:interface:display:)`.
+ 
+ **Example Usage**
+ 
+ ```swift
+ var colorOverrides = """
+ @primaryLabel:#FF6000;
+ @primaryLabel_darkBackground:#00FFFF;
+ """
+ 
+ try? StyleSheetSettings.loadStylesheetByString(content: colorOverrides)
+ ```
+ */
+public struct StyleSheetSettings {
+    static var shared = StyleSheetSettings()
+    private init() {}
+    
+    internal private(set) var globalDefinitions = StyleSheetGlobalDefinitions()
+    
+    public static func reset() {
+        StyleSheetSettings.shared.globalDefinitions = StyleSheetGlobalDefinitions()
+        ThemeManager.shared.reset()
+    }
+    
+    /// Load a specific stylesheet for theming with an given URL to the style sheet
+    ///
+    /// - parameter url: The `URL` to the style sheet
+    public static func loadStylesheetByURL(url: URL) throws {
+        let parser = StyleSheetParser()
+        guard let stylesheet = try? parser.loadStylesheetByURL(url: url) else { return }
+        for (key, value) in stylesheet.globalDefinitions {
+            StyleSheetSettings.shared.globalDefinitions.updateValue(value, forKey: key)
+        }
+    }
+    
+    /// Load a stylesheet as `String` represetation of style sheet file
+    ///
+    /// - Parameter content: the `String` representation of a style sheet file document
+    public static func loadStylesheetByString(content: String) throws {
+        let parser = StyleSheetParser()
+        guard let stylesheet = try? parser.loadStylesheetByString(content: content) else { return }
+        for (key, value) in stylesheet.globalDefinitions {
+            StyleSheetSettings.shared.globalDefinitions.updateValue(value, forKey: key)
+        }
+    }
+}

--- a/Sources/FioriThemeManager/ThemeManager.swift
+++ b/Sources/FioriThemeManager/ThemeManager.swift
@@ -2,6 +2,23 @@ import Foundation
 import SwiftUI
 import UIKit
 
+/**
+ Manager class which supplies color palette values to Fiori components, and the `Color.preferredColor(_:background:interface:display:)` API.
+ 
+ Changes made to the manager affect all future calls to `Color.preferredColor(_:background:interface:display:)`. Most components do not reload dynamically, so calls to the `ThemeManager` should happen at the beginning of the application lifecycle.
+ 
+ - note: `AppDelegate.didFinishLaunching(withOptions...)` is the recommended location.
+ 
+ **Example Usage**
+ 
+ ```swift
+ // Pin palette version used by application to a specific version (defaults to `.latest`)
+ ThemeManager.shared.setPaletteVersion(.v7)
+ 
+ // Override some color definitions to match your application palette
+ ThemeManager.shared.setColor(.darkGray, for: .primary2, background: .light)
+ ThemeManager.shared.setHexColor("1b931d", for: .positive, background: .light)
+ */
 public class ThemeManager {
     /// Singleton instance shared by all application components.
     public static let shared = ThemeManager()
@@ -26,11 +43,57 @@ public class ThemeManager {
     }
     
     /// Accessor to current palette.
-    /// - note: It is unusual to need to read from the palette directly; generally, use the `UIColor.preferredFioriColor(...)` API.
+    /// - note: It is unusual to need to read from the palette directly; generally, use the `Color.preferredColor(...)` API.
     public private(set) var palette: Palette = PaletteVersion.latest.rawValue {
         didSet {
             self.paletteVersion = PaletteVersion(rawValue: self.palette)
         }
+    }
+    
+    /// Method to supply a custom definition for a particular `ColorStyle`. Will be applied to `.light` background color scheme.
+    ///
+    /// - Parameters:
+    ///   - color: Color definition to override the base definition in the palette.
+    ///   - style: Reference of `ColorStyle` to which color is bound.
+    public func setColor(_ color: Color, for style: ColorStyle) {
+        self.setColor(color, for: style, variant: .light)
+    }
+    
+    /// Method to supply a custom definition for a particular `ColorStyle` and `ColorVariant` combination.
+    /// - note:  A `nil` value for `background` will default to `.light`.
+    ///
+    /// - Parameters:
+    ///   - color: Color definition to override the base definition in the palette.
+    ///   - style: Reference of `ColorStyle` to which color is bound.
+    ///   - variant: Reference of `ColorVariant` to which color is bound.  Defaults to `.light`. If no value is supplied for `.dark`, the value for `.light` will be read as a fallback.
+    public func setColor(_ color: Color, for style: ColorStyle, variant: ColorVariant?) {
+        self.developerOverrides[style, default: [:]].updateValue(color, forKey: variant ?? .light)
+    }
+    
+    /// Method to supply a custom definition for a particular `ColorStyle`. Will applied to `.light` background color scheme.
+    ///
+    /// - Parameters:
+    ///   - hex: Color definition as hexidecimal string to override the base definition in the palette.
+    ///   - style: Reference of `ColorStyle` to which color is bound.
+    public func setHexColor(_ hex: String, for style: ColorStyle) {
+        self.setHexColor(hex, for: style, variant: .light)
+    }
+    
+    /// Method to supply a custom definition for a particular `ColorStyle` and `ColorVariant` combination.
+    ///
+    /// - Parameters:
+    ///   - hex: Color definition as hexidecimal string to override the base definition in the palette.
+    ///   - style: Reference of `ColorStyle` to which color is bound.
+    ///   - variant: Reference of `ColorVariant` to which color is bound.  Defaults to `.light`. If no value is supplied for `.dark`, the value for `.light` will be read as a fallback.
+    public func setHexColor(_ hex: String, for style: ColorStyle, variant: ColorVariant) {
+        guard let color = Color(hex: hex) else { return }
+        self.setColor(color, for: style, variant: variant)
+    }
+    
+    /// Helper method, to clear any override colors set via `setColor(...)` or `setHexColor(...)`. Does not affect the base definition of the current palette.
+    public func reset() {
+        self.developerOverrides.removeAll()
+        self.styleSheetOverrides.removeAll()
     }
     
     internal var compatibilityMap: ColorCompatibilityMap? {
@@ -39,14 +102,22 @@ public class ThemeManager {
     
     internal var paletteVersion: PaletteVersion? = PaletteVersion.latest
     
+    internal private(set) var developerOverrides: [ColorStyle: [ColorVariant: Color]] = [:]
+    internal private(set) var styleSheetOverrides: [ColorStyle: [ColorVariant: Color]] = [:]
+    
     /// :nodoc:
     internal func hexColor(for style: ColorStyle) -> HexColor? {
-        let compatibleDefinitions = self.mergedCompatibleDefinitions()
-        guard !compatibleDefinitions.isEmpty else {
-            return self.mergedDeprecatedDefinitions()[style]
+        switch self.paletteVersion {
+        case .v3_x, .v3_2, .v4, .v5, .v6, .v7:
+            let compatibleDefinitions = self.mergedCompatibleDefinitions()
+            guard !compatibleDefinitions.isEmpty else {
+                return self.mergedDeprecatedDefinitions()[style]
+            }
+            let _style = compatibleDefinitions[style] ?? style
+            return self.mergedDeprecatedDefinitions()[_style]
+        default:
+            return self.palette.hexColor(for: style)
         }
-        let _style = compatibleDefinitions[style] ?? style
-        return self.mergedDeprecatedDefinitions()[_style]
     }
     
     /// Merges deprecated styles till the `current` palette.
@@ -85,6 +156,26 @@ public class ThemeManager {
     internal func color(for style: ColorStyle, background scheme: BackgroundColorScheme?, interface level: InterfaceLevel?, display mode: ColorDisplayMode?) -> Color {
         let uiColor = self.uiColor(for: style, background: scheme, interface: level, display: mode)
         let color = Color(uiColor)
+        
+        guard let hexColor = self.hexColor(for: style) else { return color }
+        
+        let variant = hexColor.getVariant(traits: UITraitCollection.current, background: scheme, interface: level, display: mode)
+        
+        if let ssOverrideColor = self.styleSheetOverrides[style, default: [:]][variant] {
+            return ssOverrideColor
+        }
+        
+        if let ssHexColor = nssHexColor(for: style, with: variant) {
+            if let ssColor: Color = StyleSheetConverter.toColor(value: ssHexColor) {
+                self.styleSheetOverrides[style, default: [:]].updateValue(ssColor, forKey: variant)
+                return ssColor
+            }
+        }
+        
+        if let devOverrideColor = developerOverrides[style, default: [:]][variant] {
+            return devOverrideColor
+        }
+        
         return color
     }
     
@@ -98,5 +189,83 @@ public class ThemeManager {
                            blue: CGFloat(components.b), alpha: CGFloat(components.a))
         }
         return uc
+    }
+    
+    func nssHexColor(for style: ColorStyle, with variant: ColorVariant) -> String? {
+        var developerOverriddenColors = [String: String]()
+        
+//        // Get the developer defined color definitions from the .nss file
+        developerOverriddenColors = StyleSheetSettings.shared.globalDefinitions // NUISettings.getInstance()._globalDefinitions
+        
+        // In .nss file color is defined using background scheme, so check for inversed color variant
+        if !StyleSheetSettings.shared.globalDefinitions.isEmpty {
+            // The keys in the .nss file are of the format style_scheme (for example, primary1_darkBackground) or just style (for example, "primary1)
+            // convert the enums into a string to search for the corresponding key-value pairs in the dictionary retreived from the NUISettings.
+            let keyStringForStyle = String(describing: style) // for example,"primary1"
+            let keyStringForScheme: String = {
+                switch variant {
+                case .dark:
+                    return "lightBackground"
+                case .elevatedLight:
+                    return "elevatedDarkBackground"
+                case .elevatedDark:
+                    return "elevatedLightBackground"
+                case .contrastLight:
+                    return "contrastDarkBackground"
+                case .contrastDark:
+                    return "contrastLightBackground"
+                default:
+                    return "darkBackground"
+                }
+            }()
+            let combinedKeyString = keyStringForStyle + "_" + keyStringForScheme // "primary1_lightBackground"
+            var developerOverrideColorString: String?
+            
+            switch variant {
+            case .dark:
+                if developerOverriddenColors.keys.contains(combinedKeyString) {
+                    developerOverrideColorString = developerOverriddenColors[combinedKeyString] // First look for "primary1_lightBackground" as that has precedence
+                } else if developerOverriddenColors.keys.contains(keyStringForStyle) {
+                    developerOverrideColorString = developerOverriddenColors[keyStringForStyle] // Else return the value for "primary1"
+                } else {
+                    // Special case for tintColorDark - check if there is an override in the nss file for "tintColorDark" which is the same as "tintColor_lightBackground"
+                    if keyStringForStyle == "tintColor" {
+                        if developerOverriddenColors.keys.contains("tintColorDark") {
+                            developerOverrideColorString = developerOverriddenColors["tintColorDark"]
+                        }
+                    }
+                    // Special case for tintColorTapStateDark - check if there is an override in the nss file for "tintColorTapStateDark" which is the same as "tintColorTapState_lightBackground"
+                    if keyStringForStyle == "tintColorTapState" {
+                        if developerOverriddenColors.keys.contains("tintColorTapStateDark") {
+                            developerOverrideColorString = developerOverriddenColors["tintColorTapStateDark"]
+                        }
+                    }
+                }
+            case .light:
+                if developerOverriddenColors.keys.contains(combinedKeyString) {
+                    developerOverrideColorString = developerOverriddenColors[combinedKeyString] // First look for "primary1_darkBackground" as that has precedence
+                } else {
+                    if keyStringForStyle == "tintColor" {
+                        // Special case for tintColorLight  - check if there is an override for "tintColorLight" which is the same as "tintColor_darkBackground"
+                        if developerOverriddenColors.keys.contains("tintColorLight") {
+                            developerOverrideColorString = developerOverriddenColors["tintColorLight"]
+                        }
+                    }
+                    // Special case for tintColorTapStateLight - check if there is an override in the nss file for "tintColorTapStateLight" which is the same as "tintColorTapState_darkBackground"
+                    if keyStringForStyle == "tintColorTapState" {
+                        if developerOverriddenColors.keys.contains("tintColorTapStateLight") {
+                            developerOverrideColorString = developerOverriddenColors["tintColorTapStateLight"]
+                        }
+                    }
+                }
+            default:
+                if developerOverriddenColors.keys.contains(combinedKeyString) {
+                    developerOverrideColorString = developerOverriddenColors[combinedKeyString]
+                }
+            }
+            return developerOverrideColorString
+        }
+        
+        return nil
     }
 }

--- a/Tests/FioriSwiftUITests/FioriThemeManager/StyleSheetConverterTests.swift
+++ b/Tests/FioriSwiftUITests/FioriThemeManager/StyleSheetConverterTests.swift
@@ -1,0 +1,11 @@
+@testable import FioriThemeManager
+import SwiftUI
+import XCTest
+
+class StyleSheetConverterTests: XCTestCase {
+    func testToColorRemovingWhitespaces() throws {
+        let color = StyleSheetConverter.toColor(value: "                  #FF6000")
+        XCTAssertNotNil(color)
+        XCTAssertEqual(color?.toHex(), "FF6000")
+    }
+}

--- a/Tests/FioriSwiftUITests/FioriThemeManager/StyleSheetParserTests.swift
+++ b/Tests/FioriSwiftUITests/FioriThemeManager/StyleSheetParserTests.swift
@@ -1,0 +1,61 @@
+@testable import FioriThemeManager
+import SwiftUI
+import XCTest
+
+class StyleSheetParserTests: XCTestCase {
+    func testGlobalDefinition() throws {
+        let content = """
+        @primaryLabel:blue;
+        @primaryLabel_darkBackground:blue;
+        """
+        let parser = StyleSheetParser()
+        let styleSheet = try XCTUnwrap(try? parser.loadStylesheetByString(content: content))
+        
+        XCTAssertEqual(styleSheet.globalDefinitions.keys.count, 2)
+        XCTAssertEqual(styleSheet.globalDefinitions["primaryLabel"], "blue")
+        XCTAssertEqual(styleSheet.globalDefinitions["primaryLabel_darkBackground"], "blue")
+    }
+
+    func testPrecedence() throws {
+        let content = """
+        @primaryLabel:red;
+        @primaryLabel_darkBackground:red;
+        @primaryLabel:blue;
+        @primaryLabel_darkBackground:blue;
+        """
+        let parser = StyleSheetParser()
+        let styleSheet = try XCTUnwrap(try? parser.loadStylesheetByString(content: content))
+        
+        XCTAssertEqual(styleSheet.globalDefinitions.keys.count, 2)
+        XCTAssertEqual(styleSheet.globalDefinitions["primaryLabel"], "red")
+        XCTAssertEqual(styleSheet.globalDefinitions["primaryLabel_darkBackground"], "red")
+    }
+
+    func testIngoreNonGlobalDefinitionContent() throws {
+        let content = """
+        
+        BarButton {
+            background-color-top: #9D3024;
+            background-color-bottom: #872A1F;
+            border-color: #681C13;
+            border-width: 1;
+            corner-radius: 7;
+            font-name: @primaryFontNameBold;
+            font-color: #FFFFFF;
+            font-size: 15;
+            text-shadow-color: clear;
+        }
+        """
+        let parser = StyleSheetParser()
+        let styleSheet = try XCTUnwrap(try? parser.loadStylesheetByString(content: content))
+        
+        XCTAssertEqual(styleSheet.globalDefinitions.keys.count, 0)
+    }
+    
+    func testLoadFromURL() throws {
+        let parser = StyleSheetParser()
+        let styleSheet = try XCTUnwrap(try? parser.loadStylesheetByURL(url: Bundle.module.url(forResource: "styleSheet", withExtension: "nss")!))
+        
+        XCTAssertNotEqual(styleSheet.globalDefinitions.keys.count, 0)
+    }
+}

--- a/Tests/FioriSwiftUITests/FioriThemeManager/StyleSheetSettingsIntegrationTests.swift
+++ b/Tests/FioriSwiftUITests/FioriThemeManager/StyleSheetSettingsIntegrationTests.swift
@@ -1,0 +1,79 @@
+@testable import FioriThemeManager
+import SwiftUI
+import UIKit
+import XCTest
+
+let sampleStyleSheetContent = """
+@tintColor:#FF00F9;
+@tintColor2:#FF00F9;
+@tintColorTapState:#FF00F9;
+@header:#fff;
+@headerBlended:#fff;
+@barTransparent:#fff;
+@primaryBackground:#fff;
+@tertiaryBackground:#fff;
+@secondaryGroupedBackground:#fff;
+@secondaryBackground:#f5f6f7;
+@primaryGroupedBackground:#f5f6f7;
+@tertiaryGroupedBackground:#f5f6f7;
+@primaryLabel:#FF6000;
+@tintColor_darkBackground:#FF0000;
+@tintColor2_darkBackground:#FF0000;
+@tintColorTapState_darkBackground:#FF0000;
+@header_darkBackground:#1d232a;
+@headerBlended_darkBackground:#1d232a;
+@barTransparent_darkBackground:#1d232a;
+@primaryBackground_darkBackground:#1d232a;
+@tertiaryBackground_darkBackground:#1d232a;
+@secondaryGroupedBackground_darkBackground:#1d232a;
+@secondaryBackground_darkBackground:#12171c;
+@primaryGroupedBackground_darkBackground:#12171c;
+@tertiaryGroupedBackground_darkBackground:#12171c;
+@primaryLabel_darkBackground:#00FFFF;
+
+// NOT SUPPORTED ⬇️
+Button {
+background-color: @primaryBackgroundColor;
+border-color: #A2A2A2;
+border-width: @primaryBorderWidth;
+font-color: @primaryFontColor;
+font-color-highlighted: #999999;
+font-name: @primaryFontName;
+font-size: 18;
+corner-radius: 7;
+}
+"""
+
+class StyleSheetSettingsIntegrationTests: XCTestCase {
+    override func setUp() {
+        StyleSheetSettings.reset()
+    }
+    
+    func testLoadStylesheetByString() {
+        let originalColor = Color.preferredColor(.primaryLabel)
+        
+        XCTAssertNoThrow(try? StyleSheetSettings.loadStylesheetByString(content: sampleStyleSheetContent))
+        
+        XCTAssertNotEqual(originalColor.toHex(), Color.preferredColor(.primaryLabel).toHex(), "Color.preferredColor should return the color specified in the styleSheet")
+        XCTAssertEqual(ThemeManager.shared.styleSheetOverrides.keys.count, 1)
+    }
+    
+    func testLoadStylesheetByURL() {
+        let originalColor = Color.preferredColor(.primaryLabel)
+        
+        XCTAssertNoThrow(try? StyleSheetSettings.loadStylesheetByURL(url: Bundle.module.url(forResource: "styleSheet", withExtension: "nss")!))
+        
+        XCTAssertNotEqual(originalColor.toHex(), Color.preferredColor(.primaryLabel).toHex(), "Color.preferredColor should return the color specified in the styleSheet")
+        XCTAssertEqual(ThemeManager.shared.styleSheetOverrides.keys.count, 1)
+    }
+    
+    func testReset() {
+        let originalColor = Color.preferredColor(.primaryLabel)
+        
+        XCTAssertNoThrow(try? StyleSheetSettings.loadStylesheetByString(content: sampleStyleSheetContent))
+        StyleSheetSettings.reset()
+        
+        XCTAssertEqual(ThemeManager.shared.styleSheetOverrides.keys.count, 0)
+        XCTAssertEqual(originalColor.toHex(), Color.preferredColor(.primaryLabel).toHex(), "Color.preferredColor should return original color because loaded stylesheet settings shall be discared after `reset`")
+    }
+}

--- a/Tests/FioriSwiftUITests/FioriThemeManager/TestResources/styleSheet.nss
+++ b/Tests/FioriSwiftUITests/FioriThemeManager/TestResources/styleSheet.nss
@@ -1,0 +1,37 @@
+@tintColor:#FF00F9;
+@tintColor2:#FF00F9;
+@tintColorTapState:#FF00F9;
+@header:#fff;
+@headerBlended:#fff;
+@barTransparent:#fff;
+@primaryBackground:#fff;
+@tertiaryBackground:#fff;
+@secondaryGroupedBackground:#fff;
+@secondaryBackground:#f5f6f7;
+@primaryGroupedBackground:#f5f6f7;
+@tertiaryGroupedBackground:#f5f6f7;
+@primaryLabel:#FF6000;
+@tintColor_darkBackground:#FF0000;
+@tintColor2_darkBackground:#FF0000;
+@tintColorTapState_darkBackground:#FF0000;
+@header_darkBackground:#1d232a;
+@headerBlended_darkBackground:#1d232a;
+@barTransparent_darkBackground:#1d232a;
+@primaryBackground_darkBackground:#1d232a;
+@tertiaryBackground_darkBackground:#1d232a;
+@secondaryGroupedBackground_darkBackground:#1d232a;
+@secondaryBackground_darkBackground:#12171c;
+@primaryGroupedBackground_darkBackground:#12171c;
+@tertiaryGroupedBackground_darkBackground:#12171c;
+@primaryLabel_darkBackground:#00FFFF;
+
+Button {
+    background-color: @primaryBackgroundColor;
+    border-color: #A2A2A2;
+    border-width: @primaryBorderWidth;
+    font-color: @primaryFontColor;
+    font-color-highlighted: #999999;
+    font-name: @primaryFontName;
+    font-size: 18;
+    corner-radius: 7;
+}

--- a/Tests/FioriSwiftUITests/FioriThemeManager/ThemeManagerTests.swift
+++ b/Tests/FioriSwiftUITests/FioriThemeManager/ThemeManagerTests.swift
@@ -4,6 +4,10 @@ import UIKit
 import XCTest
 
 class ThemeManagerTests: XCTestCase {
+    override func tearDown() {
+        ThemeManager.shared.reset()
+    }
+    
     func testLatestColorStyle() throws {
         XCTAssertEqual(ColorStyle.allCases.count, 194)
     }
@@ -68,5 +72,47 @@ class ThemeManagerTests: XCTestCase {
         XCTAssertEqual(v4Style_negative, HexColor(lightColor: "FF453A", darkColor: "BB0000"))
         let v4FutureStyle_primaryLabel = tm.hexColor(for: .primaryLabel)
         XCTAssertEqual(v4FutureStyle_primaryLabel, HexColor(lightColor: "FFFFFF", darkColor: "32363A"))
+    }
+    
+    func testSetColor() throws {
+        let tm = ThemeManager.shared
+        tm.setPaletteVersion(.v7)
+
+        XCTAssertEqual(tm.developerOverrides.keys.count, 0)
+        
+        tm.setColor(.red, for: .grey1, variant: .light)
+        tm.setColor(.blue, for: .grey1, variant: .dark)
+        
+        XCTAssertEqual(tm.developerOverrides.keys.count, 1)
+        XCTAssertEqual(tm.developerOverrides[.grey1]?[.light], .red)
+        XCTAssertEqual(tm.developerOverrides[.grey1]?[.dark], .blue)
+    }
+    
+    func testSetColorIntegration() throws {
+        let tm = ThemeManager.shared
+        tm.setPaletteVersion(.v7)
+        
+        tm.setColor(.red, for: .grey1, variant: .light)
+        XCTAssertEqual(Color.preferredColor(.grey1, background: .darkConstant), Color.red)
+    }
+    
+    func testSetHexColor() throws {
+        let tm = ThemeManager.shared
+        tm.setPaletteVersion(.v7)
+
+        XCTAssertEqual(tm.developerOverrides.keys.count, 0)
+        
+        tm.setHexColor("223548FF", for: .grey1, variant: .light)
+        
+        XCTAssertEqual(tm.developerOverrides.keys.count, 1)
+        XCTAssertEqual(tm.developerOverrides[.grey1]?[.light]?.toHex(), "223548")
+    }
+    
+    func testSetHexColorIntegration() throws {
+        let tm = ThemeManager.shared
+        tm.setPaletteVersion(.v7)
+        
+        tm.setHexColor("223548FF", for: .grey1, variant: .light)
+        XCTAssertEqual(Color.preferredColor(.grey1, background: .darkConstant).toHex(), "223548")
     }
 }

--- a/jazzy/FioriThemeManager_README.md
+++ b/jazzy/FioriThemeManager_README.md
@@ -7,3 +7,68 @@ All Fiori Colors are dynamic colors, which means they will adjust based on iOS A
 72 is a SAP patent typeface that delivers great reading experience to our users. You can get these fonts using `Font.fiori(forTextStyle:)` or `Font.fioriCondensed(forTextStyle:)`. Note that these fonts support Dynamic Type out of the box. If you want the fonts with fixed size, use `Font.fiori(fixedSize:)` or `Font.fioriCondensed(fixedSize:)` instead.
 
 > Custom fonts need to be loaded and registered during App's runtime. Make sure you call `Font.registerFioriFonts()` inside `application(_:didFinishLaunchingWithOptions:)` of your `AppDelegate`.
+
+## Color Palette Customization
+
+The cases of the `ColorStyle` enum correspond to the colors of the [Fiori for iOS Design Guidelines palette](https://experience.sap.com/fiori-design-ios/article/colors/).
+
+Any `FioriSwiftUICore` or `FioriCharts` views will request a color for a given color style through calling an extension method
+
+Example:
+
+```swift
+Color.preferredColor(.primaryLabel)
+```
+
+You can override the global constants used for the `ColorStyle` case
+- programmatically
+- through a style sheet
+
+### Programmatically
+
+Use one of the following methods:
+
+- `ThemeManager.setColor(_:for:variant:)`
+- `ThemeManager.setHexColor(_:for:variant:)`
+
+Example:
+
+```swift
+ThemeManager.shared.setColor(.mint, for: .primaryLabel)
+```
+
+###  Style Sheet
+
+Add global color definitions to the top of your style sheet file, using the following pattern: a leading `@` symbol, then the variable key followed by `:` and the variable value and finally end the line with `;` .
+
+Example:
+
+```swift
+@tintColor: blue;                              /* equivalent to @tintColor_lightBackground */
+@tintColor_darkBackground: "12171CFF";
+@tintColorTapState_lightBackground: "F5F6F7FF";    /* equivalent to @tintColorTapState */
+@tintColorTapState_darkBackground : purple;
+```
+
+The strings used as the variable name should match the string values of the `ColorStyle` enums, and optionally append `_lightBackground` or `_darkBackground`, to specialize the `background` parameter passed to the `static Color.preferredColor(_:background:interface:display:)` invocation.
+
+Global color definitions in the style sheet file modify their corresponding attributes. All other color definitions for which an override is not provided retain their original values.  
+
+As per the Fiori guidelines, when the background is not explicitly specified it defaults to the light background. For example, the global constants, `tintColor` and `tintColor_lightBackground` are equivalent.  Similarly, `primary1` and `primary1_lightBackground` are equivalent.
+
+When overriding global constants in the style sheet file, if two equivalent constants are overridden, then the order of precedence is as shown below, where `Color.red` will be used for all invocations of `Color.preferredColor(.tintColor)` or `Color.preferredColor(.tintColor, background: .lightBackground)` :
+
+```swift
+@tintColor_lightBackground: red; /* This takes precedence over tintColor */
+@tintColor: blue;
+@tintColorDark: green;
+```
+
+> `tintColor` and `tintColor_lightBackground` also have another equivalent constant : `tintColorDark`. This has the last precedence. The dark background variant of it is `tintColorLight`, that is, `tintColorLight` and `tintColor_darkBackground` are equivalent.
+> Similarly `tintColorTapStateDark` is equivalent to `tintColorTapState` and `tintColorTapState_lightBackground` whereas `tintColorTapStateLight` and `tintColorTapState_darkBackground` are equivalent.
+
+```swift
+try? StyleSheetSettings.loadStylesheetByString(content: "@tintColor: blue;")
+
+// or load a style sheet from a local file with StyleSheetSettings.loadStylesheetByURL(url:)
+```


### PR DESCRIPTION
This PR introduces the possibility to **override the color definitions of an existing color palette** in two ways

- programmatically

  ```Swift
  ThemeManager.shared.setColor(.red, for: .primaryLabel, variant: .light)
  
  // or
  
  ThemeManager.shared.setHexColor("FF0000", for: .primaryLabel, variant: .light)
  ```

- through a style sheet

  ```Swift
   var colorOverrides = """
   @primaryLabel:#FF6000;
   @primaryLabel_darkBackground:#00FFFF;
   """
   
   try? StyleSheetSettings.loadStylesheetByString(content: colorOverrides)
  
  // or use static StyleSheetSettings.loadStylesheetByURL(url:) to load from a local file
  ```

Related to this new functionality the PR includes

- documentation for `FioriThemeManager` module
- integration tests
- programming and style sheet usage examples in ExamplesApp

  https://user-images.githubusercontent.com/4176826/192340515-9bf490ea-42b6-4a8a-b365-d0ada68dbe15.mp4

SAP BTP SDK for iOS customers will be able to reuse existing style sheet files (`.nss`) and color-related global definitions will be applied when calling`StyleSheetSettings.loadStylesheetByURL(url:)` 

> Other information in the style sheet file, i.e. styles for components like Button, will be ignored.

This is accomplished by a minimal implementation which does **not** rely

- on the open-source framework NUI
- on `SAPFiori.xcframework`