### PR TITLE
chore: 🤖[HCPSDKFIORIUIKIT-2608] Clean up warnings : FioriThemeManager…

### DIFF
--- a/Sources/FioriCharts/Model/ChartAxisAttributes.swift
+++ b/Sources/FioriCharts/Model/ChartAxisAttributes.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SwiftUI
+import Combine
 
 /**
  Identifiers for different axes presented by the chart.

--- a/Sources/FioriCharts/Model/ChartLineAttributes.swift
+++ b/Sources/FioriCharts/Model/ChartLineAttributes.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SwiftUI
 import FioriThemeManager
+import Combine
 
 /// Gridline properties for an Axis.
 public class ChartGridlineAttributes: ObservableObject, Identifiable, NSCopying, CustomStringConvertible {

--- a/Sources/FioriCharts/Model/ChartLineAttributes.swift
+++ b/Sources/FioriCharts/Model/ChartLineAttributes.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SwiftUI
+import FioriThemeManager
 
 /// Gridline properties for an Axis.
 public class ChartGridlineAttributes: ObservableObject, Identifiable, NSCopying, CustomStringConvertible {

--- a/Sources/FioriCharts/Model/ChartPointAttributes.swift
+++ b/Sources/FioriCharts/Model/ChartPointAttributes.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SwiftUI
 import FioriThemeManager
+import Combine
 
 public class ChartPointAttributes: ObservableObject, Identifiable, NSCopying {
     /// Indicates if the point is hidden or visible.

--- a/Sources/FioriCharts/Model/ChartPointAttributes.swift
+++ b/Sources/FioriCharts/Model/ChartPointAttributes.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SwiftUI
+import FioriThemeManager
 
 public class ChartPointAttributes: ObservableObject, Identifiable, NSCopying {
     /// Indicates if the point is hidden or visible.

--- a/Sources/FioriCharts/Model/ChartSeriesAttributes.swift
+++ b/Sources/FioriCharts/Model/ChartSeriesAttributes.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SwiftUI
+import Combine
 
 /// Each series has its own ChartSeriesAttributes
 public class ChartSeriesAttributes: ObservableObject, Identifiable, NSCopying {

--- a/Sources/FioriCharts/Model/ChartSeriesPalette.swift
+++ b/Sources/FioriCharts/Model/ChartSeriesPalette.swift
@@ -1,6 +1,7 @@
 import FioriThemeManager
 import Foundation
 import SwiftUI
+import Combine
 
 public class ChartSeriesPalette: ObservableObject, Identifiable, NSCopying {
     public init(colors: [Color],

--- a/Sources/FioriSwiftUICore/Models/StyleCache.swift
+++ b/Sources/FioriSwiftUICore/Models/StyleCache.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Combine
 
 // public struct StyleSheet: Decodable {
 //    let palette: [String: Color]

--- a/Sources/FioriSwiftUICore/Views/FilterFeedbackBarButton+View.swift
+++ b/Sources/FioriSwiftUICore/Views/FilterFeedbackBarButton+View.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import FioriThemeManager
 
 extension Fiori {
     enum FilterFeedbackBarButton {


### PR DESCRIPTION
… was not imported by this file; this is an error in Swift 6

# Description

+ Enum case 'secondaryFill' cannot be used in a default argument value because 'FioriThemeManager' was not imported by this file; this is an error in Swift 6.

Id.