### PR TITLE
fix: 🐛 IOSSDKBUG-416 FilterFeedbackBar not anchored correctly

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/SortFilter/SortFilterExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/SortFilter/SortFilterExample.swift
@@ -6,7 +6,8 @@ struct SortFilterExample: View {
         [
             .switch(item: .init(name: "Favorite", value: true, icon: "heart.fill"), showsOnFilterFeedbackBar: true),
             .switch(item: .init(name: "Tagged", value: nil, icon: "tag"), showsOnFilterFeedbackBar: false),
-            .picker(item: .init(name: "JIRA Status", value: [0], valueOptions: ["Received", "Started", "Hold", "Transfer", "Completed", "Pending Review Pending Pending Pending Pending Pending", "Accepted Medium", "Pending Medium", "Completed Medium"], allowsMultipleSelection: true, allowsEmptySelection: true, showsValueForSingleSelected: false, icon: "clock", itemLayout: .fixed, displayMode: .automatic), showsOnFilterFeedbackBar: true)
+            .picker(item: .init(name: "JIRA Status", value: [0], valueOptions: ["Received", "Started", "Hold", "Transfer", "Completed", "Pending Review Pending Pending Pending Pending Pending", "Accepted Medium", "Pending Medium", "Completed Medium"], allowsMultipleSelection: true, allowsEmptySelection: true, showsValueForSingleSelected: false, icon: "clock", itemLayout: .fixed, displayMode: .automatic), showsOnFilterFeedbackBar: true),
+            .picker(item: .init(name: "Filter Selection", value: [0], valueOptions: ["Received", "Started", "Hold", "Transfer", "Completed", "Pending Review Pending Pending Pending Pending Pending", "Accepted Medium", "Pending Medium", "Completed Medium"], allowsMultipleSelection: true, allowsEmptySelection: true, showsValueForSingleSelected: false, icon: "clock", itemLayout: .fixed, displayMode: .filterFormCell), showsOnFilterFeedbackBar: true)
         ],
         [
             .picker(item: .init(name: "Priority", value: [0], valueOptions: ["High", "Medium", "Low"], allowsMultipleSelection: true, allowsEmptySelection: true, showsValueForSingleSelected: false, icon: "filemenu.and.cursorarrow"), showsOnFilterFeedbackBar: true),

--- a/Sources/FioriSwiftUICore/Views/SortFilter/FilterFeedbackBarItem+View.swift
+++ b/Sources/FioriSwiftUICore/Views/SortFilter/FilterFeedbackBarItem+View.swift
@@ -77,7 +77,7 @@ struct SliderMenuItem: View {
             .onTapGesture {
                 self.isSheetVisible.toggle()
             }
-            .popover(isPresented: self.$isSheetVisible, attachmentAnchor: .point(.bottom)) {
+            .popover(isPresented: self.$isSheetVisible) {
                 CancellableResettableDialogForm {
                     SortFilterItemTitle(title: self.item.name)
                 } cancelAction: {
@@ -153,7 +153,7 @@ struct PickerMenuItem: View {
             .onTapGesture {
                 self.isSheetVisible.toggle()
             }
-            .popover(isPresented: self.$isSheetVisible, attachmentAnchor: .point(.bottom)) {
+            .popover(isPresented: self.$isSheetVisible) {
                 CancellableResettableDialogForm {
                     SortFilterItemTitle(title: self.item.name)
                 } cancelAction: {
@@ -224,7 +224,7 @@ struct PickerMenuItem: View {
             .onTapGesture {
                 self.isSheetVisible.toggle()
             }
-            .popover(isPresented: self.$isSheetVisible, attachmentAnchor: .point(.bottom)) {
+            .popover(isPresented: self.$isSheetVisible) {
                 CancellableResettableDialogNavigationForm {
                     SortFilterItemTitle(title: self.item.name)
                 } cancelAction: {
@@ -311,7 +311,7 @@ struct DateTimeMenuItem: View {
             .onTapGesture {
                 self.isSheetVisible.toggle()
             }
-            .popover(isPresented: self.$isSheetVisible, attachmentAnchor: .point(.bottom)) {
+            .popover(isPresented: self.$isSheetVisible) {
                 CancellableResettableDialogForm {
                     SortFilterItemTitle(title: self.item.name)
                 } cancelAction: {
@@ -448,7 +448,7 @@ struct FullCFGMenuItem: View {
             .onTapGesture {
                 self.isSheetVisible.toggle()
             }
-            .popover(isPresented: self.$isSheetVisible, attachmentAnchor: .point(.bottom)) {
+            .popover(isPresented: self.$isSheetVisible) {
                 SortFilterView(
                     title: {
                         if let title = fullCFGButton.name {


### PR DESCRIPTION
.popover can be anchored correctly by iOS automatically.
So, there is no need to use the property "attachmentAnchor: .point(.bottom)"

After fix for iOS 18 and 17 (iPad):
![Screenshot 2024-10-23 at 14 32 22](https://github.com/user-attachments/assets/c0c50613-69f9-41d5-83db-b7113f7e67ef)

![Screenshot 2024-10-23 at 14 33 22](https://github.com/user-attachments/assets/5528ed6c-053f-4755-b6c8-849a717c5f76)
