### PR TITLE
fix: 🐛 [IOSSDKBUG-416]FilterFeedbackBar on 17 iPad layout

### DIFF
--- a/Sources/FioriSwiftUICore/Views/OptionListPickerItem+View.swift
+++ b/Sources/FioriSwiftUICore/Views/OptionListPickerItem+View.swift
@@ -71,7 +71,9 @@ extension OptionListPickerItem: View {
                 }
             )
         }
-        .frame(height: _height)
+        .ifApply(UIDevice.current.userInterfaceIdiom == .phone, content: { v in
+            v.frame(height: _height)
+        })
     }
     
     private func generateFlexibleContent() -> some View {
@@ -102,7 +104,9 @@ extension OptionListPickerItem: View {
                 }
             )
         }
-        .frame(height: _height)
+        .ifApply(UIDevice.current.userInterfaceIdiom == .phone, content: { v in
+            v.frame(height: _height)
+        })
     }
     
     private func getSafeAreaInsets() -> UIEdgeInsets {

--- a/Sources/FioriSwiftUICore/Views/SortFilter/FilterFeedbackBarItem+View.swift
+++ b/Sources/FioriSwiftUICore/Views/SortFilter/FilterFeedbackBarItem+View.swift
@@ -183,6 +183,9 @@ struct PickerMenuItem: View {
                     }
                     .padding([.leading, .trailing], UIDevice.current.userInterfaceIdiom == .pad ? 13 : 16)
                 }
+                .ifApply(UIDevice.current.userInterfaceIdiom != .phone, content: { v in
+                    v.frame(minHeight: 155)
+                })
                 .readHeight()
                 .onPreferenceChange(HeightPreferenceKey.self) { height in
                     if let height {


### PR DESCRIPTION
Fix popover arrow direction on 17 iPad when 'displayMode' is '.filterFormCell'.