### PR TITLE
chore: 🤖 update pre-commit to sync up with CI job

### DIFF
--- a/Sources/FioriSwiftUICore/DataTable/ItemView.swift
+++ b/Sources/FioriSwiftUICore/DataTable/ItemView.swift
@@ -324,8 +324,8 @@ struct FocusedEditingView: View {
                 
                                               self.layoutManager.model.valueDidChange?(DataTableChange(rowIndex: rowIndex, columnIndex: columnIndex, value: .text(editingText), text: editingText, selectedIndex: selectedIndex))
                                           })
-                                          .listBackground(Color.preferredColor(.primaryBackground))
-                                          .navigationTitle(data.1)
+                    .listBackground(Color.preferredColor(.primaryBackground))
+                    .navigationTitle(data.1)
             } else {
                 return EmptyView()
             }

--- a/scripts/githooks/pre-commit
+++ b/scripts/githooks/pre-commit
@@ -1,3 +1,3 @@
 #!/bin/bash
 # exclude files in Sources/FioriSwiftUICore/_generated/ (needed as exclude option in .swiftformat config file is not honored by git-format-staged)
-npx git-format-staged --formatter 'swiftformat stdin --stdinpath "{}"' '*.swift' '!Sources/FioriSwiftUICore/_generated/*'
+npx git-format-staged --formatter 'mint run swiftformat stdin --stdinpath "{}"' '*.swift' '!Sources/FioriSwiftUICore/_generated/*'


### PR DESCRIPTION
update pre-commit to sync up with CI job, also one swift file whose format was overridden by a previous commit

BREAKING CHANGE: 🧨 No