### PR TITLE
fix: incorrect color value for the elevatedContrastLight variant

### DIFF
--- a/Sources/FioriThemeManager/ThemeManager.swift
+++ b/Sources/FioriThemeManager/ThemeManager.swift
@@ -229,6 +229,10 @@ public class ThemeManager {
                     return "contrastDarkBackground"
                 case .contrastDark:
                     return "contrastLightBackground"
+                case .elevatedContrastLight:
+                    return "elevatedContrastDarkBackground"
+                case .elevatedContrastDark:
+                    return "elevatedContrastLightkBackground"
                 default:
                     return "darkBackground"
                 }

--- a/Tests/FioriSwiftUITests/FioriThemeManager/StyleSheetParserTests.swift
+++ b/Tests/FioriSwiftUITests/FioriThemeManager/StyleSheetParserTests.swift
@@ -58,4 +58,42 @@ class StyleSheetParserTests: XCTestCase {
         
         XCTAssertNotEqual(styleSheet.globalDefinitions.keys.count, 0)
     }
+    
+    func testBCP2370020386() throws {
+        XCTAssertNoThrow(try? StyleSheetSettings.loadStylesheetByURL(url: Bundle.module.url(forResource: "BCP2370020386", withExtension: "nss")!))
+        
+        #if os(iOS)
+        // tintColor light variant
+        var tintColor = Color.preferredColor(.tintColor, background: .darkConstant, interface: .baseConstant, display: .normalConstant).toHex()
+        XCTAssertEqual(tintColor!, "0CBB74", "Incorrect tintColor light variant")
+        
+        // tintColor dark variant
+        tintColor = Color.preferredColor(.tintColor, background: .lightConstant, interface: .baseConstant, display: .normalConstant).toHex()
+        XCTAssertEqual(tintColor!, "0070F2", "Incorrect tintColor dark variant")
+        
+        // tintColor elevatedLight variant
+        tintColor = Color.preferredColor(.tintColor, background: .darkConstant, interface: .elevatedConstant, display: .normalConstant).toHex()
+        XCTAssertEqual(tintColor!, "0CBB74", "Incorrect tintColor elevatedLight variant")
+        
+        // tintColor elevatedDark variant
+        tintColor = Color.preferredColor(.tintColor, background: .lightConstant, interface: .elevatedConstant, display: .normalConstant).toHex()
+        XCTAssertEqual(tintColor!, "0070F2", "Incorrect tintColor elevatedDark variant")
+        
+        // tintColor contrastLight variant
+        tintColor = Color.preferredColor(.tintColor, background: .darkConstant, interface: .baseConstant, display: .highConstant).toHex()
+        XCTAssertEqual(tintColor!, "0CBB74", "Incorrect tintColor contrastLight variant")
+        
+        // tintColor contrastDark variant
+        tintColor = Color.preferredColor(.tintColor, background: .lightConstant, interface: .baseConstant, display: .highConstant).toHex()
+        XCTAssertEqual(tintColor!, "0046A8", "Incorrect tintColor contrastDark variant")
+        
+        // tintColor elevatedContrastLight variant
+        tintColor = Color.preferredColor(.tintColor, background: .darkConstant, interface: .elevatedConstant, display: .highConstant).toHex()
+        XCTAssertEqual(tintColor!, "0CBB74", "Incorrect tintColor elevatedContrastLight variant")
+        
+        // tintColor elevatedContrastDark variant
+        tintColor = Color.preferredColor(.tintColor, background: .lightConstant, interface: .elevatedConstant, display: .highConstant).toHex()
+        XCTAssertEqual(tintColor!, "0070F2", "Incorrect tintColor elevatedContrastDark variant")
+        #endif
+    }
 }

--- a/Tests/FioriSwiftUITests/FioriThemeManager/TestResources/BCP2370020386.nss
+++ b/Tests/FioriSwiftUITests/FioriThemeManager/TestResources/BCP2370020386.nss
@@ -1,0 +1,8 @@
+/*
+BCP: 2370020386
+*/
+
+@tintColor_darkBackground:#0cbb74;
+@tintColor_elevatedDarkBackground:#0cbb74;
+@tintColor_contrastDarkBackground:#0cbb74;
+@tintColor_elevatedContrastDarkBackground:#0cbb74;


### PR DESCRIPTION
Problem was found in processing input parameters mapping to variant.
Fix is to add cases of switch statement for the missing cases.