### PR TITLE
ci: build & test for visionOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,3 +61,18 @@ jobs:
     - uses: actions/checkout@v3
     - name: Run tests on Apple Watch simulator
       run: set -o pipefail && make test_watch
+
+  build_vision:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-14]
+        xcode: ['Xcode_15.3']
+    runs-on: ${{ matrix.os }}         
+    env:
+      DEVELOPER_DIR: /Applications/${{ matrix.xcode }}.app/Contents/Developer
+    
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run tests on Vision OS simulator
+      run: set -o pipefail && make test_vision

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 test_watch:
 	bash scripts/setup_spm_tests.sh
 	xcodebuild -scheme FioriThemeManagerTests -destination 'platform=watchOS Simulator,name=Apple Watch Series 8 (45mm)' test
+test_vision:
+	xcodebuild -scheme FioriSwiftUI-Package -destination 'platform=visionOS Simulator,name=Apple Vision Pro' clean build test | xcbeautify
 test_ios:
 	xcodebuild -scheme FioriSwiftUI-Package -destination 'platform=iOS Simulator,name=iPhone 14 Pro' clean build test | xcbeautify


### PR DESCRIPTION
Changes to build & test for visionOS when GitHub action is triggered by PR/commit

Helps to avoid that code changes will be merged that would not compile on visionOS