### PR TITLE
fix: 🐛 [JIRA: HCPSDKFIORIUIKIT-1940] profile header style

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/ProfileHeader/ProfileHeaderStaticExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/ProfileHeader/ProfileHeaderStaticExample.swift
@@ -2,16 +2,14 @@ import FioriSwiftUICore
 import SwiftUI
 
 struct ProfileHeaderStaticExample: View {
-    var profileHeader: some View {
-        ProfileHeader(detailImage: {
-            Image("ProfilePic").resizable()
-        }, title: {
-            Text("Title")
-        }, subtitle: {
-            Text("This is a subtitle.")
-        }, description: {
-            Text("This is a description.")
-        }) {
+    @State var useButtonForDetails = false
+    
+    @ViewBuilder var detailContent: some View {
+        if self.useButtonForDetails {
+            FioriButton { _ in
+                Text("Label")
+            }
+        } else {
             HStack(spacing: 30) {
                 Button(action: {}, label: {
                     Image(systemName: "mail")
@@ -23,6 +21,33 @@ struct ProfileHeaderStaticExample: View {
                 Button(action: {}, label: {
                     Image(systemName: "phone")
                 })
+            }
+        }
+    }
+    
+    var profileHeader: some View {
+        ProfileHeader(detailImage: {
+            Image("ProfilePic").resizable()
+        }, title: {
+            Text("Title")
+        }, subtitle: {
+            Text("This is a subtitle.")
+        }, description: {
+            Text("This is a description.")
+        }) {
+            self.detailContent
+        }
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Menu {
+                    Button(action: {
+                        self.useButtonForDetails.toggle()
+                    }, label: {
+                        Text("Icons / Button")
+                    })
+                } label: {
+                    Text("Styles")
+                }
             }
         }
     }

--- a/Sources/FioriSwiftUICore/_FioriStyles/ProfileHeaderStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/ProfileHeaderStyle.fiori.swift
@@ -195,6 +195,7 @@ extension ProfileHeaderFioriStyle {
         
         func makeBody(_ configuration: TitleConfiguration) -> some View {
             Title(configuration)
+                .foregroundStyle(Color.preferredColor(.primaryLabel))
                 .font(.fiori(forTextStyle: .title3, weight: .bold))
         }
     }
@@ -204,7 +205,8 @@ extension ProfileHeaderFioriStyle {
         
         func makeBody(_ configuration: SubtitleConfiguration) -> some View {
             Subtitle(configuration)
-                .font(.fiori(forTextStyle: .body))
+                .foregroundStyle(Color.preferredColor(.secondaryLabel))
+                .font(.fiori(forTextStyle: .headline))
         }
     }
     


### PR DESCRIPTION
1. Update subtitle style to headline font with secondaryLabel color.
2. Add missed title color.
3. Add a picker to switch detail content between fiori button and icons stack.