### PR TITLE
chore: 🤖 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [3.0.1](https://github.com/SAP/cloud-sdk-ios-fiori/compare/3.0.0...3.0.1) (2022-11-03)
+### Bug Fixes
+
+* 🐛 [BCP: 675290] improve selection as same as rombichart ([#464](https://github.com/SAP/cloud-sdk-ios-fiori/issues/464)) ([86114e1](https://github.com/SAP/cloud-sdk-ios-fiori/commit/86114e10d55b803de825b0151561835c3bfe52cc))
+* 🐛 3-digit hex color is not parsed correctly ([e4a62e0](https://github.com/SAP/cloud-sdk-ios-fiori/commit/e4a62e0f18ff2709826fecc8f2fa5ba8495d6a74)), closes [#477](https://github.com/SAP/cloud-sdk-ios-fiori/issues/477)
+
 ## [3.0.0](https://github.com/SAP/cloud-sdk-ios-fiori/compare/2.2.0...3.0.0) (2022-09-28)
 ### ⚠ BREAKING CHANGES
 


### PR DESCRIPTION
Omitted `sizeThatFits` feature that was added to mainly support auto-sizing chart card in UIKit and is not supposed to be used by SwiftUI consumers.

I will create tag and GitHub release for 3.0.1 once merged into `main` branch

