### PR TITLE
fix: IOSSDKBUG-282 - JMC welcome screen legal disclaimer bg color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [4.1.1](https://github.com/SAP/cloud-sdk-ios-fiori/compare/4.1.0...4.1.1) (2024-07-31)
+
+
+### Bug Fixes
+
+* fix compilation error caused by StepperView ([#754](https://github.com/SAP/cloud-sdk-ios-fiori/issues/754)) ([277d17d](https://github.com/SAP/cloud-sdk-ios-fiori/commit/277d17d17475836298ee6a8992c3f00d83a227ec))
+
 ## [4.1.0](https://github.com/SAP/cloud-sdk-ios-fiori/compare/4.0.0...4.1.0) (2024-07-31)
 
 

--- a/Sources/FioriSwiftUICore/_FioriStyles/JouleWelcomeScreenStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/JouleWelcomeScreenStyle.fiori.swift
@@ -38,7 +38,6 @@ public struct JouleWelcomeScreenBaseStyle: JouleWelcomeScreenStyle {
             Spacer()
             configuration.footnote
         }
-        .background(Color.preferredColor(.primaryBackground))
     }
 }
 
@@ -47,7 +46,8 @@ extension JouleWelcomeScreenFioriStyle {
     struct ContentFioriStyle: JouleWelcomeScreenStyle {
         func makeBody(_ configuration: JouleWelcomeScreenConfiguration) -> some View {
             JouleWelcomeScreen(configuration)
-            // Add default style for its content
+                // Add default style for its content
+                .background(Color.preferredColor(.primaryBackground))
         }
     }
     

--- a/Sources/FioriSwiftUICore/_FioriStyles/JouleWelcomeScreenStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/JouleWelcomeScreenStyle.fiori.swift
@@ -1,3 +1,8 @@
+🌱 Cloning SwiftFormat 0.53.4
+🌱 Resolving package
+🌱 Building product swiftformat
+🌱 Installed SwiftFormat 0.53.4
+🌱 Running swiftformat 0.53.4...
 import FioriThemeManager
 
 // Generated using Sourcery 2.1.7 — https://github.com/krzysztofzablocki/Sourcery
@@ -38,6 +43,7 @@ public struct JouleWelcomeScreenBaseStyle: JouleWelcomeScreenStyle {
             Spacer()
             configuration.footnote
         }
+        .background(Color.preferredColor(.primaryBackground))
     }
 }
 

--- a/Sources/FioriSwiftUICore/_FioriStyles/JouleWelcomeScreenStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/JouleWelcomeScreenStyle.fiori.swift
@@ -1,8 +1,3 @@
-🌱 Cloning SwiftFormat 0.53.4
-🌱 Resolving package
-🌱 Building product swiftformat
-🌱 Installed SwiftFormat 0.53.4
-🌱 Running swiftformat 0.53.4...
 import FioriThemeManager
 
 // Generated using Sourcery 2.1.7 — https://github.com/krzysztofzablocki/Sourcery


### PR DESCRIPTION
Adding default JMC welcome screen background color so that the legal disclaimer's background color matches conversation scroll view's background color.

After adding background color
<img width="1179" alt="image" src="https://github.com/user-attachments/assets/04f9a3be-c074-49d8-8275-cd8a5c549fc3">

Before adding background color
<img width="1179" alt="image" src="https://github.com/user-attachments/assets/5be59463-9851-4033-a2da-1964fab7aed6">
