### PR TITLE
fix: 🐛 searchable list selection handler

### DIFF
--- a/Sources/FioriSwiftUICore/Views/SearchableListView+View.swift
+++ b/Sources/FioriSwiftUICore/Views/SearchableListView+View.swift
@@ -171,7 +171,7 @@ public extension SearchableListView where CancelActionView == _ConditionalConten
         doneAction: Action? = Action(model: _DoneActionDefault())
     ) {
         self.init(cancelAction: cancelAction, doneAction: doneAction)
-        var selectionBuffer: Set<ID>?
+        var selectionBuffer = selection?.wrappedValue
         var content = SearchableListContent(data: data,
                                             id: id,
                                             children: children,


### PR DESCRIPTION
Without updates, selection should not be cleared.