### PR TITLE
docs: ✏️ build documentation with DocC and host on swiftpackageindex.com

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,5 @@
+version: 1
+builder:
+  configs:
+    - documentation_targets: [FioriThemeManager, FioriCharts]
+      platform: ios

--- a/Sources/FioriCharts/FioriCharts.docc/Info.plist
+++ b/Sources/FioriCharts/FioriCharts.docc/Info.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CDAppleDefaultAvailability</key>
+	<dict>
+		<key>FioriThemeManager</key>
+		<array>
+			<dict>
+				<key>name</key>
+				<string>iOS</string>
+				<key>version</key>
+				<string>15.0</string>
+			</dict>
+		</array>
+	</dict>
+</dict>
+</plist>

--- a/Sources/FioriCharts/FioriCharts.docc/LandingPage.md
+++ b/Sources/FioriCharts/FioriCharts.docc/LandingPage.md
@@ -1,0 +1,7 @@
+# ``FioriCharts``
+
+Enterprise-ready charts in SwiftUI
+
+## Overview
+
+Easily add new chart components (donut, bullet, stocks, etc.) while modernizing the existing supported charts with pinch-to-zoom, pan, and new design features.

--- a/Sources/FioriThemeManager/FioriThemeManager.docc/CustomizeColorPalette.md
+++ b/Sources/FioriThemeManager/FioriThemeManager.docc/CustomizeColorPalette.md
@@ -1,0 +1,56 @@
+# Customize the Color Palette
+
+Override the global constants used for the ``ColorStyle`` cases
+
+## Overview
+
+You can choose one of the two options.
+
+### Programmatically
+
+Use one of the following methods:
+
+- ``ThemeManager/setColor(_:for:variant:)``
+- ``ThemeManager/setHexColor(_:for:variant:)``
+
+Example:
+
+```swift
+ThemeManager.shared.setColor(.mint, for: .primaryLabel)
+```
+
+###  Style Sheet
+
+Add global color definitions to the top of your style sheet file, using the following pattern: a leading `@` symbol, then the variable key followed by `:` and the variable value and finally end the line with `;` .
+
+Example:
+
+```swift
+@tintColor: blue;                              /* equivalent to @tintColor_lightBackground */
+@tintColor_darkBackground: "12171CFF";
+@tintColorTapState_lightBackground: "F5F6F7FF";    /* equivalent to @tintColorTapState */
+@tintColorTapState_darkBackground : purple;
+```
+
+The strings used as the variable name should match the string values of the ``ColorStyle`` enums, and optionally append `_lightBackground` or `_darkBackground`, to specialize the `background` parameter passed to the static ``SwiftUI/Color/preferredColor(_:background:interface:display:)`` invocation.
+
+Global color definitions in the style sheet file modify their corresponding attributes. All other color definitions for which an override is not provided retain their original values.  
+
+As per the Fiori guidelines, when the background is not explicitly specified it defaults to the light background. For example, the global constants, ``ColorStyle/tintColor`` and `tintColor_lightBackground` are equivalent.  Similarly, ``ColorStyle/primary1`` and `primary1_lightBackground` are equivalent.
+
+When overriding global constants in the style sheet file, if two equivalent constants are overridden, then the order of precedence is as shown below, where `Color.red` will be used for all invocations of `Color.preferredColor(.tintColor)` or `Color.preferredColor(.tintColor, background: .lightBackground)` :
+
+```swift
+@tintColor_lightBackground: red; /* This takes precedence over tintColor */
+@tintColor: blue;
+@tintColorDark: green;
+```
+
+> `tintColor` and `tintColor_lightBackground` also have another equivalent constant : `tintColorDark`. This has the last precedence. The dark background variant of it is `tintColorLight`, that is, `tintColorLight` and `tintColor_darkBackground` are equivalent.
+> Similarly `tintColorTapStateDark` is equivalent to `tintColorTapState` and `tintColorTapState_lightBackground` whereas `tintColorTapStateLight` and `tintColorTapState_darkBackground` are equivalent.
+
+```swift
+try? StyleSheetSettings.loadStylesheetByString(content: "@tintColor: blue;")
+
+// or load a style sheet from a local file with StyleSheetSettings.loadStylesheetByURL(url:)
+```

--- a/Sources/FioriThemeManager/FioriThemeManager.docc/Info.plist
+++ b/Sources/FioriThemeManager/FioriThemeManager.docc/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CDAppleDefaultAvailability</key>
+	<dict>
+		<key>FioriThemeManager</key>
+		<array>
+			<dict>
+				<key>name</key>
+				<string>watchOS</string>
+				<key>version</key>
+				<string>7.0</string>
+			</dict>
+			<dict>
+				<key>name</key>
+				<string>iOS</string>
+				<key>version</key>
+				<string>15.0</string>
+			</dict>
+		</array>
+	</dict>
+</dict>
+</plist>

