### PR TITLE
fix: 🐛 Fix scroll issue on SideBar

### DIFF
--- a/Sources/FioriSwiftUICore/_FioriStyles/SideBarStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/SideBarStyle.fiori.swift
@@ -27,11 +27,11 @@ public struct SideBarBaseStyle: SideBarStyle {
                             self.buildSideBarList(configuration)
                         }
                         .padding(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
+                        .background(Color.preferredColor(.secondaryBackground))
                     })
                     
                     configuration.footer.typeErased
                 })
-                .background(Color.preferredColor(.secondaryBackground))
                 .environment(\.editMode, .constant(configuration.isEditing ? EditMode.active : EditMode.inactive))
             } else {
                 let onEditButtonClicked = {


### PR DESCRIPTION
This PR addresses the issue concerning the scrolling in the UIKit Sidebar, a problem discovered while implementing UX designer enhancements.

The issue was with the Sidebar as the content of primary view in the UISplitViewController. When setting a `.background` modifier on a `ScrollView` or outside of it within the SwiftUI Sidebar, the primary view in the UISplitViewController could not be scrolled vertically and only the 'SideBar' control was scrolled vertically. After testing, I found that moving the `.background` modifier inside the `ScrollView` resolves the problem for the UIKit Sidebar.