### PR TITLE
feat: 🎸 [JIRA:IOSSDKBUG-434] filterFeedBack list mutil selections shown in section

### DIFF
--- a/Sources/FioriSwiftUICore/DataTypes/SortFilter+DataType.swift
+++ b/Sources/FioriSwiftUICore/DataTypes/SortFilter+DataType.swift
@@ -365,6 +365,7 @@ public extension SortFilterItem {
         public var displayMode: DisplayMode = .automatic
         /// If searchBar in list picker is shown. Default is `false`.
         public var isSearchBarHidden: Bool = false
+        var disableListEntriesSection: Bool = false
 
         /// Available OptionListPicker modes. Use this enum to define picker mode  to present.
         public enum DisplayMode {
@@ -390,7 +391,18 @@ public extension SortFilterItem {
             case nameAndValue
         }
         
-        public init(id: String = UUID().uuidString, name: String, value: [Int], valueOptions: [String], allowsMultipleSelection: Bool, allowsEmptySelection: Bool, barItemDisplayMode: BarItemDisplayMode = .name, isSearchBarHidden: Bool = false, icon: String? = nil, itemLayout: OptionListPickerItemLayoutType = .fixed, displayMode: DisplayMode = .automatic) {
+        /// Enum for list show entries section
+        ///  The default value is `.default`.
+        public enum ListEntriesSectionMode {
+            /// Depend on 'allowsMultipleSelection'
+            case `default`
+            /// Enable
+            case enable
+            /// Disable
+            case disable
+        }
+        
+        public init(id: String = UUID().uuidString, name: String, value: [Int], valueOptions: [String], allowsMultipleSelection: Bool, allowsEmptySelection: Bool, barItemDisplayMode: BarItemDisplayMode = .name, isSearchBarHidden: Bool = false, icon: String? = nil, itemLayout: OptionListPickerItemLayoutType = .fixed, displayMode: DisplayMode = .automatic, listEntriesSectionMode: ListEntriesSectionMode = .default) {
             self.id = id
             self.name = name
             self.value = value
@@ -404,6 +416,15 @@ public extension SortFilterItem {
             self.icon = icon
             self.itemLayout = itemLayout
             self.displayMode = displayMode
+            
+            switch listEntriesSectionMode {
+            case .default:
+                self.disableListEntriesSection = allowsMultipleSelection ? false : true
+            case .disable:
+                self.disableListEntriesSection = true
+            case .enable:
+                self.disableListEntriesSection = false
+            }
         }
         
         mutating func onTap(option: String) {

--- a/Sources/FioriSwiftUICore/Models/ModelDefinitions.swift
+++ b/Sources/FioriSwiftUICore/Models/ModelDefinitions.swift
@@ -537,6 +537,7 @@ public protocol OptionListPickerItemModel: OptionListPickerComponent {
 // sourcery: virtualPropPopoverWidth = "let popoverWidth = 393.0"
 // sourcery: virtualPropIsSearchBarHidden = "var isSearchBarHidden: Bool = false"
 // sourcery: virtualPropKeyboardHeight = "@State var _keyboardHeight: CGFloat = 0.0"
+// sourcery: virtualPropDisableListEntriesSection = "var disableListEntriesSection: Bool = false"
 public protocol SearchListPickerItemModel: OptionListPickerComponent {
     // sourcery: default.value = nil
     // sourcery: no_view

--- a/Sources/FioriSwiftUICore/Views/SearchListPickerItem+View.swift
+++ b/Sources/FioriSwiftUICore/Views/SearchListPickerItem+View.swift
@@ -12,7 +12,8 @@ public extension SearchListPickerItem {
     ///   - onTap: The closure when tap on item.
     ///   - selectAll: The closure when click 'Select All' button.
     ///   - updateSearchListPickerHeight: The closure to update the parent view.
-    init(value: Binding<[Int]>, valueOptions: [String] = [], hint: String? = nil, allowsMultipleSelection: Bool, allowsEmptySelection: Bool, isSearchBarHidden: Bool = false, onTap: ((_ index: Int) -> Void)? = nil, selectAll: ((_ isAll: Bool) -> Void)? = nil, updateSearchListPickerHeight: ((CGFloat) -> Void)? = nil) {
+    ///   - disableListEntriesSection: A boolean value to indicate to disable entries section or not.
+    init(value: Binding<[Int]>, valueOptions: [String] = [], hint: String? = nil, allowsMultipleSelection: Bool, allowsEmptySelection: Bool, isSearchBarHidden: Bool = false, disableListEntriesSection: Bool, onTap: ((_ index: Int) -> Void)? = nil, selectAll: ((_ isAll: Bool) -> Void)? = nil, updateSearchListPickerHeight: ((CGFloat) -> Void)? = nil) {
         self.init(value: value, valueOptions: valueOptions, hint: hint, onTap: onTap)
         
         self.allowsMultipleSelection = allowsMultipleSelection
@@ -20,6 +21,7 @@ public extension SearchListPickerItem {
         self.isSearchBarHidden = isSearchBarHidden
         self.selectAll = selectAll
         self.updateSearchListPickerHeight = updateSearchListPickerHeight
+        self.disableListEntriesSection = disableListEntriesSection
     }
 }
 
@@ -27,7 +29,7 @@ extension SearchListPickerItem: View {
     public var body: some View {
         VStack(spacing: 0) {
             List {
-                if allowsMultipleSelection, _value.count > 0 {
+                if !disableListEntriesSection, _value.count > 0 {
                     self.selectionHeader()
                     
                     Section {

--- a/Sources/FioriSwiftUICore/Views/SearchListPickerItem+View.swift
+++ b/Sources/FioriSwiftUICore/Views/SearchListPickerItem+View.swift
@@ -104,7 +104,7 @@ extension SearchListPickerItem: View {
             .environment(\.defaultMinListRowHeight, 0)
             .environment(\.defaultMinListHeaderHeight, 0)
             .ifApply(!isSearchBarHidden, content: { v in
-                v.searchable(text: $_searchText, placement: .automatic)
+                v.searchable(text: $_searchText, placement: .navigationBarDrawer(displayMode: .always))
                     .onReceive(NotificationCenter.default.publisher(for: UIApplication.keyboardDidShowNotification)) { notif in
                         let rect = (notif.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect) ?? .zero
                         self._keyboardHeight = rect.height

--- a/Sources/FioriSwiftUICore/Views/SortFilter/FilterFeedbackBarItem+View.swift
+++ b/Sources/FioriSwiftUICore/Views/SortFilter/FilterFeedbackBarItem+View.swift
@@ -249,7 +249,7 @@ struct PickerMenuItem: View {
                     })
                     .buttonStyle(ApplyButtonStyle())
                 } components: {
-                    SearchListPickerItem(value: self.$item.workingValue, valueOptions: self.item.valueOptions, hint: nil, allowsMultipleSelection: self.item.allowsMultipleSelection, allowsEmptySelection: self.item.allowsEmptySelection, isSearchBarHidden: self.item.isSearchBarHidden) { index in
+                    SearchListPickerItem(value: self.$item.workingValue, valueOptions: self.item.valueOptions, hint: nil, allowsMultipleSelection: self.item.allowsMultipleSelection, allowsEmptySelection: self.item.allowsEmptySelection, isSearchBarHidden: self.item.isSearchBarHidden, disableListEntriesSection: self.item.disableListEntriesSection) { index in
                         self.item.onTap(option: self.item.valueOptions[index])
                     } selectAll: { isAll in
                         self.item.selectAll(isAll)

--- a/Sources/FioriSwiftUICore/Views/SortFilter/_SortFilterCFGItemContainer.swift
+++ b/Sources/FioriSwiftUICore/Views/SortFilter/_SortFilterCFGItemContainer.swift
@@ -147,7 +147,8 @@ extension _SortFilterCFGItemContainer: View {
                 valueOptions: self._items[r][c].picker.valueOptions,
                 allowsMultipleSelection: self._items[r][c].picker.allowsMultipleSelection,
                 allowsEmptySelection: self._items[r][c].picker.allowsEmptySelection,
-                isSearchBarHidden: self._items[r][c].picker.isSearchBarHidden
+                isSearchBarHidden: self._items[r][c].picker.isSearchBarHidden,
+                disableListEntriesSection: self._items[r][c].picker.disableListEntriesSection
             ) { index in
                 self._items[r][c].picker.onTap(option: self._items[r][c].picker.valueOptions[index])
             } selectAll: { isAll in

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/API/SearchListPickerItem+API.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/API/SearchListPickerItem+API.generated.swift
@@ -9,16 +9,17 @@ public struct SearchListPickerItem {
 	var _valueOptions: [String]
 	var _hint: String? = nil
 	var _onTap: ((_ index: Int) -> Void)? = nil
-	@State var _searchText: String = ""
+	var disableListEntriesSection: Bool = false
+	var updateSearchListPickerHeight: ((CGFloat) -> ())? = nil
+	@State var _height: CGFloat = 44
+	var allowsEmptySelection: Bool = false
+	var allowsMultipleSelection: Bool = false
 	var isSearchBarHidden: Bool = false
+	@State var _searchText: String = ""
+	let popoverWidth = 393.0
+	var selectAll: ((Bool) -> ())? = nil
 	@State var _keyboardHeight: CGFloat = 0.0
 	@State var _searchViewCornerRadius: CGFloat = 18
-	var allowsEmptySelection: Bool = false
-	let popoverWidth = 393.0
-	@State var _height: CGFloat = 44
-	var updateSearchListPickerHeight: ((CGFloat) -> ())? = nil
-	var selectAll: ((Bool) -> ())? = nil
-	var allowsMultipleSelection: Bool = false
     public init(model: SearchListPickerItemModel) {
         self.init(value: Binding<[Int]>(get: { model.value }, set: { model.value = $0 }), valueOptions: model.valueOptions, hint: model.hint, onTap: model.onTap)
     }

--- a/Sources/FioriSwiftUICore/_localization/en.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/en.lproj/FioriSwiftUICore.strings
@@ -269,6 +269,8 @@
 "Select All" = "Select All";
 /* XBUT: The \"Deselect All\" button title on the List Picker header */
 "Deselect All" = "Deselect All";
+/* XBUT: The \"Selected\" title on the List Picker header */
+"Selected" = "Selected";
 
 /* XACT: The accessibility hint for Text Input Views, editable */
 "Text field, Double tap to edit" = "Text field, Double tap to edit";


### PR DESCRIPTION
Add 'ListEntriesSectionMode' to control whether entries section shown or not.
when listEntriesSectionMode is 'default', depends on 'allowsMultipleSelection', when allowsMultipleSelection is true, selections should be shown in an individual section.
![2](https://github.com/user-attachments/assets/10485caa-0e29-43a7-8809-a0e89fe91b2c)