### PR TITLE
fix: 🐛 update navigation bar style

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/NavigationBar/NavigationBarCustomItem.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/NavigationBar/NavigationBarCustomItem.swift
@@ -4,11 +4,12 @@ import SwiftUI
 struct NavigationBarCustomItem: View {
     var body: some View {
         Color.random
+            .frame(height: 5000)
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     HStack {
                         Button {} label: {
-                            Text("Option")
+                            Text("Custom Button")
                                 .padding()
                         }
                         .buttonStyle(CustomBarButtonStyle())
@@ -22,18 +23,22 @@ struct NavigationBarCustomItem: View {
                 }
             }
             .navigationTitle("Custom Bar Item")
+            .toolbarBackground(.visible, for: .navigationBar)
+            .toolbarBackground(.thinMaterial, for: .navigationBar)
     }
 }
 
 #Preview {
-    NavigationBarCustomItem()
+    NavigationStack {
+        NavigationBarCustomItem()
+    }
 }
 
 struct CustomBarButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
-            .font(Font.fiori(forTextStyle: .headline, weight: .black))
-            .foregroundStyle(Color.preferredColor(configuration.isPressed ? .tintColor : .tintColorTapState))
+            .font(Font.fiori(forTextStyle: .headline, weight: .bold))
+            .foregroundStyle(Color.preferredColor(configuration.isPressed ? .tintColor : .accentLabel5))
             .background(Color.preferredColor(configuration.isPressed ? .quaternaryFill : .cellBackground))
             .clipShape(RoundedRectangle(cornerRadius: 16))
     }

--- a/Apps/Examples/Examples/FioriSwiftUICore/NavigationBar/NavigationBarExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/NavigationBar/NavigationBarExample.swift
@@ -7,7 +7,7 @@ struct NavigationBarExample: View {
     var body: some View {
         List {
             HStack {
-                Text("FioriStyle")
+                Text("FioriStyle Version")
                 Spacer()
             }
             .contentShape(Rectangle())
@@ -21,13 +21,13 @@ struct NavigationBarExample: View {
             NavigationLink {
                 NavigationBarPopover()
             } label: {
-                Text("Title & Subtitle for TitleView(Long press to show popover)")
+                Text("Long title and subtitle for TitleView (Long press to show popover)")
             }
             
             NavigationLink {
                 NavigationBarCustomItem()
             } label: {
-                Text("BarButtonItem with Expandable Touch Area & Highlighted State")
+                Text("Custom Nav Bar with custom buttons (expanded touch area and highlighted state)")
             }
         }
         .navigationTitle("NavigationBar Test")

--- a/Apps/Examples/Examples/FioriSwiftUICore/NavigationBar/NavigationBarExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/NavigationBar/NavigationBarExample.swift
@@ -35,5 +35,7 @@ struct NavigationBarExample: View {
 }
 
 #Preview {
-    NavigationBarExample()
+    NavigationStack {
+        NavigationBarExample()
+    }
 }

--- a/Apps/Examples/Examples/FioriSwiftUICore/NavigationBar/NavigationBarFioriStyle.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/NavigationBar/NavigationBarFioriStyle.swift
@@ -11,13 +11,12 @@ struct NavigationBarFioriStyle: View {
             List {
                 Text("NavigationBar Background")
                 Text("Standard title font & color")
-                Text("Long press on navigation bar can show full title")
             }
             .navigationTitle("FioriStyle")
             .toolbar {
                 ToolbarItem(placement: .principal) {
                     VStack {
-                        Text("Title goes here")
+                        Text("FioriStyle")
                             .font(.fiori(forTextStyle: .subheadline)).fontWeight(.black)
                         Text("Subtitle goes here")
                             .font(.fiori(forTextStyle: .caption1))
@@ -33,10 +32,11 @@ struct NavigationBarFioriStyle: View {
                             Image(systemName: "camera")
                         })
                     }
-                    .font(.fiori(forTextStyle: .headline)).fontWeight(.black)
+                    .font(.fiori(forTextStyle: .headline)).fontWeight(.bold)
                 }
             }
         }
+        .presentationDragIndicator(.visible)
     }
 }
 

--- a/Apps/Examples/Examples/FioriSwiftUICore/NavigationBar/NavigationBarPopover.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/NavigationBar/NavigationBarPopover.swift
@@ -78,7 +78,7 @@ struct NavigationBarPopover: View {
                         Text("Edit")
                     }
                 }
-                .font(.fiori(forTextStyle: .headline)).fontWeight(.black)
+                .font(.fiori(forTextStyle: .headline)).fontWeight(.bold)
             }
         }
     }

--- a/Apps/Examples/Examples/FioriSwiftUICore/NavigationBar/NavigationBarPopover.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/NavigationBar/NavigationBarPopover.swift
@@ -3,17 +3,17 @@ import SwiftUI
 
 struct NavigationBarPopover: View {
     @Environment(\.presentationMode) var presentationMode
-    @State private var title: String = "Title goes here"
-    @State private var subtitle: String = "Subtitle goes here"
+    @State private var title: String = "Title with a very long long text wraps up to two lines"
+    @State private var subtitle: String = "Subtitle with a very long long long long long long text wraps up to two lines"
     @State private var isPopoverPresented = false
     
     var body: some View {
         List {
             Text("NavigationBar Background")
             Text("Standard title font & color")
-            Text("Long press on navigation bar can show full title")
+            Text("Info: Long press on a truncated navigation bar title can show the full title")
         }
-        .navigationTitle(self.title)
+        .navigationTitle("Popover Navigation Bar")
         .toolbar {
             ToolbarItem(placement: .principal) {
                 VStack {
@@ -75,7 +75,7 @@ struct NavigationBarPopover: View {
                             Text("Long Title & Long Subtitle")
                         })
                     } label: {
-                        Text("Title")
+                        Text("Edit")
                     }
                 }
                 .font(.fiori(forTextStyle: .headline)).fontWeight(.black)
@@ -85,5 +85,7 @@ struct NavigationBarPopover: View {
 }
 
 #Preview {
-    NavigationBarPopover()
+    NavigationStack {
+        NavigationBarPopover()
+    }
 }


### PR DESCRIPTION
|1|2|3|
|-|-|-|
|![image](https://github.com/SAP/cloud-sdk-ios-fiori/assets/2142582/42176493-e258-41ce-8dc0-2a7d5e2066ad)|![image (1)](https://github.com/SAP/cloud-sdk-ios-fiori/assets/2142582/ced33e48-da82-4e4b-bc1f-c6104eb53749)|![image (2)](https://github.com/SAP/cloud-sdk-ios-fiori/assets/2142582/71105780-9f9d-4371-87f8-e463cbfe9a25)|