### PR TITLE
fix: 🐛 step progress indicator styles

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/StepProgressIndicator/StepProgressIndicatorExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/StepProgressIndicator/StepProgressIndicatorExample.swift
@@ -1,4 +1,5 @@
 import FioriSwiftUICore
+import FioriThemeManager
 import SwiftUI
 
 struct StepProgressIndicatorExample: View {
@@ -121,7 +122,10 @@ struct SPIExampleWithHeader: View {
                 Button {} label: {
                     HStack(spacing: 2) {
                         Text("All Steps(\(self.steps.count)")
-                        Image(systemName: "chevron.right")
+                            .foregroundStyle(Color.preferredColor(.tintColor))
+                        FioriIcon.actions.slimArrowRight
+                            .font(.fiori(forTextStyle: .subheadline, weight: .semibold))
+                            .foregroundStyle(Color.preferredColor(.separator))
                     }
                 }
             }
@@ -210,8 +214,11 @@ struct SPIExampleWithoutName: View {
                                   stepItems: self.steps) {} action: {
                 Button {} label: {
                     HStack(spacing: 2) {
-                        Text("All Steps(\(self.steps.count))")
-                        Image(systemName: "chevron.right")
+                        Text("All Steps(\(self.steps.count)")
+                            .foregroundStyle(Color.preferredColor(.tintColor))
+                        FioriIcon.actions.slimArrowRight
+                            .font(.fiori(forTextStyle: .subheadline, weight: .semibold))
+                            .foregroundStyle(Color.preferredColor(.separator))
                     }
                 }
             }
@@ -250,7 +257,10 @@ struct SPIExampleByBuilder: View {
                 Button {} label: {
                     HStack(spacing: 2) {
                         Text("All Steps(2)")
-                        Image(systemName: "chevron.right")
+                            .foregroundStyle(Color.preferredColor(.tintColor))
+                        FioriIcon.actions.slimArrowRight
+                            .font(.fiori(forTextStyle: .subheadline, weight: .semibold))
+                            .foregroundStyle(Color.preferredColor(.separator))
                     }
                 }
             }, steps: {
@@ -332,7 +342,10 @@ struct SPICustomStyleExample: View {
                 Button {} label: {
                     HStack(spacing: 2) {
                         Text("All Steps(\(self.steps.count)")
-                        Image(systemName: "chevron.right")
+                            .foregroundStyle(Color.preferredColor(.tintColor))
+                        FioriIcon.actions.slimArrowRight
+                            .font(.fiori(forTextStyle: .subheadline, weight: .semibold))
+                            .foregroundStyle(Color.preferredColor(.separator))
                     }
                 }
             }

--- a/Sources/FioriSwiftUICore/Views/StepProgressIndicator/StepProgressIndicator+View.swift
+++ b/Sources/FioriSwiftUICore/Views/StepProgressIndicator/StepProgressIndicator+View.swift
@@ -79,6 +79,7 @@ extension StepProgressIndicator: View {
         } else {
             HStack(alignment: .center) {
                 title
+                    .font(.fiori(forTextStyle: .headline, weight: .semibold))
                 Spacer()
                 action
                     .onSimultaneousTapGesture(perform: {

--- a/Sources/FioriSwiftUICore/Views/StepProgressIndicator/StepsStyles.swift
+++ b/Sources/FioriSwiftUICore/Views/StepProgressIndicator/StepsStyles.swift
@@ -238,7 +238,7 @@ struct DefaultStepStyle: StepStyle {
         case (.normal, true):
             return Color.preferredColor(isPressed ? .tintColorTapState : .tintColor)
         case (.completed, _):
-            return Color.preferredColor(.primaryFill)
+            return Color.preferredColor(.quinaryLabel)
         case (.error, _):
             return Color.preferredColor(isPressed ? .negativeLabelTapState : .negativeLabel)
         default:


### PR DESCRIPTION
- The font color in a complete step should be in #FFFFFF (Quinary label)
- Use Fiori icon in the header for disclosure control (“>”):
    - Fiori icon: fiori.slim.arrow.right
    - Color: Separator
    - Size: 16pt
- Title in the header should use Headline Semi-bold (17pt)
- Right accessory in the header are not switched to dark mode colors