### PR TITLE
fix: 🐛 [IOSSDKBUG-480]Popover view height on iPad

### DIFF
--- a/Sources/FioriSwiftUICore/Models/ModelDefinitions.swift
+++ b/Sources/FioriSwiftUICore/Models/ModelDefinitions.swift
@@ -554,6 +554,7 @@ public protocol OptionListPickerItemModel: OptionListPickerComponent {
 // sourcery: virtualPropKeyboardHeight = "@State var _keyboardHeight: CGFloat = 0.0"
 // sourcery: virtualPropDisableListEntriesSection = "var disableListEntriesSection: Bool = false"
 // sourcery: virtualPropAllowsDisplaySelectionCount = "var allowsDisplaySelectionCount: Bool = true"
+// sourcery: virtualPropBarItemFrame = "var barItemFrame: CGRect = .zero"
 public protocol SearchListPickerItemModel: OptionListPickerComponent {
     // sourcery: default.value = nil
     // sourcery: no_view

--- a/Sources/FioriSwiftUICore/Views/SearchListPickerItem+View.swift
+++ b/Sources/FioriSwiftUICore/Views/SearchListPickerItem+View.swift
@@ -14,7 +14,8 @@ public extension SearchListPickerItem {
     ///   - updateSearchListPickerHeight: The closure to update the parent view.
     ///   - disableListEntriesSection: A boolean value to indicate to disable entries section or not.
     ///   - allowsDisplaySelectionCount: A boolean value to indicate to display selection count or not.
-    init(value: Binding<[Int]>, valueOptions: [String] = [], hint: String? = nil, allowsMultipleSelection: Bool, allowsEmptySelection: Bool, isSearchBarHidden: Bool = false, disableListEntriesSection: Bool, allowsDisplaySelectionCount: Bool, onTap: ((_ index: Int) -> Void)? = nil, selectAll: ((_ isAll: Bool) -> Void)? = nil, updateSearchListPickerHeight: ((CGFloat) -> Void)? = nil) {
+    ///   - barItemFrame: The frame of the bar item, which toggle to show this view.
+    init(value: Binding<[Int]>, valueOptions: [String] = [], hint: String? = nil, allowsMultipleSelection: Bool, allowsEmptySelection: Bool, isSearchBarHidden: Bool = false, disableListEntriesSection: Bool, allowsDisplaySelectionCount: Bool, barItemFrame: CGRect = .zero, onTap: ((_ index: Int) -> Void)? = nil, selectAll: ((_ isAll: Bool) -> Void)? = nil, updateSearchListPickerHeight: ((CGFloat) -> Void)? = nil) {
         self.init(value: value, valueOptions: valueOptions, hint: hint, onTap: onTap)
         
         self.allowsMultipleSelection = allowsMultipleSelection
@@ -24,6 +25,7 @@ public extension SearchListPickerItem {
         self.updateSearchListPickerHeight = updateSearchListPickerHeight
         self.disableListEntriesSection = disableListEntriesSection
         self.allowsDisplaySelectionCount = allowsDisplaySelectionCount
+        self.barItemFrame = barItemFrame
     }
 }
 
@@ -83,12 +85,25 @@ extension SearchListPickerItem: View {
                 return
             }
             DispatchQueue.main.async {
-                let popverHeight = Screen.bounds.size.height
+                let screenHeight = Screen.bounds.size.height
                 let safeAreaInset = self.getSafeAreaInsets()
-                var maxScrollViewHeight = popverHeight - self.additionalHeight() - safeAreaInset.top - (UIDevice.current.userInterfaceIdiom != .phone ? 250 : 30)
-                maxScrollViewHeight -= self._keyboardHeight
-                if self._keyboardHeight > 0 {
-                    maxScrollViewHeight -= 52
+                var maxScrollViewHeight = screenHeight - self.additionalHeight()
+                if UIDevice.current.userInterfaceIdiom != .phone {
+                    if self.barItemFrame.arrowDirection() == .top {
+                        maxScrollViewHeight -= (self.barItemFrame.maxY + 80)
+                        maxScrollViewHeight -= self._keyboardHeight
+                    } else if self.barItemFrame.arrowDirection() == .bottom {
+                        maxScrollViewHeight -= (screenHeight - self.barItemFrame.minY + 80) + safeAreaInset.bottom + 13
+                        if self._keyboardHeight > 0 {
+                            let keyboardItemHeight = (self._keyboardHeight - (screenHeight - self.barItemFrame.minY))
+                            if keyboardItemHeight > 0 {
+                                maxScrollViewHeight -= keyboardItemHeight
+                            }
+                        }
+                    }
+                } else {
+                    maxScrollViewHeight -= (safeAreaInset.top + 30)
+                    maxScrollViewHeight -= self._keyboardHeight
                 }
                 self._height = min(scrollView.contentSize.height, maxScrollViewHeight)
                 updateSearchListPickerHeight?(self._height)

--- a/Sources/FioriSwiftUICore/Views/SortFilter/FilterFeedbackBarItem+View.swift
+++ b/Sources/FioriSwiftUICore/Views/SortFilter/FilterFeedbackBarItem+View.swift
@@ -72,6 +72,7 @@ struct SliderMenuItem: View {
     @State var isSheetVisible = false
 
     @State var detentHeight: CGFloat = 0
+    @State var barItemFrame: CGRect = .zero
 
     var onUpdate: () -> Void
 
@@ -85,7 +86,7 @@ struct SliderMenuItem: View {
             .onTapGesture {
                 self.isSheetVisible.toggle()
             }
-            .popover(isPresented: self.$isSheetVisible) {
+            .popover(isPresented: self.$isSheetVisible, arrowEdge: self.barItemFrame.arrowDirection()) {
                 CancellableResettableDialogForm {
                     SortFilterItemTitle(title: self.item.name)
                 } cancelAction: {
@@ -120,6 +121,17 @@ struct SliderMenuItem: View {
                 }
                 .presentationDetents([.height(self.detentHeight)])
             }
+            .ifApply(UIDevice.current.userInterfaceIdiom != .phone, content: { v in
+                v.background(GeometryReader { geometry in
+                    Color.clear
+                        .onAppear {
+                            self.barItemFrame = geometry.frame(in: .global)
+                        }
+                        .onChange(of: geometry.frame(in: .global)) { newValue in
+                            self.barItemFrame = newValue
+                        }
+                })
+            })
     }
 }
 
@@ -132,6 +144,7 @@ struct PickerMenuItem: View {
     @State var detentHeight: CGFloat = ((UIDevice.current.userInterfaceIdiom == .phone || UIDevice.current.userInterfaceIdiom != .phone) ? 88 : 0)
     let popoverWidth = 393.0
     @State var _keyboardHeight = 0.0
+    @State var barItemFrame: CGRect = .zero
         
     public init(item: Binding<SortFilterItem.PickerItem>, onUpdate: @escaping () -> Void) {
         self._item = item
@@ -163,7 +176,7 @@ struct PickerMenuItem: View {
             .onTapGesture {
                 self.isSheetVisible.toggle()
             }
-            .popover(isPresented: self.$isSheetVisible) {
+            .popover(isPresented: self.$isSheetVisible, arrowEdge: self.barItemFrame.arrowDirection()) {
                 CancellableResettableDialogForm {
                     SortFilterItemTitle(title: self.item.name)
                 } cancelAction: {
@@ -210,6 +223,17 @@ struct PickerMenuItem: View {
                 }
                 .presentationDetents([.height(self.detentHeight)])
             }
+            .ifApply(UIDevice.current.userInterfaceIdiom != .phone, content: { v in
+                v.background(GeometryReader { geometry in
+                    Color.clear
+                        .onAppear {
+                            self.barItemFrame = geometry.frame(in: .global)
+                        }
+                        .onChange(of: geometry.frame(in: .global)) { newValue in
+                            self.barItemFrame = newValue
+                        }
+                })
+            })
     }
     
     @ViewBuilder
@@ -245,7 +269,7 @@ struct PickerMenuItem: View {
             .onTapGesture {
                 self.isSheetVisible.toggle()
             }
-            .popover(isPresented: self.$isSheetVisible) {
+            .popover(isPresented: self.$isSheetVisible, arrowEdge: self.barItemFrame.arrowDirection()) {
                 CancellableResettableDialogNavigationForm {
                     SortFilterItemTitle(title: self.item.name)
                 } cancelAction: {
@@ -276,7 +300,7 @@ struct PickerMenuItem: View {
                     })
                     .buttonStyle(ApplyButtonStyle())
                 } components: {
-                    SearchListPickerItem(value: self.$item.workingValue, valueOptions: self.item.valueOptions, hint: nil, allowsMultipleSelection: self.item.allowsMultipleSelection, allowsEmptySelection: self.item.allowsEmptySelection, isSearchBarHidden: self.item.isSearchBarHidden, disableListEntriesSection: self.item.disableListEntriesSection, allowsDisplaySelectionCount: self.item.allowsDisplaySelectionCount) { index in
+                    SearchListPickerItem(value: self.$item.workingValue, valueOptions: self.item.valueOptions, hint: nil, allowsMultipleSelection: self.item.allowsMultipleSelection, allowsEmptySelection: self.item.allowsEmptySelection, isSearchBarHidden: self.item.isSearchBarHidden, disableListEntriesSection: self.item.disableListEntriesSection, allowsDisplaySelectionCount: self.item.allowsDisplaySelectionCount, barItemFrame: self.barItemFrame) { index in
                         self.item.onTap(option: self.item.valueOptions[index])
                     } selectAll: { isAll in
                         self.item.selectAll(isAll)
@@ -297,6 +321,17 @@ struct PickerMenuItem: View {
                 .frame(height: UIDevice.current.userInterfaceIdiom != .phone ? self.calculateDetentHeight() : nil)
                 .presentationDetents([.height(self.calculateDetentHeight()), .medium, .large])
             }
+            .ifApply(UIDevice.current.userInterfaceIdiom != .phone, content: { v in
+                v.background(GeometryReader { geometry in
+                    Color.clear
+                        .onAppear {
+                            self.barItemFrame = geometry.frame(in: .global)
+                        }
+                        .onChange(of: geometry.frame(in: .global)) { newValue in
+                            self.barItemFrame = newValue
+                        }
+                })
+            })
     }
     
     private func calculateDetentHeight() -> CGFloat {
@@ -369,6 +404,7 @@ struct DateTimeMenuItem: View {
     @State private var isSheetVisible: Bool = false
 
     @State var detentHeight: CGFloat = 0
+    @State var barItemFrame: CGRect = .zero
     
     var onUpdate: () -> Void
     
@@ -388,7 +424,7 @@ struct DateTimeMenuItem: View {
             .onTapGesture {
                 self.isSheetVisible.toggle()
             }
-            .popover(isPresented: self.$isSheetVisible) {
+            .popover(isPresented: self.$isSheetVisible, arrowEdge: self.barItemFrame.arrowDirection()) {
                 CancellableResettableDialogForm {
                     SortFilterItemTitle(title: self.item.name)
                 } cancelAction: {
@@ -448,6 +484,17 @@ struct DateTimeMenuItem: View {
                 }
                 .presentationDetents([.height(self.detentHeight)])
             }
+            .ifApply(UIDevice.current.userInterfaceIdiom != .phone, content: { v in
+                v.background(GeometryReader { geometry in
+                    Color.clear
+                        .onAppear {
+                            self.barItemFrame = geometry.frame(in: .global)
+                        }
+                        .onChange(of: geometry.frame(in: .global)) { newValue in
+                            self.barItemFrame = newValue
+                        }
+                })
+            })
     }
 }
 
@@ -512,6 +559,7 @@ struct StepperMenuItem: View {
     @State var isSheetVisible = false
 
     @State var detentHeight: CGFloat = 0
+    @State var barItemFrame: CGRect = .zero
 
     var onUpdate: () -> Void
     
@@ -527,7 +575,7 @@ struct StepperMenuItem: View {
             .onTapGesture {
                 self.isSheetVisible.toggle()
             }
-            .popover(isPresented: self.$isSheetVisible) {
+            .popover(isPresented: self.$isSheetVisible, arrowEdge: self.barItemFrame.arrowDirection()) {
                 CancellableResettableDialogForm {
                     SortFilterItemTitle(title: self.item.name)
                 } cancelAction: {
@@ -598,6 +646,17 @@ struct StepperMenuItem: View {
                 }
                 .presentationDetents([.height(self.detentHeight)])
             }
+            .ifApply(UIDevice.current.userInterfaceIdiom != .phone, content: { v in
+                v.background(GeometryReader { geometry in
+                    Color.clear
+                        .onAppear {
+                            self.barItemFrame = geometry.frame(in: .global)
+                        }
+                        .onChange(of: geometry.frame(in: .global)) { newValue in
+                            self.barItemFrame = newValue
+                        }
+                })
+            })
     }
 }
 
@@ -665,6 +724,18 @@ struct FullCFGMenuItem: View {
                     onUpdate: {}
                 )
             }
+    }
+}
+
+extension CGRect {
+    /// Popover arrowEdge depends on bar item position,
+    /// only return `.top` or `.bottom` in this case
+    /// - Returns: Edge
+    func arrowDirection() -> Edge {
+        if self.minY > Screen.bounds.size.height / 2 {
+            return .bottom
+        }
+        return .top
     }
 }
 

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/API/SearchListPickerItem+API.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/API/SearchListPickerItem+API.generated.swift
@@ -9,17 +9,18 @@ public struct SearchListPickerItem {
 	var _valueOptions: [String]
 	var _hint: String? = nil
 	var _onTap: ((_ index: Int) -> Void)? = nil
-	var updateSearchListPickerHeight: ((CGFloat) -> ())? = nil
-	var selectAll: ((Bool) -> ())? = nil
+	var barItemFrame: CGRect = .zero
 	var disableListEntriesSection: Bool = false
-	let popoverWidth = 393.0
-	@State var _height: CGFloat = 44
-	@State var _searchViewCornerRadius: CGFloat = 18
-	@State var _searchText: String = ""
-	var allowsEmptySelection: Bool = false
-	var allowsMultipleSelection: Bool = false
-	var allowsDisplaySelectionCount: Bool = true
 	var isSearchBarHidden: Bool = false
+	var allowsMultipleSelection: Bool = false
+	var allowsEmptySelection: Bool = false
+	@State var _searchViewCornerRadius: CGFloat = 18
+	var selectAll: ((Bool) -> ())? = nil
+	let popoverWidth = 393.0
+	var allowsDisplaySelectionCount: Bool = true
+	@State var _searchText: String = ""
+	var updateSearchListPickerHeight: ((CGFloat) -> ())? = nil
+	@State var _height: CGFloat = 44
 	@State var _keyboardHeight: CGFloat = 0.0
     public init(model: SearchListPickerItemModel) {
         self.init(value: Binding<[Int]>(get: { model.value }, set: { model.value = $0 }), valueOptions: model.valueOptions, hint: model.hint, onTap: model.onTap)


### PR DESCRIPTION
Calculate popover height based on bar item position.
Set `arrowEdge` based on bar item position. Only `.top` or '.bottom' will be set. Condition is item's position above or below half screen height.

![Simulator Screenshot - iPad Pro 13-inch (M4) - 2024-11-26 at 15 51 04](https://github.com/user-attachments/assets/43880c1e-41f3-4319-89fa-8fd77712193b)
![Simulator Screenshot - iPad Pro 13-inch (M4) - 2024-11-26 at 15 51 08](https://github.com/user-attachments/assets/e724c131-81ae-46d3-a589-b021146e033d)
![Simulator Screenshot - iPad Pro 13-inch (M4) - 2024-11-26 at 15 51 12](https://github.com/user-attachments/assets/8eb4c77d-d8ce-492e-b462-9e84c69a8c79)
![Simulator Screenshot - iPad Pro 13-inch (M4) - 2024-11-26 at 15 51 15](https://github.com/user-attachments/assets/230008ed-962a-4a1e-b989-8d37d963f350)
![Simulator Screenshot - iPad Pro 13-inch (M4) - 2024-11-26 at 16 04 30](https://github.com/user-attachments/assets/718502b8-7e3e-457f-9a04-e9b6c835a801)
![Simulator Screenshot - iPad Pro 13-inch (M4) - 2024-11-26 at 16 04 36](https://github.com/user-attachments/assets/62b9cd7a-020b-4664-9693-99ad6b11ffcf)
