### PR TITLE
fix: 🐛 [JIRA:HCPSDKFIORIUIKIT-2840] fix onChange deprecated

### DIFF
--- a/Sources/FioriSwiftUICore/DataTable/DataTable.swift
+++ b/Sources/FioriSwiftUICore/DataTable/DataTable.swift
@@ -102,7 +102,11 @@ public struct DataTable: View {
             }
         }
         #endif
-        .onChange(of: self.dynamicTypeSize) { newValue in
+        .setOnChange(of: self.dynamicTypeSize, action1: { newValue in
+            self.layoutManager.dynamicTypeSize = newValue
+            self.layoutManager.cacheLayoutDataForMeasurement = nil
+            self.layoutManager.layoutData = nil
+        }) { _, newValue in
             self.layoutManager.dynamicTypeSize = newValue
             self.layoutManager.cacheLayoutDataForMeasurement = nil
             self.layoutManager.layoutData = nil

--- a/Sources/FioriSwiftUICore/DataTable/InlineEditingView.swift
+++ b/Sources/FioriSwiftUICore/DataTable/InlineEditingView.swift
@@ -134,11 +134,15 @@ struct InlineEditingView: View {
                 self.focusState = true
             }
         }
-        .onChange(of: self.editingText, perform: { _ in
+        .setOnChange(of: self.editingText) {
             self.layoutManager.cacheEditingText = self.editingText
-        })
-        .onChange(of: self.focusState) { newValue in
+        }
+        .setOnChange(of: self.focusState, action1: { newValue in
             // lost focus
+            if !newValue {
+                self.updateText(self.editingText)
+            }
+        }) { _, newValue in
             if !newValue {
                 self.updateText(self.editingText)
             }

--- a/Sources/FioriSwiftUICore/DataTable/ItemView.swift
+++ b/Sources/FioriSwiftUICore/DataTable/ItemView.swift
@@ -228,53 +228,65 @@ struct FocusedEditingView: View {
                 EmptyView()
             }
         }
-        .onChange(of: self.editingDate) { newValue in
-            guard let layoutData = self.layoutManager.layoutData else { return }
-            
-            var dataItem = layoutData.allDataItems[self.rowIndex][self.columnIndex]
-            dataItem.date = newValue
-            self.isValid = self.layoutManager.checkIsValid(for: dataItem)
-            let errorChange: Int = dataItem.isValid != self.isValid.0 ? (self.isValid.0 ? -1 : 1) : 0
-            layoutData.numOfErrors += errorChange
-            dataItem.isValid = self.isValid.0
-            if let value = dataItem.string(for: layoutManager.model.columnAttribute(for: columnIndex)) {
-                self.editingText = value
-                dataItem.text = value
-                dataItem.size = layoutData.calcDataItemSize(dataItem)
-            }
-            
-            layoutData.allDataItems[self.rowIndex][self.columnIndex] = dataItem
-            layoutData.updateCellLayout(for: self.rowIndex, columnIndex: self.columnIndex)
-            self.layoutManager.needRefresh.toggle()
-            self.layoutManager.isValid = self.isValid
-            self.showBanner = !self.isValid.0
-            
-            self.layoutManager.model.valueDidChange?(DataTableChange(rowIndex: self.rowIndex, columnIndex: self.columnIndex, value: .date(newValue), text: self.editingText))
+        .setOnChange(of: self.editingDate, action1: { newValue in
+            self.onEditingDateChange(newValue)
+        }) { _, newValue in
+            self.onEditingDateChange(newValue)
         }
-        .onChange(of: self.editingDuration) { newValue in
-            guard let layoutData = self.layoutManager.layoutData else { return }
-            
-            var dataItem = layoutData.allDataItems[self.rowIndex][self.columnIndex]
-            dataItem.ti = TimeInterval(newValue * 60)
-            self.isValid = self.layoutManager.checkIsValid(for: dataItem)
-            let errorChange: Int = dataItem.isValid != self.isValid.0 ? (self.isValid.0 ? -1 : 1) : 0
-            layoutData.numOfErrors += errorChange
-            dataItem.isValid = self.isValid.0
-            if let value = dataItem.string(for: layoutManager.model.columnAttribute(for: columnIndex)) {
-                self.editingText = value
-                dataItem.text = value
-                dataItem.size = layoutData.calcDataItemSize(dataItem)
-            }
-            layoutData.allDataItems[self.rowIndex][self.columnIndex] = dataItem
-            layoutData.updateCellLayout(for: self.rowIndex, columnIndex: self.columnIndex)
-            self.layoutManager.needRefresh.toggle()
-            self.layoutManager.isValid = self.isValid
-            self.showBanner = !self.isValid.0
-            
-            self.layoutManager.model.valueDidChange?(DataTableChange(rowIndex: self.rowIndex, columnIndex: self.columnIndex, value: .duration(TimeInterval(newValue * 60)), text: self.editingText))
+        .setOnChange(of: self.editingDuration, action1: { newValue in
+            self.onEditingDurationChange(newValue)
+        }) { _, newValue in
+            self.onEditingDurationChange(newValue)
         }
     }
-    
+
+    func onEditingDateChange(_ newValue: Date) {
+        guard let layoutData = self.layoutManager.layoutData else { return }
+
+        var dataItem = layoutData.allDataItems[self.rowIndex][self.columnIndex]
+        dataItem.date = newValue
+        self.isValid = self.layoutManager.checkIsValid(for: dataItem)
+        let errorChange: Int = dataItem.isValid != self.isValid.0 ? (self.isValid.0 ? -1 : 1) : 0
+        layoutData.numOfErrors += errorChange
+        dataItem.isValid = self.isValid.0
+        if let value = dataItem.string(for: layoutManager.model.columnAttribute(for: columnIndex)) {
+            self.editingText = value
+            dataItem.text = value
+            dataItem.size = layoutData.calcDataItemSize(dataItem)
+        }
+
+        layoutData.allDataItems[self.rowIndex][self.columnIndex] = dataItem
+        layoutData.updateCellLayout(for: self.rowIndex, columnIndex: self.columnIndex)
+        self.layoutManager.needRefresh.toggle()
+        self.layoutManager.isValid = self.isValid
+        self.showBanner = !self.isValid.0
+
+        self.layoutManager.model.valueDidChange?(DataTableChange(rowIndex: self.rowIndex, columnIndex: self.columnIndex, value: .date(newValue), text: self.editingText))
+    }
+
+    func onEditingDurationChange(_ newValue: Int) {
+        guard let layoutData = self.layoutManager.layoutData else { return }
+
+        var dataItem = layoutData.allDataItems[self.rowIndex][self.columnIndex]
+        dataItem.ti = TimeInterval(newValue * 60)
+        self.isValid = self.layoutManager.checkIsValid(for: dataItem)
+        let errorChange: Int = dataItem.isValid != self.isValid.0 ? (self.isValid.0 ? -1 : 1) : 0
+        layoutData.numOfErrors += errorChange
+        dataItem.isValid = self.isValid.0
+        if let value = dataItem.string(for: layoutManager.model.columnAttribute(for: columnIndex)) {
+            self.editingText = value
+            dataItem.text = value
+            dataItem.size = layoutData.calcDataItemSize(dataItem)
+        }
+        layoutData.allDataItems[self.rowIndex][self.columnIndex] = dataItem
+        layoutData.updateCellLayout(for: self.rowIndex, columnIndex: self.columnIndex)
+        self.layoutManager.needRefresh.toggle()
+        self.layoutManager.isValid = self.isValid
+        self.showBanner = !self.isValid.0
+
+        self.layoutManager.model.valueDidChange?(DataTableChange(rowIndex: self.rowIndex, columnIndex: self.columnIndex, value: .duration(TimeInterval(newValue * 60)), text: self.editingText))
+    }
+
     func pickerView() -> some View {
         let data = self.layoutManager.model.listItemDataAndTitle?(self.rowIndex, self.columnIndex) ?? ([self.editingText], "")
         let indexData: [Int] = (0 ..< data.0.count).map { $0 }

--- a/Sources/FioriSwiftUICore/Experimental/Popover/PopoverModifier.swift
+++ b/Sources/FioriSwiftUICore/Experimental/Popover/PopoverModifier.swift
@@ -13,17 +13,10 @@ struct PopoverModifier<PopView: View>: ViewModifier {
                 .frameReader(rect: { rect in
                     self.sourceFrame = rect
                 })
-                .onChange(of: self.isPresented) { newValue in
-                    if newValue {
-                        let popover = Popover(popView: AnyView(popView()), isPresented: $isPresented)
-                        popover.context.sourceFrame = self.sourceFrame
-                        popover.context.windowFrame = window?.bounds ?? .zero
-                        popover.present(in: window)
-                        self.popover = popover
-                    } else {
-                        guard let popover else { return }
-                        popover.dismiss()
-                    }
+                .setOnChange(of: self.isPresented, action1: { newValue in
+                    self.onIsPresentedChange(newValue, window: window)
+                }) { _, newValue in
+                    self.onIsPresentedChange(newValue, window: window)
                 }
             #if !os(visionOS)
                 .onReceive(NotificationCenter.default.publisher(for: UIDevice.orientationDidChangeNotification)) { _ in
@@ -31,6 +24,19 @@ struct PopoverModifier<PopView: View>: ViewModifier {
                     popover.dismiss()
                 }
             #endif
+        }
+    }
+
+    func onIsPresentedChange(_ newValue: Bool, window: UIWindow?) {
+        if newValue {
+            let popover = Popover(popView: AnyView(popView()), isPresented: $isPresented)
+            popover.context.sourceFrame = self.sourceFrame
+            popover.context.windowFrame = window?.bounds ?? .zero
+            popover.present(in: window)
+            self.popover = popover
+        } else {
+            guard let popover else { return }
+            popover.dismiss()
         }
     }
 }

--- a/Sources/FioriSwiftUICore/Toast/ToastView.swift
+++ b/Sources/FioriSwiftUICore/Toast/ToastView.swift
@@ -78,7 +78,7 @@ struct ToastModifier: ViewModifier {
                     }
                 }
             )
-            .onChange(of: self.toast) { _ in
+            .setOnChange(of: self.toast) {
                 self.showToast()
             }
     }

--- a/Sources/FioriSwiftUICore/Utils/View+Extensions.swift
+++ b/Sources/FioriSwiftUICore/Utils/View+Extensions.swift
@@ -54,3 +54,38 @@ extension View {
         return false
     }
 }
+
+extension View {
+    nonisolated func setOnChange<V>(
+        of value: V,
+        initial: Bool = false,
+        action1: @escaping (V) -> Void,
+        action2: @escaping (V, V) -> Void
+    ) -> some View where V: Equatable {
+        if #available(iOS 17.0, *) {
+            return self.onChange(of: value, initial: initial) {
+                action2($0, $1)
+            }
+        } else {
+            return self.onChange(of: value) {
+                action1($0)
+            }
+        }
+    }
+
+    nonisolated func setOnChange(
+        of value: some Equatable,
+        initial: Bool = false,
+        _ action: @escaping () -> Void
+    ) -> some View {
+        if #available(iOS 17.0, *) {
+            return self.onChange(of: value, initial: initial) {
+                action()
+            }
+        } else {
+            return self.onChange(of: value) { _ in
+                action()
+            }
+        }
+    }
+}

