### PR TITLE
ci: use actions/checkout@v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       DEVELOPER_DIR: /Applications/${{ matrix.xcode }}.app/Contents/Developer
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build and Test
       run: set -o pipefail && xcodebuild -enableCodeCoverage YES -scheme FioriSwiftUI-Package -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 11' clean build test | xcpretty
     - name: Create code coverage report
@@ -37,7 +37,7 @@ jobs:
     if: github.event_name == 'push' || github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Get coverage from build job

--- a/.github/workflows/dependencyManagement.yml
+++ b/.github/workflows/dependencyManagement.yml
@@ -7,7 +7,7 @@ jobs:
   spm-dep-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Check Swift package dependencies
       uses: MarcoEidinger/swift-package-dependencies-check@1.1.0
       with:
@@ -26,7 +26,7 @@ jobs:
   owasp-dep-check:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Run dependency-check (experimental for Swift)
       run: |
         brew install dependency-check

--- a/.github/workflows/jazzy.yml
+++ b/.github/workflows/jazzy.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install
         run: |
           brew install sourcekitten

--- a/.github/workflows/pr_only.yml
+++ b/.github/workflows/pr_only.yml
@@ -19,7 +19,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@v4
@@ -29,14 +29,14 @@ jobs:
   ReuseComplianceCheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: REUSE Compliance Check
         uses: fsfe/reuse-action@v1.1
 
   CodeFormattingCheck:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Cache Mint packages
         id: mint-cache
         uses: actions/cache@v2
@@ -63,7 +63,7 @@ jobs:
 #       DEVELOPER_DIR: /Applications/Xcode_11.6.app/Contents/Developer
 #     steps:
 #     - name: Checkout Repo
-#       uses: actions/checkout@v2
+#       uses: actions/checkout@v3
 #     - name: Check for file changes in Sources folder
 #       uses: getsentry/paths-filter@v2
 #       id: changes
@@ -72,7 +72,7 @@ jobs:
 #           src:
 #             - 'Sources/**'
 #     - name: Checkout Snapshot references
-#       uses: actions/checkout@v2
+#       uses: actions/checkout@v3
 #       if: steps.changes.outputs.src == 'true'
 #       with:
 #         repository: SAP/cloud-sdk-ios-fiori-snapshot-references
@@ -106,9 +106,9 @@ jobs:
   LocalizableTextCommentsCheck:
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
         - name: Checkout Repo
-          uses: actions/checkout@v2
+          uses: actions/checkout@v3
         - name: Check for changes in .strings files
           uses: getsentry/paths-filter@v2
           id: changes

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout the latest code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Automatic Rebase

--- a/.github/workflows/recordSnapshotImages.yml
+++ b/.github/workflows/recordSnapshotImages.yml
@@ -25,9 +25,9 @@ jobs:
       DEVELOPER_DIR: /Applications/Xcode_${{ github.event.inputs.xcodeVersion }}.app/Contents/Developer
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Checkout Snapshot references
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: SAP/cloud-sdk-ios-fiori-snapshot-references
         path: Apps/Examples/cloud-sdk-ios-fiori-snapshot-references

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
         token: ${{ secrets.PAT_ME_REPO }} # use PAT to being able to push to protected branch later on

--- a/.github/workflows/tooling.yml
+++ b/.github/workflows/tooling.yml
@@ -14,7 +14,7 @@ jobs:
     if: (github.repository == 'SAP/cloud-sdk-ios-fiori' && github.event_name == 'schedule') || github.event_name == 'pull_request'
     runs-on: macOS-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       # The cache action will attempt to restore a cache based on the key.
       # When the action finds a cache, the action restores the cached files to the path you configure.
       # If there is no exact match, the action creates a new cache entry if the job completes successfully.

--- a/.github/workflows/xcframeworks.yml
+++ b/.github/workflows/xcframeworks.yml
@@ -16,7 +16,7 @@ jobs:
       DEVELOPER_DIR: /Applications/Xcode_13.0.app/Contents/Developer
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.ref }}
     - run: brew install xcodegen


### PR DESCRIPTION
actions/checkout@v2 uses Node.js 12 which is deprecated
actions/checkout@v3 uses Node.js 16

See https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/ for more details.

Command to replace in all yml files:

`find . -type f -name "*.yml" -print0 | xargs -0 sed -i '' -e 's/actions\/checkout@v2/actions\/checkout@v3/g'`
