### PR TITLE
fix: 🐛 [JIRA:IOSSDKBUG-375] TextInput Fom View a11y fixes 1

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/FormViews/KeyValueFormViewExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/FormViews/KeyValueFormViewExample.swift
@@ -13,7 +13,7 @@ struct KeyValueFormViewExample: View {
         return aString
     }
 
-    @State var valueText1: String = "1234567890 12345678"
+    @State var valueText1: String = "This is default text for one line"
 
     var key2: AttributedString {
         let aString = AttributedString("Key 2")

--- a/Apps/Examples/Examples/FioriSwiftUICore/FormViews/NoteFormViewExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/FormViews/NoteFormViewExample.swift
@@ -2,7 +2,7 @@ import FioriSwiftUICore
 import SwiftUI
 
 struct NoteFormViewExample: View {
-    @State var valueText1: String = "1234567890 12345678"
+    @State var valueText1: String = "Line 1\nLine 2\nLine 3"
 
     @State var valueText2: String = "This is a test"
 

--- a/Apps/Examples/Examples/FioriSwiftUICore/FormViews/TextFieldFormViewExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/FormViews/TextFieldFormViewExample.swift
@@ -7,7 +7,7 @@ struct TextFieldFormViewExample: View {
         return aString
     }
 
-    @State var valueText1: String = "1234567890 12345678"
+    @State var valueText1: String = "This is default text for one line"
 
     var key2: AttributedString {
         let aString = AttributedString("Key 2")

--- a/Apps/Examples/Examples/FioriSwiftUICore/FormViews/TitleFormViewExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/FormViews/TitleFormViewExample.swift
@@ -2,7 +2,7 @@ import FioriSwiftUICore
 import SwiftUI
 
 struct TitleFormViewExample: View {
-    @State var valueText1: String = "1234567890 12345678"
+    @State var valueText1: String = "This is default text for one line"
     
     @State var valueText2: String = "This is a test"
     

--- a/Sources/FioriSwiftUICore/_FioriStyles/KeyValueFormViewStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/KeyValueFormViewStyle.fiori.swift
@@ -15,6 +15,7 @@ public struct KeyValueFormViewBaseStyle: KeyValueFormViewStyle {
             }
             configuration._noteFormView
         }
+        .accessibilityElement(children: .combine)
     }
 }
     
@@ -31,7 +32,7 @@ extension KeyValueFormViewFioriStyle {
                 }
                 .mandatoryFieldIndicatorStyle { indicatorConf in
                     MandatoryFieldIndicator(indicatorConf)
-                        .foregroundStyle(self.getTitleColor(configuration))
+                        .foregroundStyle(self.getMandatoryIndicatorColor(configuration))
                         .font(.fiori(forTextStyle: .subheadline, weight: .semibold))
                 }
                 .focused(self.$isFocused)
@@ -39,6 +40,10 @@ extension KeyValueFormViewFioriStyle {
 
         private func getTitleColor(_ configuration: KeyValueFormViewConfiguration) -> Color {
             TextInputFormViewConfiguration(configuration, isFocused: self.isFocused).getTitleColor()
+        }
+
+        private func getMandatoryIndicatorColor(_ configuration: KeyValueFormViewConfiguration) -> Color {
+            TextInputFormViewConfiguration(configuration, isFocused: false).getTitleColor()
         }
     }
 

--- a/Sources/FioriSwiftUICore/_FioriStyles/NoteFormViewStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/NoteFormViewStyle.fiori.swift
@@ -13,6 +13,8 @@ public struct NoteFormViewBaseStyle: NoteFormViewStyle {
                 .disabled(self.getDisabled(configuration))
         }
         .textInputInfoView(isPresented: Binding(get: { self.isInfoViewNeeded(configuration) }, set: { _ in }), description: self.getInfoString(configuration), counter: self.getCounterString(configuration))
+        .accessibilityElement(children: .combine)
+        .accessibilityHint(configuration.controlState == .normal ? (self.isFocused ? NSLocalizedString("Text field, is editing", tableName: "FioriSwiftUICore", bundle: Bundle.accessor, comment: "Text field, is editing") : NSLocalizedString("Text field, Double tap to edit", tableName: "FioriSwiftUICore", bundle: Bundle.accessor, comment: "Text field, Double tap to edit")) : "")
     }
 
     func getDisabled(_ configuration: NoteFormViewConfiguration) -> Bool {

--- a/Sources/FioriSwiftUICore/_FioriStyles/TextFieldFormViewStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/TextFieldFormViewStyle.fiori.swift
@@ -38,7 +38,7 @@ extension TextFieldFormViewFioriStyle {
                 }
                 .mandatoryFieldIndicatorStyle { indicatorConf in
                     MandatoryFieldIndicator(indicatorConf)
-                        .foregroundStyle(self.getTitleColor(configuration))
+                        .foregroundStyle(self.getMandatoryIndicatorColor(configuration))
                         .font(.fiori(forTextStyle: .subheadline, weight: .semibold))
                 }
                 .placeholderTextFieldStyle { config in
@@ -58,6 +58,7 @@ extension TextFieldFormViewFioriStyle {
                                 actionIcon
                             }
                             .padding(.trailing, 8)
+                            .disabled(UIAccessibility.isVoiceOverRunning)
                         }
                     }
                     .background(RoundedRectangle(cornerRadius: 8).stroke(self.getBorderColor(configuration), lineWidth: self.getBorderWidth(configuration)).background(self.getBackgroundColor(configuration)))