--- a/Sources/FioriSwiftUICore/Views/SearchableListContent.swift
+++ b/Sources/FioriSwiftUICore/Views/SearchableListContent.swift
@@ -82,7 +82,9 @@ struct SearchableListContent<Data: RandomAccessCollection, ID: Hashable, RowCont
                 }
                 .scrollContentBackground(.hidden)
                 .background(listBackground)
-                .onChange(of: selectionBuffer) { newValue in
+                .setOnChange(of: selectionBuffer, action1: { newValue in
+                    selectionUpdated?(newValue)
+                }) { _, newValue in
                     selectionUpdated?(newValue)
                 }
                 .ifApply(searchFilter != nil, content: {

--- a/Sources/FioriSwiftUICore/Views/SortFilter/FilterFeedbackBarItem+View.swift
+++ b/Sources/FioriSwiftUICore/Views/SortFilter/FilterFeedbackBarItem+View.swift
@@ -127,7 +127,9 @@ struct SliderMenuItem: View {
                         .onAppear {
                             self.barItemFrame = geometry.frame(in: .global)
                         }
-                        .onChange(of: geometry.frame(in: .global)) { newValue in
+                        .setOnChange(of: geometry.frame(in: .global), action1: { newValue in
+                            self.barItemFrame = newValue
+                        }) { _, newValue in
                             self.barItemFrame = newValue
                         }
                 })
@@ -229,7 +231,9 @@ struct PickerMenuItem: View {
                         .onAppear {
                             self.barItemFrame = geometry.frame(in: .global)
                         }
-                        .onChange(of: geometry.frame(in: .global)) { newValue in
+                        .setOnChange(of: geometry.frame(in: .global), action1: { newValue in
+                            self.barItemFrame = newValue
+                        }) { _, newValue in
                             self.barItemFrame = newValue
                         }
                 })
@@ -327,7 +331,9 @@ struct PickerMenuItem: View {
                         .onAppear {
                             self.barItemFrame = geometry.frame(in: .global)
                         }
-                        .onChange(of: geometry.frame(in: .global)) { newValue in
+                        .setOnChange(of: geometry.frame(in: .global), action1: { newValue in
+                            self.barItemFrame = newValue
+                        }) { _, newValue in
                             self.barItemFrame = newValue
                         }
                 })
@@ -490,7 +496,9 @@ struct DateTimeMenuItem: View {
                         .onAppear {
                             self.barItemFrame = geometry.frame(in: .global)
                         }
-                        .onChange(of: geometry.frame(in: .global)) { newValue in
+                        .setOnChange(of: geometry.frame(in: .global), action1: { newValue in
+                            self.barItemFrame = newValue
+                        }) { _, newValue in
                             self.barItemFrame = newValue
                         }
                 })
@@ -652,7 +660,9 @@ struct StepperMenuItem: View {
                         .onAppear {
                             self.barItemFrame = geometry.frame(in: .global)
                         }
-                        .onChange(of: geometry.frame(in: .global)) { newValue in
+                        .setOnChange(of: geometry.frame(in: .global), action1: { newValue in
+                            self.barItemFrame = newValue
+                        }) { _, newValue in
                             self.barItemFrame = newValue
                         }
                 })

--- a/Sources/FioriSwiftUICore/Views/SortFilter/_SortFilterCFGItemContainer.swift
+++ b/Sources/FioriSwiftUICore/Views/SortFilter/_SortFilterCFGItemContainer.swift
@@ -67,7 +67,7 @@ extension _SortFilterCFGItemContainer: View {
                 self.height = min(scrollView.contentSize.height, maxScrollViewHeight)
             }
         })
-        .onChange(of: self._items) { _ in
+        .setOnChange(of: self._items) {
             self.checkUpdateButtonState()
         }
         .onAppear {

--- a/Sources/FioriSwiftUICore/Views/StepProgressIndicator/StepProgressIndicator+View.swift
+++ b/Sources/FioriSwiftUICore/Views/StepProgressIndicator/StepProgressIndicator+View.swift
@@ -48,7 +48,15 @@ extension StepProgressIndicator: View {
                     StepProgressIndicatorContainer(selection: _selection,
                                                    steps: steps)
                         .environment(\.stepFrames, $stepFrames)
-                        .onChange(of: _selection.wrappedValue) { newValue in
+                        .setOnChange(of: _selection.wrappedValue, action1: { newValue in
+                            if let currentFrame = stepFrames[newValue],
+                               !scrollBounds.contains(currentFrame)
+                            {
+                                withAnimation {
+                                    proxy.scrollTo(newValue, anchor: .leading)
+                                }
+                            }
+                        }) { _, newValue in
                             if let currentFrame = stepFrames[newValue],
                                !scrollBounds.contains(currentFrame)
                             {

--- a/Sources/FioriSwiftUICore/_FioriStyles/BannerMultiMessageSheetStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/BannerMultiMessageSheetStyle.fiori.swift
@@ -343,9 +343,8 @@ public struct BannerMultiMessageSheetBaseStyle: BannerMultiMessageSheetStyle {
         })
         .frame(minWidth: !self.isPhone ? 393 : nil)
         .frame(height: self.popoverHeight)
-        .animation(self.scrollContentHeight <= 40.0 ? nil : .spring)
-//        .animation(.spring, value: self.popoverHeight)
-        .onChange(of: configuration.bannerMultiMessages) { _ in
+        .animation(self.scrollContentHeight <= 40.0 ? nil : .spring, value: self.scrollContentHeight)
+        .setOnChange(of: configuration.bannerMultiMessages) {
             // when datasource is empty, dismiss in 2 seconds
             if configuration.bannerMultiMessages.isEmpty {
                 self.timer = Timer.scheduledTimer(withTimeInterval: 2, repeats: false, block: { _ in

--- a/Sources/FioriSwiftUICore/_FioriStyles/CheckoutIndicatorStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/CheckoutIndicatorStyle.fiori.swift
@@ -45,7 +45,9 @@ public struct CheckoutIndicatorBaseStyle: CheckoutIndicatorStyle {
                             self.performAnimation(state: configuration.displayState)
                         }
                     }
-                    .onChange(of: configuration.displayState) { newValue in
+                    .setOnChange(of: configuration.displayState, action1: { newValue in
+                        self.performAnimation(state: newValue)
+                    }) { _, newValue in
                         self.performAnimation(state: newValue)
                     }
                 if configuration.displayState != .inProgress {

--- a/Sources/FioriSwiftUICore/_FioriStyles/DateTimePickerStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/DateTimePickerStyle.fiori.swift
@@ -85,9 +85,9 @@ public struct DateTimePickerBaseStyle: DateTimePickerStyle {
     func showPicker(_ configuration: DateTimePickerConfiguration) -> some View {
         DatePicker("", selection: configuration.$selectedDate, displayedComponents: configuration.pickerComponents)
             .datePickerStyle(.graphical)
-            .onChange(of: configuration.selectedDate, perform: { _ in
+            .setOnChange(of: configuration.selectedDate) {
                 _ = self.getValueLabel(configuration)
-            })
+            }
     }
 }
 

--- a/Sources/FioriSwiftUICore/_FioriStyles/ListPickerDestinationStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/ListPickerDestinationStyle.fiori.swift
@@ -573,7 +573,7 @@ struct ListPickerDestinationContent<Data: RandomAccessCollection, ID: Hashable, 
                 self.listContent()
             }
         }
-        .onChange(of: self.selections) { _ in
+        .setOnChange(of: self.selections) {
             self.postSelectionsUpdated()
         }
         .ifApply(!self.isTrackingLiveChanges && self.isTopLevel) {

--- a/Sources/FioriSwiftUICore/_FioriStyles/NoteFormViewStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/NoteFormViewStyle.fiori.swift
@@ -62,7 +62,9 @@ extension NoteFormViewFioriStyle {
                                 .stroke(self.getBorderColor(configuration), lineWidth: self.getBorderWidth(configuration))
                         )
                         .cornerRadius(8)
-                        .onChange(of: configuration.text) { s in
+                        .setOnChange(of: configuration.text, action1: { s in
+                            self.checkCharCount(configuration, textString: s)
+                        }) { _, s in
                             self.checkCharCount(configuration, textString: s)
                         }
                         .padding(.bottom, self.isInfoViewNeeded(configuration) ? 0 : 7)

--- a/Sources/FioriSwiftUICore/_FioriStyles/ProgressIndicatorStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/ProgressIndicatorStyle.fiori.swift
@@ -30,13 +30,10 @@ public struct ProgressIndicatorBaseStyle: ProgressIndicatorStyle {
                 .onAppear {
                     self.performAnimation(configuration)
                 }
-                .onChange(of: configuration.progress) { [oldValue = configuration.progress] _ in
-                    self.previousProgress = oldValue
-                    self.performAnimation(configuration)
-                }
+                .onProgressChange(configuration, progressIndicatorBaseStyle: self)
         }
     }
-    
+
     func performAnimation(_ configuration: ProgressIndicatorConfiguration) {
         DispatchQueue.main.async {
             if self.isProcessing {
@@ -49,6 +46,22 @@ public struct ProgressIndicatorBaseStyle: ProgressIndicatorStyle {
                 withAnimation(Animation.easeInOut(duration: 1.3)) {
                     self.drawProgress.toggle()
                 }
+            }
+        }
+    }
+}
+
+extension View {
+    nonisolated func onProgressChange(_ configuration: ProgressIndicatorConfiguration, progressIndicatorBaseStyle: ProgressIndicatorBaseStyle) -> some View {
+        if #available(iOS 17.0, *) {
+            return self.onChange(of: configuration.progress) { oldValue, _ in
+                progressIndicatorBaseStyle.previousProgress = oldValue
+                progressIndicatorBaseStyle.performAnimation(configuration)
+            }
+        } else {
+            return self.onChange(of: configuration.progress) { [oldValue = configuration.progress] _ in
+                progressIndicatorBaseStyle.previousProgress = oldValue
+                progressIndicatorBaseStyle.performAnimation(configuration)
             }
         }
     }

--- a/Sources/FioriSwiftUICore/_FioriStyles/StepperFieldStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/StepperFieldStyle.fiori.swift
@@ -25,7 +25,9 @@ public struct StepperFieldBaseStyle: StepperFieldStyle {
                 }
             configuration._textInputField
                 .textInputFieldStyle(.number)
-                .onChange(of: configuration.text) { newValue in
+                .setOnChange(of: configuration.text, action1: { newValue in
+                    self.updateText(for: newValue, configuration: configuration)
+                }) { _, newValue in
                     self.updateText(for: newValue, configuration: configuration)
                 }
             configuration.incrementAction

--- a/Sources/FioriSwiftUICore/_FioriStyles/TextFieldFormViewStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/TextFieldFormViewStyle.fiori.swift
@@ -49,7 +49,9 @@ extension TextFieldFormViewFioriStyle {
                             .font(.fiori(forTextStyle: .body))
                             .accentColor(self.getCursorColor(configuration))
                             .focused(self.$isFocused)
-                            .onChange(of: configuration.text) { s in
+                            .setOnChange(of: configuration.text, action1: { s in
+                                self.checkCharCount(configuration, textString: s)
+                            }) { _, s in
                                 self.checkCharCount(configuration, textString: s)
                             }
                             .frame(minHeight: 44)

--- a/Sources/FioriSwiftUICore/_FioriStyles/TextInputFieldStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/TextInputFieldStyle.fiori.swift
@@ -25,7 +25,12 @@ public struct TextInputFieldNumberStyle: TextInputFieldStyle {
         TextInputField(configuration)
             .frame(minHeight: 44)
             .keyboardType(.numberPad)
-            .onChange(of: configuration.text) { newValue in
+            .setOnChange(of: configuration.text, action1: { newValue in
+                let filtered = newValue.filter { $0.isNumber || $0 == "." }
+                if filtered != newValue {
+                    configuration.text = filtered
+                }
+            }) { _, newValue in
                 let filtered = newValue.filter { $0.isNumber || $0 == "." }
                 if filtered != newValue {
                     configuration.text = filtered

--- a/Sources/FioriSwiftUICore/_FioriStyles/TitleFormViewStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/TitleFormViewStyle.fiori.swift
@@ -80,7 +80,9 @@ extension TitleFormViewFioriStyle {
                     }
                     .placeholderTextFieldStyle { config in
                         PlaceholderTextField(config)
-                            .onChange(of: configuration.text) { s in
+                            .setOnChange(of: configuration.text, action1: { s in
+                                self.checkCharCount(configuration, textString: s)
+                            }) { _, s in
                                 self.checkCharCount(configuration, textString: s)
                             }
                             .background(self.getBackgroundColor(configuration))

--- a/Sources/FioriSwiftUICore/_FioriStyles/ToastMessageStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/ToastMessageStyle.fiori.swift
@@ -163,7 +163,7 @@ struct ToastMessageModifier: ViewModifier {
                     })
                 }
             })
-            .onChange(of: self.isPresented) { _ in
+            .setOnChange(of: self.isPresented) {
                 self.showToast()
             }
     }


### PR DESCRIPTION
'onChange(of:perform:)' was deprecated in iOS 17.0: Use `onChange` with a two or zero parameter action closure instead.

✅ Closes: HCPSDKFIORIUIKIT-2840