### PR TITLE
feat: 🎸 JIRA-2846 ignore warnings from old color palettes

### DIFF
--- a/Sources/FioriThemeManager/ColorCompatibilityMap/ColorCompatibilityMapV4.swift
+++ b/Sources/FioriThemeManager/ColorCompatibilityMap/ColorCompatibilityMapV4.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+@available(*, deprecated, message: "Intentionally used for backward compatibility.")
 @available(watchOS, unavailable)
 struct ColorCompatibilityMapV4: ColorStyleCompatibilityProvider {
     let uuid = UUID()

--- a/Sources/FioriThemeManager/ColorCompatibilityMap/ColorCompatibilityMapV5.swift
+++ b/Sources/FioriThemeManager/ColorCompatibilityMap/ColorCompatibilityMapV5.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+@available(*, deprecated, message: "Intentionally used for backward compatibility.")
 @available(watchOS, unavailable)
 struct ColorCompatibilityMapV5: ColorStyleCompatibilityProvider {
     let uuid = UUID()

--- a/Sources/FioriThemeManager/Palettes/PaletteV2.swift
+++ b/Sources/FioriThemeManager/Palettes/PaletteV2.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+@available(*, deprecated, message: "Intentionally used for backward compatibility.")
 @available(watchOS, unavailable)
 struct PaletteV2: PaletteProvider {
     /// :nodoc:

--- a/Sources/FioriThemeManager/Palettes/PaletteV3.swift
+++ b/Sources/FioriThemeManager/Palettes/PaletteV3.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+@available(*, deprecated, message: "Intentionally used for backward compatibility.")
 @available(watchOS, unavailable)
 struct PaletteV3: PaletteProvider {
     /// :nodoc:

--- a/Sources/FioriThemeManager/Palettes/PaletteV4.swift
+++ b/Sources/FioriThemeManager/Palettes/PaletteV4.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+@available(*, deprecated, message: "Intentionally used for backward compatibility.")
 @available(watchOS, unavailable)
 struct PaletteV4: PaletteProvider {
     /// :nodoc:

--- a/Sources/FioriThemeManager/Palettes/PaletteV5.swift
+++ b/Sources/FioriThemeManager/Palettes/PaletteV5.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+@available(*, deprecated, message: "Intentionally used for backward compatibility.")
 @available(watchOS, unavailable)
 struct PaletteV5: PaletteProvider {
     /// :nodoc:


### PR DESCRIPTION
There are lots of warnings from old Palette related files ( V2 , V3, V4, V5 ), since some of the color styles were deprecated.

Added the "@available" annotation in related files to tell the compiler to ignore these warnings.

Before the fix :
Showing All Issues
/github/cloud-sdk-ios-fiori/Sources/FioriThemeManager/ColorCompatibilityMap/ColorCompatibilityMapV4.swift:14:25: 'primary1' is deprecated: renamed to 'primaryLabel'

/github/cloud-sdk-ios-fiori/Sources/FioriThemeManager/ColorCompatibilityMap/ColorCompatibilityMapV4.swift:15:27: 'primary2' is deprecated: renamed to 'secondaryLabel'

/github/cloud-sdk-ios-fiori/Sources/FioriThemeManager/ColorCompatibilityMap/ColorCompatibilityMapV4.swift:16:26: 'primary3' is deprecated: renamed to 'tertiaryLabel'

/github/cloud-sdk-ios-fiori/Sources/FioriThemeManager/ColorCompatibilityMap/ColorCompatibilityMapV4.swift:17:26: 'primary4' is deprecated: renamed to 'secondaryFill'

/github/cloud-sdk-ios-fiori/Sources/FioriThemeManager/ColorCompatibilityMap/ColorCompatibilityMapV4.swift:18:39: 'primary6' is deprecated: renamed to 'secondaryGroupedBackground'

/github/cloud-sdk-ios-fiori/Sources/FioriThemeManager/ColorCompatibilityMap/ColorCompatibilityMapV4.swift:19:28: 'primary7' is deprecated: renamed to 'quaternaryLabel'

/github/cloud-sdk-ios-fiori/Sources/FioriThemeManager/ColorCompatibilityMap/ColorCompatibilityMapV4.swift:20:27: 'primary8' is deprecated: renamed to 'barTransparent'

/github/cloud-sdk-ios-fiori/Sources/FioriThemeManager/ColorCompatibilityMap/ColorCompatibilityMapV4.swift:21:22: 'primary9' is deprecated: renamed to 'separator'

/github/cloud-sdk-ios-fiori/Sources/FioriThemeManager/ColorCompatibilityMap/ColorCompatibilityMapV4.swift:22:26: 'backgroundGradientTop' is deprecated: renamed to 'header'

/github/cloud-sdk-ios-fiori/Sources/FioriThemeManager/ColorCompatibilityMap/ColorCompatibilityMapV4.swift:23:19: 'backgroundGradientBottom' is deprecated: renamed to 'header'

/github/cloud-sdk-ios-fiori/Sources/FioriThemeManager/ColorCompatibilityMap/ColorCompatibilityMapV4.swift:24:37: 'backgroundBase' is deprecated: renamed to 'primaryBackground'

/github/cloud-sdk-ios-fiori/Sources/FioriThemeManager/ColorCompatibilityMap/ColorCompatibilityMapV5.swift:14:28: 'line' is deprecated: renamed to 'separatorOpaque'

/github/cloud-sdk-ios-fiori/Sources/FioriThemeManager/ColorCompatibilityMap/ColorCompatibilityMapV5.swift:15:28: 'primary10' is deprecated: renamed to 'contrastElement'

/github/cloud-sdk-ios-fiori/Sources/FioriThemeManager/ColorCompatibilityMap/ColorCompatibilityMapV5.swift:16:23: 'tintColorDark' is deprecated: renamed to 'tintColor2'

/github/cloud-sdk-ios-fiori/Sources/FioriThemeManager/ColorCompatibilityMap/ColorCompatibilityMapV5.swift:17:23: 'shadow' is deprecated: renamed to 'cardShadow'

