### PR TITLE
fix: 🐛 [IOSSDKBUG-416]Fix FilterFeedbackBar layout on iPad

### DIFF
--- a/Sources/FioriSwiftUICore/Views/SortFilter/FilterFeedbackBarItem+View.swift
+++ b/Sources/FioriSwiftUICore/Views/SortFilter/FilterFeedbackBarItem+View.swift
@@ -252,7 +252,7 @@ struct PickerMenuItem: View {
                     } selectAll: { isAll in
                         self.item.selectAll(isAll)
                     } updateSearchListPickerHeight: { height in
-                        self.detentHeight = height + 52 + 56 + 90
+                        self.detentHeight = height
                     }
                     .frame(maxHeight: UIDevice.current.userInterfaceIdiom != .phone ? (self.detentHeight) : nil)
                     .padding(0)


### PR DESCRIPTION
Fix FilterFeedbackBar popover view layout on iPad and Vision Pro.