### PR TITLE
fix: 🐛 Fix Image size issue on SideBar

### DIFF
--- a/Sources/FioriSwiftUICore/_FioriStyles/SideBarListItemStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/SideBarListItemStyle.fiori.swift
@@ -22,7 +22,7 @@ public struct SideBarListItemBaseStyle: SideBarListItemStyle {
     public func makeBody(_ configuration: SideBarListItemConfiguration) -> some View {
         Group {
             let dragImage = Image(systemName: "line.horizontal.3")
-                .frame(width: 22 * self.scale, height: 22 * self.scale)
+                .font(.fiori(forTextStyle: .title3))
                 .foregroundStyle(Color.preferredColor(.secondaryLabel))
             
             if self.sizeCategory.isAccessibilityCategory {
@@ -30,10 +30,8 @@ public struct SideBarListItemBaseStyle: SideBarListItemStyle {
                     HStack(spacing: 11) {
                         if configuration.isSelected, self.editMode?.wrappedValue == .inactive {
                             configuration.filledIcon
-                                .frame(width: 22 * self.scale, height: 22 * self.scale)
                         } else {
                             configuration.icon
-                                .frame(width: 22 * self.scale, height: 22 * self.scale)
                         }
                         configuration.title.multilineTextAlignment(.leading)
                         Spacer()
@@ -44,7 +42,6 @@ public struct SideBarListItemBaseStyle: SideBarListItemStyle {
                         if self.editMode?.wrappedValue == .inactive {
                             configuration.subtitle.multilineTextAlignment(.trailing)
                             configuration.accessoryIcon
-                                .frame(width: 22 * self.scale, height: 22 * self.scale)
                         } else if self.editMode?.wrappedValue == .active {
                             configuration._switch
                                 .frame(width: 60 * self.scale, height: 22 * self.scale)
@@ -56,10 +53,8 @@ public struct SideBarListItemBaseStyle: SideBarListItemStyle {
                 HStack(spacing: 11) {
                     if configuration.isSelected, self.editMode?.wrappedValue == .inactive {
                         configuration.filledIcon
-                            .frame(width: 22 * self.scale, height: 22 * self.scale)
                     } else {
                         configuration.icon
-                            .frame(width: 22 * self.scale, height: 22 * self.scale)
                     }
                     
                     configuration.title.frame(height: 44, alignment: .leading).multilineTextAlignment(.leading)
@@ -67,7 +62,6 @@ public struct SideBarListItemBaseStyle: SideBarListItemStyle {
                     if self.editMode?.wrappedValue == .inactive {
                         configuration.subtitle.frame(height: 44, alignment: .leading).multilineTextAlignment(.trailing)
                         configuration.accessoryIcon
-                            .frame(width: 22 * self.scale, height: 22 * self.scale)
                     } else if self.editMode?.wrappedValue == .active {
                         configuration._switch
                             .frame(width: 50, height: 35)
@@ -121,10 +115,12 @@ extension SideBarListItemFioriStyle {
             Group {
                 if self.modelObject.isSelected, self.editMode?.wrappedValue == .inactive {
                     Icon(configuration)
+                        .font(.fiori(forTextStyle: .body))
                         .fontWeight(.bold)
                         .foregroundStyle(Color.preferredColor(.quinaryLabel))
                 } else {
                     Icon(configuration)
+                        .font(.fiori(forTextStyle: .body))
                         .foregroundStyle(Color.preferredColor(.tintColor))
                 }
             }
@@ -136,6 +132,7 @@ extension SideBarListItemFioriStyle {
     
         func makeBody(_ configuration: FilledIconConfiguration) -> some View {
             FilledIcon(configuration)
+                .font(.fiori(forTextStyle: .body))
                 .fontWeight(.bold)
                 .foregroundStyle(Color.preferredColor(.quinaryLabel))
         }
@@ -186,10 +183,12 @@ extension SideBarListItemFioriStyle {
             Group {
                 if self.modelObject.isSelected, self.editMode?.wrappedValue == .inactive {
                     AccessoryIcon(configuration)
+                        .font(.fiori(forTextStyle: .body))
                         .fontWeight(.bold)
                         .foregroundStyle(Color.preferredColor(.quinaryLabel))
                 } else {
                     AccessoryIcon(configuration)
+                        .font(.fiori(forTextStyle: .body))
                         .foregroundStyle(Color.preferredColor(.tertiaryLabel))
                 }
             }

--- a/Sources/FioriSwiftUICore/_FioriStyles/SideBarStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/SideBarStyle.fiori.swift
@@ -148,6 +148,7 @@ public struct SideBarBaseStyle: SideBarStyle {
                     }
                 } else if configuration.isEditing { // For edit-mode
                     configuration.item(bindableItem).typeErased
+                        .background(Color.preferredColor(.secondaryBackground))
                         .simultaneousGesture(TapGesture().onEnded {}) // To capture the Tap Gesture on the Item Row in Edit mode and to do nothing to avoid the Tap Gesture was captured by section expending logic
                         .background(Color.white)
                         .overlay(


### PR DESCRIPTION
This PR addresses the issue concerning the image size used in the UIKit Sidebar, a problem discovered while implementing UX designer enhancements.

In the UIKit Sidebar, an SWiftUI Image converted from UIImage is employed. Originally, the code attempted to use the .resizable modifier to allow the image to resize and maintain a default size. Unfortunately, this approach was ineffective as the image continuously displayed at an incorrect size. After consulting with Xiao-Yu, it became evident that the placement of a frame around the image was erroneous. To rectify this, we should avoid setting a frame and instead, designate a suitable font size to maintain the image’s default dimensions. Additionally, this modification ensures support for larger accessibility sizes. With this fix, there is no longer a necessity to apply the .resizable modifier to the converted image, and the original UIImage can leverage UIImage.SymbolConfiguration with an apt font size to accommodate larger accessibility features.

Additionally, this PR resolves another issue related to the background color in scenarios involving larger accessibility sizes for the UIKit Sidebar.