### PR TITLE
feat: 🎸 [JIRA:HCPSDKFIORIUIKIT-2828] PreviewDevice is ignored in a #Preview macro

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/KPI/KPIProgressViewExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/KPI/KPIProgressViewExample.swift
@@ -28,7 +28,6 @@ struct KPIProgressPreview: PreviewProvider {
     static var previews: some View {
         Group {
             KPIProgressExample()
-                .previewDevice(PreviewDevice(rawValue: "iPhone 12"))
                 .previewDisplayName("iPhone 12")
         }
     }

--- a/Apps/Examples/Examples/FioriSwiftUICore/KPI/KPIViewExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/KPI/KPIViewExample.swift
@@ -44,7 +44,6 @@ struct KPIPreview: PreviewProvider {
     static var previews: some View {
         Group {
             KPIExample()
-                .previewDevice(PreviewDevice(rawValue: "iPhone 12"))
                 .previewDisplayName("iPhone 12")
         }
     }

--- a/Sources/FioriSwiftUICore/Toast/ToastView.swift
+++ b/Sources/FioriSwiftUICore/Toast/ToastView.swift
@@ -130,7 +130,6 @@ extension View {
         .background(Color.green)
         .frame(maxWidth: /*@START_MENU_TOKEN@*/ .infinity/*@END_MENU_TOKEN@*/, maxHeight: .infinity)
         .toast(toast: .constant(Toast(message: "Tapped cell is read-only.")))
-        .previewDevice(PreviewDevice(rawValue: "iPhone 15"))
 }
 
 #Preview {
@@ -138,5 +137,4 @@ extension View {
         .background(Color.green)
         .frame(maxWidth: /*@START_MENU_TOKEN@*/ .infinity/*@END_MENU_TOKEN@*/, maxHeight: .infinity)
         .toast(toast: .constant(Toast(message: "Tapped cell is read-only. Tapped cell is read-only. Tapped cell is read-only.", image: Image(systemName: "info.circle.fill"))))
-        .previewDevice(PreviewDevice(rawValue: "iPad Pro (11-inch) (4th generation)"))
 }

--- a/Sources/FioriSwiftUICore/Views/_ObjectItem+View.swift
+++ b/Sources/FioriSwiftUICore/Views/_ObjectItem+View.swift
@@ -734,7 +734,6 @@ struct ObjectItem_Previews: PreviewProvider {
                 Image(systemName: "circle.fill").foregroundColor(.blue)
                 Image(systemName: "paperclip").font(.system(size: 14))
             })
-            .previewDevice(PreviewDevice(rawValue: "iPad Pro (12.9-inch) (4th generation)"))
             .previewLayout(.fixed(width: 844, height: 120))
             .environment(\.horizontalSizeClass, .regular)
             .previewDisplayName("Regular, 1st is text, init with ViewBuilder")
@@ -761,7 +760,6 @@ struct ObjectItem_Previews: PreviewProvider {
                 Image(systemName: "paperclip").font(.system(size: 14))
             })
             .splitPercent(nil)
-            .previewDevice(PreviewDevice(rawValue: "iPad Pro (12.9-inch) (4th generation)"))
             .previewLayout(.fixed(width: 844, height: 120))
             .environment(\.horizontalSizeClass, .regular)
             .previewDisplayName("Regular, 1st is icon, splitPercent to nil, init with ViewBuilder")
@@ -775,7 +773,6 @@ struct ObjectItem_Previews: PreviewProvider {
                         icons: [TextOrIcon.text("1"),
                                 TextOrIcon.icon(Image(systemName: "circle.fill")),
                                 TextOrIcon.icon(Image(systemName: "mail"))])
-                .previewDevice(PreviewDevice(rawValue: "iPad Pro (12.9-inch) (4th generation)"))
                 .previewLayout(.fixed(width: 844, height: 120))
                 .environment(\.horizontalSizeClass, .regular)
                 .previewDisplayName("Regular, 1st is text, init with model")
@@ -801,7 +798,6 @@ struct ObjectItem_Previews: PreviewProvider {
                 Circle().fill(Color.blue).frame(width: 14, height: 14)
                 Image(systemName: "paperclip").font(.system(size: 14))
             })
-            .previewDevice(PreviewDevice(rawValue: "iPad Pro (12.9-inch) (4th generation)"))
             .previewLayout(.fixed(width: 844, height: 200))
             .environment(\.horizontalSizeClass, .regular)
             .previewDisplayName("Accessibility AX1 and larger- no description text")


### PR DESCRIPTION
[HCPSDKFIORIUIKIT-2828](https://jira.tools.sap/browse/HCPSDKFIORIUIKIT-2828) PreviewDevice is ignored in a #Preview macro

This PR handle the change to clean up the warning message 'PreviewDevice is ignored in a #Preview macro' with XCode 16.1. 

See the following [Xcode 15 release notes](https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes#Previews):
_**The preview canvas has a new control for picking which device to use for previewing. By default it tracks the device family of the selected run destination, but a specific device can be selected. This should be used in favor of the previewDevice modifier.**_

Therefore, going forward, the `previewDevice` modifier should not be used. Instead, the control on the canvas GUI should be used to select a preview device.