### PR TITLE
fix: 🐛 [JIRA:IOSSDKBUG-264] No left padding for the 1st column in DataTable

### DIFF
--- a/Sources/FioriSwiftUICore/DataTable/LayoutData.swift
+++ b/Sources/FioriSwiftUICore/DataTable/LayoutData.swift
@@ -485,11 +485,7 @@ class LayoutData {
         }
         
         if let padding = dataCellPadding {
-            if columnIndex == numOfColumns - 1 {
-                return EdgeInsets(top: padding.top, leading: padding.leading, bottom: padding.bottom, trailing: 0)
-            } else {
-                return padding
-            }
+            return padding
         }
         
         let vPadding = isHeader ? TableViewLayout.topAndBottomPaddingsForHeader : TableViewLayout.topAndBottomPaddings
@@ -498,16 +494,8 @@ class LayoutData {
         let numOfColumns = self.numberOfColumns()
         if numOfColumns < 1 {
             return EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
-        } else if numOfColumns == 1 {
-            return EdgeInsets(top: vPadding, leading: contentInset, bottom: vPadding, trailing: 0)
         } else {
-            if columnIndex == 0 {
-                return EdgeInsets(top: vPadding, leading: contentInset, bottom: vPadding, trailing: contentInset)
-            } else if columnIndex == numOfColumns - 1 {
-                return EdgeInsets(top: vPadding, leading: contentInset, bottom: vPadding, trailing: 0)
-            } else {
-                return EdgeInsets(top: vPadding, leading: contentInset, bottom: vPadding, trailing: contentInset)
-            }
+            return EdgeInsets(top: vPadding, leading: contentInset, bottom: vPadding, trailing: contentInset)
         }
     }
     


### PR DESCRIPTION
All columns left and right padding are same according to regular or compact by default.
Developers can set 'dataCellPadding' to custom the padding.
