### PR TITLE
fix PR workflow which fails for CodeFormattingCheck

### DIFF
--- a/Mintfile
+++ b/Mintfile
@@ -1,3 +1,3 @@
 nicklockwood/SwiftFormat@0.47.3
 realm/SwiftLint@0.41.0
-krzysztofzablocki/Sourcery@1.1.1
+krzysztofzablocki/Sourcery@1.2.0


### PR DESCRIPTION
PR workflow fails when running code formatting as `mint bootstrap` will try to install tools specified in `Mintfile` but the tool `sourcery` with its version 1.1.1 can no longer be resolved by SPM

<img width="1277" alt="Screenshot 2023-02-24 at 7 20 46 AM" src="https://user-images.githubusercontent.com/4176826/221106934-d460d5e5-5557-4cb8-91a5-f9d25bbdc4e6.png">

The easiest fix for this CI issue is to update sourcery version in `Mintfile`.
Note: I have not re-generated files generated by sourcery so if people run `mint bootstrap` locally and re-generate files then at least the headers for touched files would change.

FYI: An alternative would be to change the workflow to run `mint install nicklockwood/SwiftFormat@0.47.3` only but then two files would need to change if we decide to use a different version of SwiftFormat so I do not favor that alternative.