### PR TITLE
fix: 🐛 [BCP:2370041675] dismiss keyboard when signing

### DIFF
--- a/Sources/FioriSwiftUICore/Views/SignatureCaptureView+View.swift
+++ b/Sources/FioriSwiftUICore/Views/SignatureCaptureView+View.swift
@@ -132,9 +132,8 @@ extension SignatureCaptureView: View {
                             .stroke(Color.preferredColor(.separator), lineWidth: 1)
                     )
                     .onTapGesture {
-                        withAnimation {
-                            self.isEditing = true
-                        }
+                        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+                        self.isEditing = true
                     }
             }
 
@@ -166,6 +165,7 @@ extension SignatureCaptureView: View {
                     .simultaneousGesture(
                         TapGesture()
                             .onEnded { _ in
+                                UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
                                 clear()
                                 onDelete()
                                 isReenterTapped = true
@@ -212,6 +212,7 @@ extension SignatureCaptureView: View {
                         .simultaneousGesture(
                             TapGesture()
                                 .onEnded { _ in
+                                    UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
                                     self.isEditing = true
                                 }
                         )


### PR DESCRIPTION
Cherry-picked from integrationSAPFiori9.1

fix: 🐛 [BCP:2370041675] dismiss keyboard when signing (cherry picked from commit 8c809613782256afa861398662bc461f262cad4d)