### PR TITLE
fix: 🐛 [BCP: 2270182630] fix tap on white space in DataTable

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/DataTable/DataTableExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/DataTable/DataTableExample.swift
@@ -228,8 +228,8 @@ public enum TestRowData {
         let header = TableRowItem(leadingAccessories: [], trailingAccessory: nil, data: titles)
         let model = TableModel(headerData: header, rowData: res, isHeaderSticky: isHeaderSticky, isFirstColumnSticky: isFirstColumnSticky, isPinchZoomEnable: isPinchZoomEnable, showListView: showListView)
         model.columnAttributes = self.generateColumnAttributes(column: column)
-        model.didSelectRowAt = { _ in
-            print(model.selectedIndexes)
+        model.didSelectRowAt = { rowIndex in
+            print("Tapped row \(rowIndex)")
         }
         model.selectedIndexes = [0]
         

--- a/Sources/FioriSwiftUICore/DataTable/DataTable.swift
+++ b/Sources/FioriSwiftUICore/DataTable/DataTable.swift
@@ -7,8 +7,8 @@ import SwiftUI
  ```
  let model = TableModel(headerData: header, rowData: res, isFirstRowSticky: true, isFirstColumnSticky: true, showListView: false)
  model.columnAttributes = ...
- model.didSelectRowAt = { _ in
-     print(model.selectedIndexes)
+ model.didSelectRowAt = { rowIndex in
+    print("Tapped row \(rowIndex)")
  }
  model.selectedIndexes = [2, 3]
  DataTable(model: model)

--- a/Sources/FioriSwiftUICore/DataTable/ItemView.swift
+++ b/Sources/FioriSwiftUICore/DataTable/ItemView.swift
@@ -133,6 +133,7 @@ struct ItemView: View {
         }
         .padding(contentInset)
         .frame(width: cellWidth, height: cellHeight)
+        .contentShape(Rectangle())
         .gesture(tapGesture)
     }
     


### PR DESCRIPTION
Cherrypick from main