### PR TITLE
ci: 🎡 remove pull_request_target as trigger condition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
-  pull_request_target:
   workflow_dispatch:
 
 jobs:
@@ -40,7 +38,7 @@ jobs:
 
   sonar:
     needs: build
-    if: github.event_name == 'push' || github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
+    if: github.event_name == 'push' && github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ***
 
 [![Build and Test Status Check](https://github.com/SAP/cloud-sdk-ios-fiori/workflows/CI/badge.svg)](https://github.com/SAP/cloud-sdk-ios-fiori/actions?query=workflow%3A%22CI%22)
-[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=cloud-sdk-ios-fiori&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=cloud-sdk-ios-fiori)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=SAP_cloud-sdk-ios-fiori&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=SAP_cloud-sdk-ios-fiori)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/3962/badge?latest)](https://bestpractices.coreinfrastructure.org/projects/3962)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)


### PR DESCRIPTION
pull_request_target as a trigger condition was introduced for being able to trigger sonar scan for pull requests from forks but  we don't make much use of this and using pul_request_target has disadvantages as the workflow runs against the base  of the pull request which can cause issues

Plus minor other changes