### PR TITLE
fix: 🐛 improve Carousel's drag gesture to avoid conflicts

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/Card/MobileCardExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/Card/MobileCardExample.swift
@@ -107,12 +107,18 @@ struct CarouselTestView: View {
     
     var body: some View {
         ScrollView(.vertical) {
-            Carousel(numberOfColumns: Int(self.numberOfColumns), spacing: self.spacing, alignment: self.alignment == 0 ? .top : (self.alignment == 1 ? .center : .bottom), isSnapping: self.isSnapping, isSameHeight: self.isSameHeight) {
-                ForEach(0 ..< CardTests.cardSamples.count, id: \.self) { i in
-                    NavigationLink(destination: Text("Detail View")) {
-                        CardTests.cardSamples[i]
+            VStack(alignment: .leading, spacing: 24) {
+                RoundedRectangle(cornerRadius: 16).foregroundStyle(Color.preferredColor(.grey3)).frame(height: 300)
+                
+                Carousel(numberOfColumns: Int(self.numberOfColumns), spacing: self.spacing, alignment: self.alignment == 0 ? .top : (self.alignment == 1 ? .center : .bottom), isSnapping: self.isSnapping, isSameHeight: self.isSameHeight) {
+                    ForEach(0 ..< CardTests.cardSamples.count, id: \.self) { i in
+                        NavigationLink(destination: Text("Detail View")) {
+                            CardTests.cardSamples[i]
+                        }
                     }
                 }
+                
+                RoundedRectangle(cornerRadius: 16).foregroundStyle(Color.preferredColor(.grey3)).frame(height: 300)
             }
             .cardStyle(.card)
             .padding(self.padding)

--- a/Sources/FioriSwiftUICore/Views/Carousel.swift
+++ b/Sources/FioriSwiftUICore/Views/Carousel.swift
@@ -260,7 +260,7 @@ public struct Carousel<Content>: View where Content: View {
             }
             .contentShape(Rectangle())
             .highPriorityGesture(
-                DragGesture()
+                DragGesture(minimumDistance: 20)
                     .onChanged { value in
                         self.contentOffset.x = self.preContentOffset.x + (self.layoutDirection == .leftToRight ? -1 : 1) * value.translation.width
                     }
@@ -273,7 +273,6 @@ public struct Carousel<Content>: View where Content: View {
                             if self.isSnapping {
                                 let itemWidth: CGFloat = (viewSize.width - CGFloat(self.numberOfColumns + 2) * self.spacing) / CGFloat(self.numberOfColumns)
                                 let index = (expectedX / (itemWidth + self.spacing)).rounded()
-                                //                                finalX = max(0, min(maxX, index * (itemWidth + self.spacing) - self.spacing))
                                 finalX = max(0, min(maxX, index * (itemWidth + self.spacing)))
                             }
                             


### PR DESCRIPTION
Cherrypick from main

Improve Carousel's drag gesture to avoid conflicts btw a carousel's
horizontal scrolling and the parent scrollview's vertical scrolling

https://github.com/user-attachments/assets/85b7bee3-9f56-4cf6-a007-5f62b1e93960