@@ -71,6 +72,7 @@ extension TextFieldFormViewFioriStyle {
                         .typeErased
                         .padding(.top, -3)
                 }
+                .accessibilityElement(children: .combine)
         }
 
         func isDisabled(_ configuration: TextFieldFormViewConfiguration) -> Bool {
@@ -79,6 +81,10 @@ extension TextFieldFormViewFioriStyle {
 
         func getTitleColor(_ configuration: TextFieldFormViewConfiguration) -> Color {
             TextInputFormViewConfiguration(configuration, isFocused: self.isFocused).getTitleColor()
+        }
+
+        func getMandatoryIndicatorColor(_ configuration: TextFieldFormViewConfiguration) -> Color {
+            TextInputFormViewConfiguration(configuration, isFocused: false).getTitleColor()
         }
 
         func getTextColor(_ configuration: TextFieldFormViewConfiguration) -> Color {

--- a/Sources/FioriSwiftUICore/_FioriStyles/TextInputInfoViewStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/TextInputInfoViewStyle.fiori.swift
@@ -77,6 +77,7 @@ struct TextInputInfoViewModifier: ViewModifier {
             
             if self.isPresented {
                 TextInputInfoView(icon: self.icon, description: self.description, counter: self.counter)
+                    .accessibilityElement(children: .combine)
             }
         }
     }

--- a/Sources/FioriSwiftUICore/_FioriStyles/TitleFormViewStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/TitleFormViewStyle.fiori.swift
@@ -15,6 +15,9 @@ public struct TitleFormViewBaseStyle: TitleFormViewStyle {
         .textInputInfoView(isPresented: Binding(get: { self.isInfoViewNeeded(configuration) }, set: { _ in }), description: self.getInfoString(configuration), counter: self.getCounterString(configuration))
         .padding(.top, -1)
         .padding(.bottom, self.isInfoViewNeeded(configuration) ? -12 : -1)
+        .accessibilityElement(children: .combine)
+        .accessibilityHint(self.getAccessibilityHint(configuration, isFocused: self.isFocused))
+        .disabled(configuration.controlState == .disabled)
     }
 
     func getDisabled(_ configuration: TitleFormViewConfiguration) -> Bool {
@@ -31,6 +34,27 @@ public struct TitleFormViewBaseStyle: TitleFormViewStyle {
 
     func isInfoViewNeeded(_ configuration: TitleFormViewConfiguration) -> Bool {
         TextInputFormViewConfiguration(configuration, isFocused: self.isFocused).isInfoViewNeeded()
+    }
+
+    func getAccessibilityHint(_ configuration: TitleFormViewConfiguration, isFocused: Bool) -> String {
+        var accHintString = ""
+
+        switch configuration.controlState {
+        case .normal:
+            if isFocused {
+                if configuration.text.isEmpty {
+                    accHintString = NSLocalizedString("Text field, is editing", tableName: "FioriSwiftUICore", bundle: Bundle.accessor, comment: "Text field, is editing")
+                } else {
+                    accHintString = NSLocalizedString("Text field, is editing. Double tap to clear text", tableName: "FioriSwiftUICore", bundle: Bundle.accessor, comment: "Text field, is editing. Double tap to clear text")
+                }
+            } else {
+                accHintString = NSLocalizedString("Text field, Double tap to edit", tableName: "FioriSwiftUICore", bundle: Bundle.accessor, comment: "Text field, Double tap to edit")
+            }
+        default:
+            break
+        }
+
+        return accHintString
     }
 }
 

--- a/Sources/FioriSwiftUICore/_localization/en.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/en.lproj/FioriSwiftUICore.strings
@@ -269,3 +269,12 @@
 "Select All" = "Select All";
 /* XBUT: The \"Deselect All\" button title on the List Picker header */
 "Deselect All" = "Deselect All";
+
+/* XACT: The accessibility hint for Text Input Views, editable */
+"Text field, Double tap to edit" = "Text field, Double tap to edit";
+
+/* XACT: The accessibility hint for Text Input Views, editing */
+"Text field, is editing" = "Text field, is editing";
+
+/* XACT: The accessibility hint for Text Input Views, editing, with clear button */
+"Text field, is editing. Double tap to clear text" = "Text field, is editing. Double tap to clear text";


### PR DESCRIPTION
1. Fixes the mandatory indicator color problem.
2. Fixes a11y problem with NoteFormView, KeyValueFormView, and, TitleFormView.
3. For TextFieldFormView, the fix is not completed yet. There is still problem when alternative action button is present.

Note that the TextField and TextEditor is always read by VoiceOver no matter the order it is on the FormView. I think this is a SwiftUI behavior. We can change the order for UIKit but not SwiftUI. I believe this is a SwiftUI behavior.