--- a/Sources/FioriThemeManager/FioriThemeManager.docc/LandingPage.md
+++ b/Sources/FioriThemeManager/FioriThemeManager.docc/LandingPage.md
@@ -1,0 +1,60 @@
+# ``FioriThemeManager``
+
+Use Fiori Colors, Fonts and Icons in your SwiftUI views
+
+## Overview
+
+This module provides APIs and the technical implementation for the following aspects of the [Fiori for iOS Design Language](https://experience.sap.com/fiori-design-ios/):
+
+- [**Colors**](https://experience.sap.com/fiori-design-ios/article/colors/)
+- [**Typography**](https://experience.sap.com/fiori-design-ios/article/typography/)
+- [**Iconography**](``FioriIcon``)
+
+### Colors
+
+A **color palette** consists of a set of vibrant colors providing a flexible yet consistent color system and distinct look to all SAP products. All Fiori Colors are dynamic colors, which means they will adjust based on iOS Appearance settings (Light/Dark).
+
+SDK-provided SwiftUI already use the color palette.
+
+Use ``SwiftUI/Color/preferredColor(_:background:interface:display:)`` to leverage Fiori colors in your SwiftUI views. 
+
+```swift
+// Example
+var body: some View {
+  Circle()
+    .fill(Color.preferredColor(.primary))
+}
+```
+
+You can override the color values defined in the color palette and therefore influence the branding of your and SDK-provided SwiftUI views. See <doc:CustomizeColorPalette> for more information.
+
+### Typography
+
+**SAP 72** is the primary font for SAP Fiori for iOS.
+
+> Important: Call ``SwiftUI/Font/registerFioriFonts()`` inside `application(_:didFinishLaunchingWithOptions:)` of your `AppDelegate` to register 72 as a custom font. Otherwise the font won't be loaded.
+
+SDK-provided SwiftUI already use the font.
+
+Use ``SwiftUI/Font/fiori(forTextStyle:weight:isItalic:isCondensed:)`` to leverage 72 font in your SwiftUI views.
+
+```swift
+// example
+var body: some View {
+  Text("Hello, World")
+    .font(.fiori(forTextStyle: .headline))
+}
+```
+
+If you want the fonts with fixed size, use ``SwiftUI/Font/fiori(fixedSize:weight:isItalic:isCondensed:)`` instead.
+
+### Iconography
+
+The SAP Fiori for iOS icon library (``FioriIcon``) identifies a standard subset of SF Symbols that are aligned with the SAP Fiori design language. This allows us to have a robust collection that offers the familiarity, accessibility, and cohesiveness SAP customers expect across different platforms while still being consistent with the iOS experience.
+
+```swift
+// example
+var body: some View {
+  Image(fioriName: "fiori.e.care")
+}
+```


### PR DESCRIPTION
FioriSwiftUI is currently accessible via the Swift Package Index (https://swiftpackageindex.com/SAP/cloud-sdk-ios-fiori).

This PR enhances our Swift Package Index experience by leveraging its auto-building and auto-hosting DocC feature to build and host the API Reference documentation for `FioriThemeManager` and `FioriCharts` .

## Motivation

Give the API reference a facelift using [Apple's Swift Documentation Compiler](https://www.swift.org/documentation/docc/) (DocC).

DocC offers a similar feature set like `Jazzy` but with a modern look, symbol search, platform availability indicators and theming options.

## Changes
- Add a `.spi.yml` file
[See SPI docs](https://blog.swiftpackageindex.com/posts/auto-generating-auto-hosting-and-auto-updating-docc-documentation/) on how this auto-hosted, auto-generated docs works. It's really neat! We could even have this replace our hosted reference docs entirely 👀.
- Add documentation catalogs (`.docc`) and respective material for a better generation result

## Expected results

![Screenshot 2023-11-15 at 9 13 28 AM](https://github.com/SAP/cloud-sdk-ios-fiori/assets/4176826/7651c061-dd9e-4455-8741-73d896858ba3)

![Screenshot 2023-11-15 at 9 11 31 AM](https://github.com/SAP/cloud-sdk-ios-fiori/assets/4176826/3090f6b8-a3ea-4570-baeb-ee8148fa2f34)

## Future changes

Suppose the result is as expected and satisfying. Any `Jazzy` related information (e.g. overview pages, GitHub action to build Jazzy Doc and host as GitHub page, etc.) can be removed from the repository.