### PR TITLE
chore: make required modules for FioriSwiftUI target/library also available for MacCatalyst

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
     targets: [
         .target(
             name: "FioriSwiftUI",
-            dependencies: [.target(name: "FioriSwiftUICore", condition: .when(platforms: [.iOS, .visionOS]))]
+            dependencies: [.target(name: "FioriSwiftUICore", condition: .when(platforms: [.iOS, .macCatalyst, .visionOS]))]
         ),
         .target(
             name: "FioriCharts",
@@ -38,8 +38,8 @@ let package = Package(
         .target(
             name: "FioriSwiftUICore",
             dependencies: [
-                .target(name: "FioriThemeManager", condition: .when(platforms: [.iOS, .visionOS])),
-                .target(name: "FioriCharts", condition: .when(platforms: [.iOS, .visionOS]))
+                .target(name: "FioriThemeManager", condition: .when(platforms: [.iOS, .macCatalyst, .visionOS])),
+                .target(name: "FioriCharts", condition: .when(platforms: [.iOS, .macCatalyst, .visionOS]))
             ],
             resources: [.process("_localization")]
         ),


### PR DESCRIPTION
I observed this issue when trying to use FioriSwiftUI package in a framework and using FioriSwiftUI umbrella library. The framework, when compiling for MacCatalyst, complains for `import FioriThemeManager`.

The conditional target handling, introduced for supporting visionOS, requires us to specify the macCatalyst platform. A regression issue but no customer noticed that because we didn't create a new release yet.