### PR TITLE
fix: 🐛 [JIRA: IOSSDKBUG-306] toolbar layout issue

### DIFF
--- a/Sources/FioriSwiftUICore/Views/Toolbar/FioriToolbar.swift
+++ b/Sources/FioriSwiftUICore/Views/Toolbar/FioriToolbar.swift
@@ -7,7 +7,7 @@ struct FioriToolbar<Items: IndexedViewContainer>: ViewModifier {
     let items: Items
     
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
-    @ObservedObject var sizeHandler = FioriToolbarHandler()
+    @StateObject var sizeHandler = FioriToolbarHandler()
     
     @Environment(\.helperTextStyle) var helperTextStyle
     @Environment(\.moreActionOverflowStyle) var moreActionOverflowStyle


### PR DESCRIPTION
Use `@StateObject` to make sure the only true source of handler.
|before|after|
|-|-|
|<img width="240" alt="Screenshot 2024-08-13 at 10 55 09" src="https://github.com/user-attachments/assets/607b06e3-c6ed-4401-9bf0-3a9efbcb1ca7">|<img width="242" alt="Screenshot 2024-08-13 at 10 54 39" src="https://github.com/user-attachments/assets/ea97acf1-5eb9-4eb5-a244-d35d2f916a76">|

Test Code
```swift
#Preview {
    TestView()
}
class TestViewModel: ObservableObject {
    @Published var isScreenLoading = false
}
struct TestView: View {
    @StateObject var viewModel = TestViewModel()
    var body: some View {
        NavigationStack {
            Text("Hello world.")
                .fioriToolbar {
                    FioriButton { _ in
                        self.viewModel.isScreenLoading = true
                    } label: { _ in
                        Text("Change value")
                            .frame(maxWidth: .infinity)
                    }
                }
        }
    }
}
```