### PR TITLE
refactor: 💡 add identifier for each component

### DIFF
--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/AccessoryIcon/AccessoryIcon.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/AccessoryIcon/AccessoryIcon.generated.swift
@@ -8,11 +8,20 @@ public struct AccessoryIcon {
 
     @Environment(\.accessoryIconStyle) var style
 
+    var componentIdentifier: String = AccessoryIcon.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder accessoryIcon: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder accessoryIcon: () -> any View = { EmptyView() },
+                componentIdentifier: String? = AccessoryIcon.identifier)
+    {
         self.accessoryIcon = accessoryIcon()
+        self.componentIdentifier = componentIdentifier ?? AccessoryIcon.identifier
     }
+}
+
+public extension AccessoryIcon {
+    static let identifier = "fiori_accessoryicon_component"
 }
 
 public extension AccessoryIcon {
@@ -29,6 +38,7 @@ public extension AccessoryIcon {
     internal init(_ configuration: AccessoryIconConfiguration, shouldApplyDefaultStyle: Bool) {
         self.accessoryIcon = configuration.accessoryIcon
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension AccessoryIcon: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(accessoryIcon: .init(self.accessoryIcon))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, accessoryIcon: .init(self.accessoryIcon))).typeErased
                 .transformEnvironment(\.accessoryIconStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension AccessoryIcon {
     }
 
     func defaultStyle() -> some View {
-        AccessoryIcon(.init(accessoryIcon: .init(self.accessoryIcon)))
+        AccessoryIcon(.init(componentIdentifier: self.componentIdentifier, accessoryIcon: .init(self.accessoryIcon)))
             .shouldApplyDefaultStyle(false)
             .accessoryIconStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/AccessoryIcon/AccessoryIconStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/AccessoryIcon/AccessoryIconStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyAccessoryIconStyle: AccessoryIconStyle {
 }
 
 public struct AccessoryIconConfiguration {
+    public var componentIdentifier: String = "fiori_accessoryicon_component"
     public let accessoryIcon: AccessoryIcon
 
     public typealias AccessoryIcon = ConfigurationViewWrapper
+}
+
+extension AccessoryIconConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Action/Action.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Action/Action.generated.swift
@@ -8,11 +8,20 @@ public struct Action {
 
     @Environment(\.actionStyle) var style
 
+    var componentIdentifier: String = Action.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder action: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder action: () -> any View = { EmptyView() },
+                componentIdentifier: String? = Action.identifier)
+    {
         self.action = action()
+        self.componentIdentifier = componentIdentifier ?? Action.identifier
     }
+}
+
+public extension Action {
+    static let identifier = "fiori_action_component"
 }
 
 public extension Action {
@@ -29,6 +38,7 @@ public extension Action {
     internal init(_ configuration: ActionConfiguration, shouldApplyDefaultStyle: Bool) {
         self.action = configuration.action
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension Action: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(action: .init(self.action))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, action: .init(self.action))).typeErased
                 .transformEnvironment(\.actionStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension Action {
     }
 
     func defaultStyle() -> some View {
-        Action(.init(action: .init(self.action)))
+        Action(.init(componentIdentifier: self.componentIdentifier, action: .init(self.action)))
             .shouldApplyDefaultStyle(false)
             .actionStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Action/ActionStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Action/ActionStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyActionStyle: ActionStyle {
 }
 
 public struct ActionConfiguration {
+    public var componentIdentifier: String = "fiori_action_component"
     public let action: Action
 
     public typealias Action = ConfigurationViewWrapper
+}
+
+extension ActionConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/ActiveTrack/ActiveTrack.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/ActiveTrack/ActiveTrack.generated.swift
@@ -8,11 +8,20 @@ public struct ActiveTrack {
 
     @Environment(\.activeTrackStyle) var style
 
+    var componentIdentifier: String = ActiveTrack.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder activeTrack: () -> any View) {
+    public init(@ViewBuilder activeTrack: () -> any View,
+                componentIdentifier: String? = ActiveTrack.identifier)
+    {
         self.activeTrack = activeTrack()
+        self.componentIdentifier = componentIdentifier ?? ActiveTrack.identifier
     }
+}
+
+public extension ActiveTrack {
+    static let identifier = "fiori_activetrack_component"
 }
 
 public extension ActiveTrack {
@@ -29,6 +38,7 @@ public extension ActiveTrack {
     internal init(_ configuration: ActiveTrackConfiguration, shouldApplyDefaultStyle: Bool) {
         self.activeTrack = configuration.activeTrack
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension ActiveTrack: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(activeTrack: .init(self.activeTrack))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, activeTrack: .init(self.activeTrack))).typeErased
                 .transformEnvironment(\.activeTrackStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension ActiveTrack {
     }
 
     func defaultStyle() -> some View {
-        ActiveTrack(.init(activeTrack: .init(self.activeTrack)))
+        ActiveTrack(.init(componentIdentifier: self.componentIdentifier, activeTrack: .init(self.activeTrack)))
             .shouldApplyDefaultStyle(false)
             .activeTrackStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/ActiveTrack/ActiveTrackStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/ActiveTrack/ActiveTrackStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyActiveTrackStyle: ActiveTrackStyle {
 }
 
 public struct ActiveTrackConfiguration {
+    public var componentIdentifier: String = "fiori_activetrack_component"
     public let activeTrack: ActiveTrack
 
     public typealias ActiveTrack = ConfigurationViewWrapper
+}
+
+extension ActiveTrackConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/ActivityItem/ActivityItem.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/ActivityItem/ActivityItem.generated.swift
@@ -17,16 +17,24 @@ public struct ActivityItem {
 
     @Environment(\.activityItemStyle) var style
 
+    var componentIdentifier: String = ActivityItem.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder icon: () -> any View = { EmptyView() },
                 @ViewBuilder subtitle: () -> any View = { EmptyView() },
-                layout: ActivityItemLayout = .vertical)
+                layout: ActivityItemLayout = .vertical,
+                componentIdentifier: String? = ActivityItem.identifier)
     {
-        self.icon = Icon(icon: icon)
-        self.subtitle = Subtitle(subtitle: subtitle)
+        self.icon = Icon(icon: icon, componentIdentifier: componentIdentifier)
+        self.subtitle = Subtitle(subtitle: subtitle, componentIdentifier: componentIdentifier)
         self.layout = layout
+        self.componentIdentifier = componentIdentifier ?? ActivityItem.identifier
     }
+}
+
+public extension ActivityItem {
+    static let identifier = "fiori_activityitem_component"
 }
 
 public extension ActivityItem {
@@ -48,6 +56,7 @@ public extension ActivityItem {
         self.subtitle = configuration.subtitle
         self.layout = configuration.layout
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -56,7 +65,7 @@ extension ActivityItem: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(icon: .init(self.icon), subtitle: .init(self.subtitle), layout: self.layout)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, icon: .init(self.icon), subtitle: .init(self.subtitle), layout: self.layout)).typeErased
                 .transformEnvironment(\.activityItemStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -74,7 +83,7 @@ private extension ActivityItem {
     }
 
     func defaultStyle() -> some View {
-        ActivityItem(.init(icon: .init(self.icon), subtitle: .init(self.subtitle), layout: self.layout))
+        ActivityItem(.init(componentIdentifier: self.componentIdentifier, icon: .init(self.icon), subtitle: .init(self.subtitle), layout: self.layout))
             .shouldApplyDefaultStyle(false)
             .activityItemStyle(ActivityItemFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/ActivityItem/ActivityItemStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/ActivityItem/ActivityItemStyle.generated.swift
@@ -22,12 +22,19 @@ struct AnyActivityItemStyle: ActivityItemStyle {
 }
 
 public struct ActivityItemConfiguration {
+    public var componentIdentifier: String = "fiori_activityitem_component"
     public let icon: Icon
     public let subtitle: Subtitle
     public let layout: ActivityItemLayout
 
     public typealias Icon = ConfigurationViewWrapper
     public typealias Subtitle = ConfigurationViewWrapper
+}
+
+extension ActivityItemConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct ActivityItemFioriStyle: ActivityItemStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/ActivityItems/ActivityItems.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/ActivityItems/ActivityItems.generated.swift
@@ -18,11 +18,20 @@ public struct ActivityItems {
 
     @Environment(\.activityItemsStyle) var style
 
+    var componentIdentifier: String = ActivityItems.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ActivityItemsBuilder activityItems: () -> any View = { EmptyView() }) {
+    public init(@ActivityItemsBuilder activityItems: () -> any View = { EmptyView() },
+                componentIdentifier: String? = ActivityItems.identifier)
+    {
         self.activityItems = activityItems()
+        self.componentIdentifier = componentIdentifier ?? ActivityItems.identifier
     }
+}
+
+public extension ActivityItems {
+    static let identifier = "fiori_activityitems_component"
 }
 
 public extension ActivityItems {
@@ -39,6 +48,7 @@ public extension ActivityItems {
     internal init(_ configuration: ActivityItemsConfiguration, shouldApplyDefaultStyle: Bool) {
         self.activityItems = configuration.activityItems
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -47,7 +57,7 @@ extension ActivityItems: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(activityItems: .init(self.activityItems))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, activityItems: .init(self.activityItems))).typeErased
                 .transformEnvironment(\.activityItemsStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -65,7 +75,7 @@ private extension ActivityItems {
     }
 
     func defaultStyle() -> some View {
-        ActivityItems(.init(activityItems: .init(self.activityItems)))
+        ActivityItems(.init(componentIdentifier: self.componentIdentifier, activityItems: .init(self.activityItems)))
             .shouldApplyDefaultStyle(false)
             .activityItemsStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/ActivityItems/ActivityItemsStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/ActivityItems/ActivityItemsStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyActivityItemsStyle: ActivityItemsStyle {
 }
 
 public struct ActivityItemsConfiguration {
+    public var componentIdentifier: String = "fiori_activityitems_component"
     public let activityItems: ActivityItems
 
     public typealias ActivityItems = ConfigurationViewWrapper
+}
+
+extension ActivityItemsConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/AllEntriesSectionTitle/AllEntriesSectionTitle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/AllEntriesSectionTitle/AllEntriesSectionTitle.generated.swift
@@ -8,11 +8,20 @@ public struct AllEntriesSectionTitle {
 
     @Environment(\.allEntriesSectionTitleStyle) var style
 
+    var componentIdentifier: String = AllEntriesSectionTitle.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder allEntriesSectionTitle: () -> any View = { Text("All".localizedFioriString()) }) {
+    public init(@ViewBuilder allEntriesSectionTitle: () -> any View = { Text("All".localizedFioriString()) },
+                componentIdentifier: String? = AllEntriesSectionTitle.identifier)
+    {
         self.allEntriesSectionTitle = allEntriesSectionTitle()
+        self.componentIdentifier = componentIdentifier ?? AllEntriesSectionTitle.identifier
     }
+}
+
+public extension AllEntriesSectionTitle {
+    static let identifier = "fiori_allentriessectiontitle_component"
 }
 
 public extension AllEntriesSectionTitle {
@@ -29,6 +38,7 @@ public extension AllEntriesSectionTitle {
     internal init(_ configuration: AllEntriesSectionTitleConfiguration, shouldApplyDefaultStyle: Bool) {
         self.allEntriesSectionTitle = configuration.allEntriesSectionTitle
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension AllEntriesSectionTitle: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(allEntriesSectionTitle: .init(self.allEntriesSectionTitle))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, allEntriesSectionTitle: .init(self.allEntriesSectionTitle))).typeErased
                 .transformEnvironment(\.allEntriesSectionTitleStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension AllEntriesSectionTitle {
     }
 
     func defaultStyle() -> some View {
-        AllEntriesSectionTitle(.init(allEntriesSectionTitle: .init(self.allEntriesSectionTitle)))
+        AllEntriesSectionTitle(.init(componentIdentifier: self.componentIdentifier, allEntriesSectionTitle: .init(self.allEntriesSectionTitle)))
             .shouldApplyDefaultStyle(false)
             .allEntriesSectionTitleStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/AllEntriesSectionTitle/AllEntriesSectionTitleStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/AllEntriesSectionTitle/AllEntriesSectionTitleStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyAllEntriesSectionTitleStyle: AllEntriesSectionTitleStyle {
 }
 
 public struct AllEntriesSectionTitleConfiguration {
+    public var componentIdentifier: String = "fiori_allentriessectiontitle_component"
     public let allEntriesSectionTitle: AllEntriesSectionTitle
 
     public typealias AllEntriesSectionTitle = ConfigurationViewWrapper
+}
+
+extension AllEntriesSectionTitleConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/ApplyAction/ApplyAction.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/ApplyAction/ApplyAction.generated.swift
@@ -8,11 +8,20 @@ public struct ApplyAction {
 
     @Environment(\.applyActionStyle) var style
 
+    var componentIdentifier: String = ApplyAction.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder applyAction: () -> any View = { FioriButton { _ in Text("Apply".localizedFioriString()) } }) {
+    public init(@ViewBuilder applyAction: () -> any View = { FioriButton { _ in Text("Apply".localizedFioriString()) } },
+                componentIdentifier: String? = ApplyAction.identifier)
+    {
         self.applyAction = applyAction()
+        self.componentIdentifier = componentIdentifier ?? ApplyAction.identifier
     }
+}
+
+public extension ApplyAction {
+    static let identifier = "fiori_applyaction_component"
 }
 
 public extension ApplyAction {
@@ -29,6 +38,7 @@ public extension ApplyAction {
     internal init(_ configuration: ApplyActionConfiguration, shouldApplyDefaultStyle: Bool) {
         self.applyAction = configuration.applyAction
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension ApplyAction: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(applyAction: .init(self.applyAction))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, applyAction: .init(self.applyAction))).typeErased
                 .transformEnvironment(\.applyActionStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension ApplyAction {
     }
 
     func defaultStyle() -> some View {
-        ApplyAction(.init(applyAction: .init(self.applyAction)))
+        ApplyAction(.init(componentIdentifier: self.componentIdentifier, applyAction: .init(self.applyAction)))
             .shouldApplyDefaultStyle(false)
             .applyActionStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/ApplyAction/ApplyActionStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/ApplyAction/ApplyActionStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyApplyActionStyle: ApplyActionStyle {
 }
 
 public struct ApplyActionConfiguration {
+    public var componentIdentifier: String = "fiori_applyaction_component"
     public let applyAction: ApplyAction
 
     public typealias ApplyAction = ConfigurationViewWrapper
+}
+
+extension ApplyActionConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Attribute/Attribute.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Attribute/Attribute.generated.swift
@@ -8,11 +8,20 @@ public struct Attribute {
 
     @Environment(\.attributeStyle) var style
 
+    var componentIdentifier: String = Attribute.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder attribute: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder attribute: () -> any View = { EmptyView() },
+                componentIdentifier: String? = Attribute.identifier)
+    {
         self.attribute = attribute()
+        self.componentIdentifier = componentIdentifier ?? Attribute.identifier
     }
+}
+
+public extension Attribute {
+    static let identifier = "fiori_attribute_component"
 }
 
 public extension Attribute {
@@ -29,6 +38,7 @@ public extension Attribute {
     internal init(_ configuration: AttributeConfiguration, shouldApplyDefaultStyle: Bool) {
         self.attribute = configuration.attribute
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension Attribute: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(attribute: .init(self.attribute))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, attribute: .init(self.attribute))).typeErased
                 .transformEnvironment(\.attributeStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension Attribute {
     }
 
     func defaultStyle() -> some View {
-        Attribute(.init(attribute: .init(self.attribute)))
+        Attribute(.init(componentIdentifier: self.componentIdentifier, attribute: .init(self.attribute)))
             .shouldApplyDefaultStyle(false)
             .attributeStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Attribute/AttributeStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Attribute/AttributeStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyAttributeStyle: AttributeStyle {
 }
 
 public struct AttributeConfiguration {
+    public var componentIdentifier: String = "fiori_attribute_component"
     public let attribute: Attribute
 
     public typealias Attribute = ConfigurationViewWrapper
+}
+
+extension AttributeConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/AvatarStack/AvatarStack.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/AvatarStack/AvatarStack.generated.swift
@@ -9,14 +9,22 @@ public struct AvatarStack {
 
     @Environment(\.avatarStackStyle) var style
 
+    var componentIdentifier: String = AvatarStack.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@AvatarsBuilder avatars: () -> any View = { EmptyView() },
-                @ViewBuilder avatarsTitle: () -> any View = { EmptyView() })
+                @ViewBuilder avatarsTitle: () -> any View = { EmptyView() },
+                componentIdentifier: String? = AvatarStack.identifier)
     {
-        self.avatars = Avatars(avatars: avatars)
-        self.avatarsTitle = AvatarsTitle(avatarsTitle: avatarsTitle)
+        self.avatars = Avatars(avatars: avatars, componentIdentifier: componentIdentifier)
+        self.avatarsTitle = AvatarsTitle(avatarsTitle: avatarsTitle, componentIdentifier: componentIdentifier)
+        self.componentIdentifier = componentIdentifier ?? AvatarStack.identifier
     }
+}
+
+public extension AvatarStack {
+    static let identifier = "fiori_avatarstack_component"
 }
 
 public extension AvatarStack {
@@ -36,6 +44,7 @@ public extension AvatarStack {
         self.avatars = configuration.avatars
         self.avatarsTitle = configuration.avatarsTitle
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -44,7 +53,7 @@ extension AvatarStack: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(avatars: .init(self.avatars), avatarsTitle: .init(self.avatarsTitle))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, avatars: .init(self.avatars), avatarsTitle: .init(self.avatarsTitle))).typeErased
                 .transformEnvironment(\.avatarStackStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -62,7 +71,7 @@ private extension AvatarStack {
     }
 
     func defaultStyle() -> some View {
-        AvatarStack(.init(avatars: .init(self.avatars), avatarsTitle: .init(self.avatarsTitle)))
+        AvatarStack(.init(componentIdentifier: self.componentIdentifier, avatars: .init(self.avatars), avatarsTitle: .init(self.avatarsTitle)))
             .shouldApplyDefaultStyle(false)
             .avatarStackStyle(AvatarStackFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/AvatarStack/AvatarStackStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/AvatarStack/AvatarStackStyle.generated.swift
@@ -22,11 +22,18 @@ struct AnyAvatarStackStyle: AvatarStackStyle {
 }
 
 public struct AvatarStackConfiguration {
+    public var componentIdentifier: String = "fiori_avatarstack_component"
     public let avatars: Avatars
     public let avatarsTitle: AvatarsTitle
 
     public typealias Avatars = ConfigurationViewWrapper
     public typealias AvatarsTitle = ConfigurationViewWrapper
+}
+
+extension AvatarStackConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct AvatarStackFioriStyle: AvatarStackStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Avatars/Avatars.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Avatars/Avatars.generated.swift
@@ -8,11 +8,20 @@ public struct Avatars {
 
     @Environment(\.avatarsStyle) var style
 
+    var componentIdentifier: String = Avatars.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@AvatarsBuilder avatars: () -> any View = { EmptyView() }) {
+    public init(@AvatarsBuilder avatars: () -> any View = { EmptyView() },
+                componentIdentifier: String? = Avatars.identifier)
+    {
         self.avatars = avatars()
+        self.componentIdentifier = componentIdentifier ?? Avatars.identifier
     }
+}
+
+public extension Avatars {
+    static let identifier = "fiori_avatars_component"
 }
 
 public extension Avatars {
@@ -29,6 +38,7 @@ public extension Avatars {
     internal init(_ configuration: AvatarsConfiguration, shouldApplyDefaultStyle: Bool) {
         self.avatars = configuration.avatars
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension Avatars: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(avatars: .init(self.avatars))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, avatars: .init(self.avatars))).typeErased
                 .transformEnvironment(\.avatarsStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension Avatars {
     }
 
     func defaultStyle() -> some View {
-        Avatars(.init(avatars: .init(self.avatars)))
+        Avatars(.init(componentIdentifier: self.componentIdentifier, avatars: .init(self.avatars)))
             .shouldApplyDefaultStyle(false)
             .avatarsStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Avatars/AvatarsStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Avatars/AvatarsStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyAvatarsStyle: AvatarsStyle {
 }
 
 public struct AvatarsConfiguration {
+    public var componentIdentifier: String = "fiori_avatars_component"
     public let avatars: Avatars
 
     public typealias Avatars = ConfigurationViewWrapper
+}
+
+extension AvatarsConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/AvatarsTitle/AvatarsTitle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/AvatarsTitle/AvatarsTitle.generated.swift
@@ -8,11 +8,20 @@ public struct AvatarsTitle {
 
     @Environment(\.avatarsTitleStyle) var style
 
+    var componentIdentifier: String = AvatarsTitle.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder avatarsTitle: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder avatarsTitle: () -> any View = { EmptyView() },
+                componentIdentifier: String? = AvatarsTitle.identifier)
+    {
         self.avatarsTitle = avatarsTitle()
+        self.componentIdentifier = componentIdentifier ?? AvatarsTitle.identifier
     }
+}
+
+public extension AvatarsTitle {
+    static let identifier = "fiori_avatarstitle_component"
 }
 
 public extension AvatarsTitle {
@@ -29,6 +38,7 @@ public extension AvatarsTitle {
     internal init(_ configuration: AvatarsTitleConfiguration, shouldApplyDefaultStyle: Bool) {
         self.avatarsTitle = configuration.avatarsTitle
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension AvatarsTitle: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(avatarsTitle: .init(self.avatarsTitle))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, avatarsTitle: .init(self.avatarsTitle))).typeErased
                 .transformEnvironment(\.avatarsTitleStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension AvatarsTitle {
     }
 
     func defaultStyle() -> some View {
-        AvatarsTitle(.init(avatarsTitle: .init(self.avatarsTitle)))
+        AvatarsTitle(.init(componentIdentifier: self.componentIdentifier, avatarsTitle: .init(self.avatarsTitle)))
             .shouldApplyDefaultStyle(false)
             .avatarsTitleStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/AvatarsTitle/AvatarsTitleStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/AvatarsTitle/AvatarsTitleStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyAvatarsTitleStyle: AvatarsTitleStyle {
 }
 
 public struct AvatarsTitleConfiguration {
+    public var componentIdentifier: String = "fiori_avatarstitle_component"
     public let avatarsTitle: AvatarsTitle
 
     public typealias AvatarsTitle = ConfigurationViewWrapper
+}
+
+extension AvatarsTitleConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/BannerMessage/BannerMessage.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/BannerMessage/BannerMessage.generated.swift
@@ -21,6 +21,8 @@ public struct BannerMessage {
 
     @Environment(\.bannerMessageStyle) var style
 
+    var componentIdentifier: String = BannerMessage.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder icon: () -> any View = { EmptyView() },
@@ -31,18 +33,24 @@ public struct BannerMessage {
                 alignment: HorizontalAlignment = .center,
                 hideSeparator: Bool = false,
                 messageType: BannerMultiMessageType = .negative,
-                showDetailLink: Bool = false)
+                showDetailLink: Bool = false,
+                componentIdentifier: String? = BannerMessage.identifier)
     {
-        self.icon = Icon(icon: icon)
-        self.title = Title(title: title)
-        self.closeAction = CloseAction(closeAction: closeAction)
-        self.topDivider = TopDivider(topDivider: topDivider)
+        self.icon = Icon(icon: icon, componentIdentifier: componentIdentifier)
+        self.title = Title(title: title, componentIdentifier: componentIdentifier)
+        self.closeAction = CloseAction(closeAction: closeAction, componentIdentifier: componentIdentifier)
+        self.topDivider = TopDivider(topDivider: topDivider, componentIdentifier: componentIdentifier)
         self.bannerTapAction = bannerTapAction
         self.alignment = alignment
         self.hideSeparator = hideSeparator
         self.messageType = messageType
         self.showDetailLink = showDetailLink
+        self.componentIdentifier = componentIdentifier ?? BannerMessage.identifier
     }
+}
+
+public extension BannerMessage {
+    static let identifier = "fiori_bannermessage_component"
 }
 
 public extension BannerMessage {
@@ -76,6 +84,7 @@ public extension BannerMessage {
         self.messageType = configuration.messageType
         self.showDetailLink = configuration.showDetailLink
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -84,7 +93,7 @@ extension BannerMessage: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(icon: .init(self.icon), title: .init(self.title), closeAction: .init(self.closeAction), topDivider: .init(self.topDivider), bannerTapAction: self.bannerTapAction, alignment: self.alignment, hideSeparator: self.hideSeparator, messageType: self.messageType, showDetailLink: self.showDetailLink)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, icon: .init(self.icon), title: .init(self.title), closeAction: .init(self.closeAction), topDivider: .init(self.topDivider), bannerTapAction: self.bannerTapAction, alignment: self.alignment, hideSeparator: self.hideSeparator, messageType: self.messageType, showDetailLink: self.showDetailLink)).typeErased
                 .transformEnvironment(\.bannerMessageStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -102,7 +111,7 @@ private extension BannerMessage {
     }
 
     func defaultStyle() -> some View {
-        BannerMessage(.init(icon: .init(self.icon), title: .init(self.title), closeAction: .init(self.closeAction), topDivider: .init(self.topDivider), bannerTapAction: self.bannerTapAction, alignment: self.alignment, hideSeparator: self.hideSeparator, messageType: self.messageType, showDetailLink: self.showDetailLink))
+        BannerMessage(.init(componentIdentifier: self.componentIdentifier, icon: .init(self.icon), title: .init(self.title), closeAction: .init(self.closeAction), topDivider: .init(self.topDivider), bannerTapAction: self.bannerTapAction, alignment: self.alignment, hideSeparator: self.hideSeparator, messageType: self.messageType, showDetailLink: self.showDetailLink))
             .shouldApplyDefaultStyle(false)
             .bannerMessageStyle(BannerMessageFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/BannerMessage/BannerMessageStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/BannerMessage/BannerMessageStyle.generated.swift
@@ -22,6 +22,7 @@ struct AnyBannerMessageStyle: BannerMessageStyle {
 }
 
 public struct BannerMessageConfiguration {
+    public var componentIdentifier: String = "fiori_bannermessage_component"
     public let icon: Icon
     public let title: Title
     public let closeAction: CloseAction
@@ -36,6 +37,12 @@ public struct BannerMessageConfiguration {
     public typealias Title = ConfigurationViewWrapper
     public typealias CloseAction = ConfigurationViewWrapper
     public typealias TopDivider = ConfigurationViewWrapper
+}
+
+extension BannerMessageConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct BannerMessageFioriStyle: BannerMessageStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/BannerMultiMessageSheet/BannerMultiMessageSheet.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/BannerMultiMessageSheet/BannerMultiMessageSheet.generated.swift
@@ -21,6 +21,8 @@ public struct BannerMultiMessageSheet {
 
     @Environment(\.bannerMultiMessageSheetStyle) var style
 
+    var componentIdentifier: String = BannerMultiMessageSheet.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder title: () -> any View,
@@ -30,17 +32,23 @@ public struct BannerMultiMessageSheet {
                 viewDetailAction: ((UUID) -> Void)? = nil,
                 turnOnSectionHeader: Bool = true,
                 @ViewBuilder messageItemView: @escaping (UUID) -> any View = { _ in EmptyView() },
-                bannerMultiMessages: Binding<[BannerMessageListModel]>)
+                bannerMultiMessages: Binding<[BannerMessageListModel]>,
+                componentIdentifier: String? = BannerMultiMessageSheet.identifier)
     {
-        self.title = Title(title: title)
-        self.closeAction = CloseAction(closeAction: closeAction)
+        self.title = Title(title: title, componentIdentifier: componentIdentifier)
+        self.closeAction = CloseAction(closeAction: closeAction, componentIdentifier: componentIdentifier)
         self.dismissAction = dismissAction
         self.removeAction = removeAction
         self.viewDetailAction = viewDetailAction
         self.turnOnSectionHeader = turnOnSectionHeader
         self.messageItemView = messageItemView
         self._bannerMultiMessages = bannerMultiMessages
+        self.componentIdentifier = componentIdentifier ?? BannerMultiMessageSheet.identifier
     }
+}
+
+public extension BannerMultiMessageSheet {
+    static let identifier = "fiori_bannermultimessagesheet_component"
 }
 
 public extension BannerMultiMessageSheet {
@@ -72,6 +80,7 @@ public extension BannerMultiMessageSheet {
         self.messageItemView = configuration.messageItemView
         self._bannerMultiMessages = configuration.$bannerMultiMessages
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -80,7 +89,7 @@ extension BannerMultiMessageSheet: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(title: .init(self.title), closeAction: .init(self.closeAction), dismissAction: self.dismissAction, removeAction: self.removeAction, viewDetailAction: self.viewDetailAction, turnOnSectionHeader: self.turnOnSectionHeader, messageItemView: self.messageItemView, bannerMultiMessages: self.$bannerMultiMessages)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, title: .init(self.title), closeAction: .init(self.closeAction), dismissAction: self.dismissAction, removeAction: self.removeAction, viewDetailAction: self.viewDetailAction, turnOnSectionHeader: self.turnOnSectionHeader, messageItemView: self.messageItemView, bannerMultiMessages: self.$bannerMultiMessages)).typeErased
                 .transformEnvironment(\.bannerMultiMessageSheetStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -98,7 +107,7 @@ private extension BannerMultiMessageSheet {
     }
 
     func defaultStyle() -> some View {
-        BannerMultiMessageSheet(.init(title: .init(self.title), closeAction: .init(self.closeAction), dismissAction: self.dismissAction, removeAction: self.removeAction, viewDetailAction: self.viewDetailAction, turnOnSectionHeader: self.turnOnSectionHeader, messageItemView: self.messageItemView, bannerMultiMessages: self.$bannerMultiMessages))
+        BannerMultiMessageSheet(.init(componentIdentifier: self.componentIdentifier, title: .init(self.title), closeAction: .init(self.closeAction), dismissAction: self.dismissAction, removeAction: self.removeAction, viewDetailAction: self.viewDetailAction, turnOnSectionHeader: self.turnOnSectionHeader, messageItemView: self.messageItemView, bannerMultiMessages: self.$bannerMultiMessages))
             .shouldApplyDefaultStyle(false)
             .bannerMultiMessageSheetStyle(BannerMultiMessageSheetFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/BannerMultiMessageSheet/BannerMultiMessageSheetStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/BannerMultiMessageSheet/BannerMultiMessageSheetStyle.generated.swift
@@ -22,6 +22,7 @@ struct AnyBannerMultiMessageSheetStyle: BannerMultiMessageSheetStyle {
 }
 
 public struct BannerMultiMessageSheetConfiguration {
+    public var componentIdentifier: String = "fiori_bannermultimessagesheet_component"
     public let title: Title
     public let closeAction: CloseAction
     public let dismissAction: (() -> Void)?
@@ -33,6 +34,12 @@ public struct BannerMultiMessageSheetConfiguration {
 
     public typealias Title = ConfigurationViewWrapper
     public typealias CloseAction = ConfigurationViewWrapper
+}
+
+extension BannerMultiMessageSheetConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct BannerMultiMessageSheetFioriStyle: BannerMultiMessageSheetStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/BodyText/BodyText.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/BodyText/BodyText.generated.swift
@@ -8,11 +8,20 @@ public struct BodyText {
 
     @Environment(\.bodyTextStyle) var style
 
+    var componentIdentifier: String = BodyText.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder bodyText: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder bodyText: () -> any View = { EmptyView() },
+                componentIdentifier: String? = BodyText.identifier)
+    {
         self.bodyText = bodyText()
+        self.componentIdentifier = componentIdentifier ?? BodyText.identifier
     }
+}
+
+public extension BodyText {
+    static let identifier = "fiori_bodytext_component"
 }
 
 public extension BodyText {
@@ -29,6 +38,7 @@ public extension BodyText {
     internal init(_ configuration: BodyTextConfiguration, shouldApplyDefaultStyle: Bool) {
         self.bodyText = configuration.bodyText
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension BodyText: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(bodyText: .init(self.bodyText))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, bodyText: .init(self.bodyText))).typeErased
                 .transformEnvironment(\.bodyTextStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension BodyText {
     }
 
     func defaultStyle() -> some View {
-        BodyText(.init(bodyText: .init(self.bodyText)))
+        BodyText(.init(componentIdentifier: self.componentIdentifier, bodyText: .init(self.bodyText)))
             .shouldApplyDefaultStyle(false)
             .bodyTextStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/BodyText/BodyTextStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/BodyText/BodyTextStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyBodyTextStyle: BodyTextStyle {
 }
 
 public struct BodyTextConfiguration {
+    public var componentIdentifier: String = "fiori_bodytext_component"
     public let bodyText: BodyText
 
     public typealias BodyText = ConfigurationViewWrapper
+}
+
+extension BodyTextConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/CancelAction/CancelAction.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/CancelAction/CancelAction.generated.swift
@@ -8,11 +8,20 @@ public struct CancelAction {
 
     @Environment(\.cancelActionStyle) var style
 
+    var componentIdentifier: String = CancelAction.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder cancelAction: () -> any View = { FioriButton { _ in Text("Cancel".localizedFioriString()) } }) {
+    public init(@ViewBuilder cancelAction: () -> any View = { FioriButton { _ in Text("Cancel".localizedFioriString()) } },
+                componentIdentifier: String? = CancelAction.identifier)
+    {
         self.cancelAction = cancelAction()
+        self.componentIdentifier = componentIdentifier ?? CancelAction.identifier
     }
+}
+
+public extension CancelAction {
+    static let identifier = "fiori_cancelaction_component"
 }
 
 public extension CancelAction {
@@ -29,6 +38,7 @@ public extension CancelAction {
     internal init(_ configuration: CancelActionConfiguration, shouldApplyDefaultStyle: Bool) {
         self.cancelAction = configuration.cancelAction
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension CancelAction: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(cancelAction: .init(self.cancelAction))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, cancelAction: .init(self.cancelAction))).typeErased
                 .transformEnvironment(\.cancelActionStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension CancelAction {
     }
 
     func defaultStyle() -> some View {
-        CancelAction(.init(cancelAction: .init(self.cancelAction)))
+        CancelAction(.init(componentIdentifier: self.componentIdentifier, cancelAction: .init(self.cancelAction)))
             .shouldApplyDefaultStyle(false)
             .cancelActionStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/CancelAction/CancelActionStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/CancelAction/CancelActionStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyCancelActionStyle: CancelActionStyle {
 }
 
 public struct CancelActionConfiguration {
+    public var componentIdentifier: String = "fiori_cancelaction_component"
     public let cancelAction: CancelAction
 
     public typealias CancelAction = ConfigurationViewWrapper
+}
+
+extension CancelActionConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Card/Card.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Card/Card.generated.swift
@@ -25,6 +25,8 @@ public struct Card {
 
     @Environment(\.cardStyle) var style
 
+    var componentIdentifier: String = Card.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder mediaImage: () -> any View = { EmptyView() },
@@ -44,27 +46,33 @@ public struct Card {
                 @ViewBuilder action: () -> any View = { EmptyView() },
                 @ViewBuilder secondaryAction: () -> any View = { EmptyView() },
                 @ViewBuilder tertiaryAction: () -> any View = { EmptyView() },
-                @ViewBuilder overflowAction: () -> any View = { FioriButton { _ in Image(systemName: "ellipsis") } })
+                @ViewBuilder overflowAction: () -> any View = { FioriButton { _ in Image(systemName: "ellipsis") } },
+                componentIdentifier: String? = Card.identifier)
     {
-        self.mediaImage = MediaImage(mediaImage: mediaImage)
-        self.description = Description(description: description)
-        self.title = Title(title: title)
-        self.subtitle = Subtitle(subtitle: subtitle)
-        self.icons = Icons(icons: icons)
-        self.detailImage = DetailImage(detailImage: detailImage)
-        self.headerAction = HeaderAction(headerAction: headerAction)
-        self.counter = Counter(counter: counter)
-        self.row1 = Row1(row1: row1)
-        self.row2 = Row2(row2: row2)
-        self.row3 = Row3(row3: row3)
-        self.kpi = Kpi(kpi: kpi)
-        self.kpiCaption = KpiCaption(kpiCaption: kpiCaption)
-        self.cardBody = CardBody(cardBody: cardBody)
-        self.action = Action(action: action)
-        self.secondaryAction = SecondaryAction(secondaryAction: secondaryAction)
-        self.tertiaryAction = TertiaryAction(tertiaryAction: tertiaryAction)
-        self.overflowAction = OverflowAction(overflowAction: overflowAction)
+        self.mediaImage = MediaImage(mediaImage: mediaImage, componentIdentifier: componentIdentifier)
+        self.description = Description(description: description, componentIdentifier: componentIdentifier)
+        self.title = Title(title: title, componentIdentifier: componentIdentifier)
+        self.subtitle = Subtitle(subtitle: subtitle, componentIdentifier: componentIdentifier)
+        self.icons = Icons(icons: icons, componentIdentifier: componentIdentifier)
+        self.detailImage = DetailImage(detailImage: detailImage, componentIdentifier: componentIdentifier)
+        self.headerAction = HeaderAction(headerAction: headerAction, componentIdentifier: componentIdentifier)
+        self.counter = Counter(counter: counter, componentIdentifier: componentIdentifier)
+        self.row1 = Row1(row1: row1, componentIdentifier: componentIdentifier)
+        self.row2 = Row2(row2: row2, componentIdentifier: componentIdentifier)
+        self.row3 = Row3(row3: row3, componentIdentifier: componentIdentifier)
+        self.kpi = Kpi(kpi: kpi, componentIdentifier: componentIdentifier)
+        self.kpiCaption = KpiCaption(kpiCaption: kpiCaption, componentIdentifier: componentIdentifier)
+        self.cardBody = CardBody(cardBody: cardBody, componentIdentifier: componentIdentifier)
+        self.action = Action(action: action, componentIdentifier: componentIdentifier)
+        self.secondaryAction = SecondaryAction(secondaryAction: secondaryAction, componentIdentifier: componentIdentifier)
+        self.tertiaryAction = TertiaryAction(tertiaryAction: tertiaryAction, componentIdentifier: componentIdentifier)
+        self.overflowAction = OverflowAction(overflowAction: overflowAction, componentIdentifier: componentIdentifier)
+        self.componentIdentifier = componentIdentifier ?? Card.identifier
     }
+}
+
+public extension Card {
+    static let identifier = "fiori_card_component"
 }
 
 public extension Card {
@@ -116,6 +124,7 @@ public extension Card {
         self.tertiaryAction = configuration.tertiaryAction
         self.overflowAction = configuration.overflowAction
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -124,7 +133,7 @@ extension Card: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(mediaImage: .init(self.mediaImage), description: .init(self.description), title: .init(self.title), subtitle: .init(self.subtitle), icons: .init(self.icons), detailImage: .init(self.detailImage), headerAction: .init(self.headerAction), counter: .init(self.counter), row1: .init(self.row1), row2: .init(self.row2), row3: .init(self.row3), kpi: .init(self.kpi), kpiCaption: .init(self.kpiCaption), cardBody: .init(self.cardBody), action: .init(self.action), secondaryAction: .init(self.secondaryAction), tertiaryAction: .init(self.tertiaryAction), overflowAction: .init(self.overflowAction))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, mediaImage: .init(self.mediaImage), description: .init(self.description), title: .init(self.title), subtitle: .init(self.subtitle), icons: .init(self.icons), detailImage: .init(self.detailImage), headerAction: .init(self.headerAction), counter: .init(self.counter), row1: .init(self.row1), row2: .init(self.row2), row3: .init(self.row3), kpi: .init(self.kpi), kpiCaption: .init(self.kpiCaption), cardBody: .init(self.cardBody), action: .init(self.action), secondaryAction: .init(self.secondaryAction), tertiaryAction: .init(self.tertiaryAction), overflowAction: .init(self.overflowAction))).typeErased
                 .transformEnvironment(\.cardStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -142,7 +151,7 @@ private extension Card {
     }
 
     func defaultStyle() -> some View {
-        Card(.init(mediaImage: .init(self.mediaImage), description: .init(self.description), title: .init(self.title), subtitle: .init(self.subtitle), icons: .init(self.icons), detailImage: .init(self.detailImage), headerAction: .init(self.headerAction), counter: .init(self.counter), row1: .init(self.row1), row2: .init(self.row2), row3: .init(self.row3), kpi: .init(self.kpi), kpiCaption: .init(self.kpiCaption), cardBody: .init(self.cardBody), action: .init(self.action), secondaryAction: .init(self.secondaryAction), tertiaryAction: .init(self.tertiaryAction), overflowAction: .init(self.overflowAction)))
+        Card(.init(componentIdentifier: self.componentIdentifier, mediaImage: .init(self.mediaImage), description: .init(self.description), title: .init(self.title), subtitle: .init(self.subtitle), icons: .init(self.icons), detailImage: .init(self.detailImage), headerAction: .init(self.headerAction), counter: .init(self.counter), row1: .init(self.row1), row2: .init(self.row2), row3: .init(self.row3), kpi: .init(self.kpi), kpiCaption: .init(self.kpiCaption), cardBody: .init(self.cardBody), action: .init(self.action), secondaryAction: .init(self.secondaryAction), tertiaryAction: .init(self.tertiaryAction), overflowAction: .init(self.overflowAction)))
             .shouldApplyDefaultStyle(false)
             .cardStyle(CardFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Card/CardStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Card/CardStyle.generated.swift
@@ -22,6 +22,7 @@ struct AnyCardStyle: CardStyle {
 }
 
 public struct CardConfiguration {
+    public var componentIdentifier: String = "fiori_card_component"
     public let mediaImage: MediaImage
     public let description: Description
     public let title: Title
@@ -59,6 +60,12 @@ public struct CardConfiguration {
     public typealias SecondaryAction = ConfigurationViewWrapper
     public typealias TertiaryAction = ConfigurationViewWrapper
     public typealias OverflowAction = ConfigurationViewWrapper
+}
+
+extension CardConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct CardFioriStyle: CardStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/CardBody/CardBody.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/CardBody/CardBody.generated.swift
@@ -8,11 +8,20 @@ public struct CardBody {
 
     @Environment(\.cardBodyStyle) var style
 
+    var componentIdentifier: String = CardBody.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder cardBody: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder cardBody: () -> any View = { EmptyView() },
+                componentIdentifier: String? = CardBody.identifier)
+    {
         self.cardBody = cardBody()
+        self.componentIdentifier = componentIdentifier ?? CardBody.identifier
     }
+}
+
+public extension CardBody {
+    static let identifier = "fiori_cardbody_component"
 }
 
 public extension CardBody {
@@ -23,6 +32,7 @@ public extension CardBody {
     internal init(_ configuration: CardBodyConfiguration, shouldApplyDefaultStyle: Bool) {
         self.cardBody = configuration.cardBody
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -31,7 +41,7 @@ extension CardBody: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(cardBody: .init(self.cardBody))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, cardBody: .init(self.cardBody))).typeErased
                 .transformEnvironment(\.cardBodyStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -49,7 +59,7 @@ private extension CardBody {
     }
 
     func defaultStyle() -> some View {
-        CardBody(.init(cardBody: .init(self.cardBody)))
+        CardBody(.init(componentIdentifier: self.componentIdentifier, cardBody: .init(self.cardBody)))
             .shouldApplyDefaultStyle(false)
             .cardBodyStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/CardBody/CardBodyStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/CardBody/CardBodyStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyCardBodyStyle: CardBodyStyle {
 }
 
 public struct CardBodyConfiguration {
+    public var componentIdentifier: String = "fiori_cardbody_component"
     public let cardBody: CardBody
 
     public typealias CardBody = ConfigurationViewWrapper
+}
+
+extension CardBodyConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/CardExtHeader/CardExtHeader.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/CardExtHeader/CardExtHeader.generated.swift
@@ -12,20 +12,28 @@ public struct CardExtHeader {
 
     @Environment(\.cardExtHeaderStyle) var style
 
+    var componentIdentifier: String = CardExtHeader.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder row1: () -> any View = { EmptyView() },
                 @ViewBuilder row2: () -> any View = { EmptyView() },
                 @ViewBuilder row3: () -> any View = { EmptyView() },
                 @ViewBuilder kpi: () -> any View = { EmptyView() },
-                @ViewBuilder kpiCaption: () -> any View = { EmptyView() })
+                @ViewBuilder kpiCaption: () -> any View = { EmptyView() },
+                componentIdentifier: String? = CardExtHeader.identifier)
     {
-        self.row1 = Row1(row1: row1)
-        self.row2 = Row2(row2: row2)
-        self.row3 = Row3(row3: row3)
-        self.kpi = Kpi(kpi: kpi)
-        self.kpiCaption = KpiCaption(kpiCaption: kpiCaption)
+        self.row1 = Row1(row1: row1, componentIdentifier: componentIdentifier)
+        self.row2 = Row2(row2: row2, componentIdentifier: componentIdentifier)
+        self.row3 = Row3(row3: row3, componentIdentifier: componentIdentifier)
+        self.kpi = Kpi(kpi: kpi, componentIdentifier: componentIdentifier)
+        self.kpiCaption = KpiCaption(kpiCaption: kpiCaption, componentIdentifier: componentIdentifier)
+        self.componentIdentifier = componentIdentifier ?? CardExtHeader.identifier
     }
+}
+
+public extension CardExtHeader {
+    static let identifier = "fiori_cardextheader_component"
 }
 
 public extension CardExtHeader {
@@ -51,6 +59,7 @@ public extension CardExtHeader {
         self.kpi = configuration.kpi
         self.kpiCaption = configuration.kpiCaption
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -59,7 +68,7 @@ extension CardExtHeader: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(row1: .init(self.row1), row2: .init(self.row2), row3: .init(self.row3), kpi: .init(self.kpi), kpiCaption: .init(self.kpiCaption))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, row1: .init(self.row1), row2: .init(self.row2), row3: .init(self.row3), kpi: .init(self.kpi), kpiCaption: .init(self.kpiCaption))).typeErased
                 .transformEnvironment(\.cardExtHeaderStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -77,7 +86,7 @@ private extension CardExtHeader {
     }
 
     func defaultStyle() -> some View {
-        CardExtHeader(.init(row1: .init(self.row1), row2: .init(self.row2), row3: .init(self.row3), kpi: .init(self.kpi), kpiCaption: .init(self.kpiCaption)))
+        CardExtHeader(.init(componentIdentifier: self.componentIdentifier, row1: .init(self.row1), row2: .init(self.row2), row3: .init(self.row3), kpi: .init(self.kpi), kpiCaption: .init(self.kpiCaption)))
             .shouldApplyDefaultStyle(false)
             .cardExtHeaderStyle(CardExtHeaderFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/CardExtHeader/CardExtHeaderStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/CardExtHeader/CardExtHeaderStyle.generated.swift
@@ -22,6 +22,7 @@ struct AnyCardExtHeaderStyle: CardExtHeaderStyle {
 }
 
 public struct CardExtHeaderConfiguration {
+    public var componentIdentifier: String = "fiori_cardextheader_component"
     public let row1: Row1
     public let row2: Row2
     public let row3: Row3
@@ -33,6 +34,12 @@ public struct CardExtHeaderConfiguration {
     public typealias Row3 = ConfigurationViewWrapper
     public typealias Kpi = ConfigurationViewWrapper
     public typealias KpiCaption = ConfigurationViewWrapper
+}
+
+extension CardExtHeaderConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct CardExtHeaderFioriStyle: CardExtHeaderStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/CardFooter/CardFooter.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/CardFooter/CardFooter.generated.swift
@@ -11,18 +11,26 @@ public struct CardFooter {
 
     @Environment(\.cardFooterStyle) var style
 
+    var componentIdentifier: String = CardFooter.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder action: () -> any View = { EmptyView() },
                 @ViewBuilder secondaryAction: () -> any View = { EmptyView() },
                 @ViewBuilder tertiaryAction: () -> any View = { EmptyView() },
-                @ViewBuilder overflowAction: () -> any View = { FioriButton { _ in Image(systemName: "ellipsis") } })
+                @ViewBuilder overflowAction: () -> any View = { FioriButton { _ in Image(systemName: "ellipsis") } },
+                componentIdentifier: String? = CardFooter.identifier)
     {
-        self.action = Action(action: action)
-        self.secondaryAction = SecondaryAction(secondaryAction: secondaryAction)
-        self.tertiaryAction = TertiaryAction(tertiaryAction: tertiaryAction)
-        self.overflowAction = OverflowAction(overflowAction: overflowAction)
+        self.action = Action(action: action, componentIdentifier: componentIdentifier)
+        self.secondaryAction = SecondaryAction(secondaryAction: secondaryAction, componentIdentifier: componentIdentifier)
+        self.tertiaryAction = TertiaryAction(tertiaryAction: tertiaryAction, componentIdentifier: componentIdentifier)
+        self.overflowAction = OverflowAction(overflowAction: overflowAction, componentIdentifier: componentIdentifier)
+        self.componentIdentifier = componentIdentifier ?? CardFooter.identifier
     }
+}
+
+public extension CardFooter {
+    static let identifier = "fiori_cardfooter_component"
 }
 
 public extension CardFooter {
@@ -46,6 +54,7 @@ public extension CardFooter {
         self.tertiaryAction = configuration.tertiaryAction
         self.overflowAction = configuration.overflowAction
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -54,7 +63,7 @@ extension CardFooter: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(action: .init(self.action), secondaryAction: .init(self.secondaryAction), tertiaryAction: .init(self.tertiaryAction), overflowAction: .init(self.overflowAction))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, action: .init(self.action), secondaryAction: .init(self.secondaryAction), tertiaryAction: .init(self.tertiaryAction), overflowAction: .init(self.overflowAction))).typeErased
                 .transformEnvironment(\.cardFooterStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -72,7 +81,7 @@ private extension CardFooter {
     }
 
     func defaultStyle() -> some View {
-        CardFooter(.init(action: .init(self.action), secondaryAction: .init(self.secondaryAction), tertiaryAction: .init(self.tertiaryAction), overflowAction: .init(self.overflowAction)))
+        CardFooter(.init(componentIdentifier: self.componentIdentifier, action: .init(self.action), secondaryAction: .init(self.secondaryAction), tertiaryAction: .init(self.tertiaryAction), overflowAction: .init(self.overflowAction)))
             .shouldApplyDefaultStyle(false)
             .cardFooterStyle(CardFooterFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/CardFooter/CardFooterStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/CardFooter/CardFooterStyle.generated.swift
@@ -22,6 +22,7 @@ struct AnyCardFooterStyle: CardFooterStyle {
 }
 
 public struct CardFooterConfiguration {
+    public var componentIdentifier: String = "fiori_cardfooter_component"
     public let action: Action
     public let secondaryAction: SecondaryAction
     public let tertiaryAction: TertiaryAction
@@ -31,6 +32,12 @@ public struct CardFooterConfiguration {
     public typealias SecondaryAction = ConfigurationViewWrapper
     public typealias TertiaryAction = ConfigurationViewWrapper
     public typealias OverflowAction = ConfigurationViewWrapper
+}
+
+extension CardFooterConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct CardFooterFioriStyle: CardFooterStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/CardHeader/CardHeader.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/CardHeader/CardHeader.generated.swift
@@ -20,6 +20,8 @@ public struct CardHeader {
 
     @Environment(\.cardHeaderStyle) var style
 
+    var componentIdentifier: String = CardHeader.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder mediaImage: () -> any View = { EmptyView() },
@@ -34,22 +36,28 @@ public struct CardHeader {
                 @ViewBuilder row2: () -> any View = { EmptyView() },
                 @ViewBuilder row3: () -> any View = { EmptyView() },
                 @ViewBuilder kpi: () -> any View = { EmptyView() },
-                @ViewBuilder kpiCaption: () -> any View = { EmptyView() })
+                @ViewBuilder kpiCaption: () -> any View = { EmptyView() },
+                componentIdentifier: String? = CardHeader.identifier)
     {
-        self.mediaImage = MediaImage(mediaImage: mediaImage)
-        self.description = Description(description: description)
-        self.title = Title(title: title)
-        self.subtitle = Subtitle(subtitle: subtitle)
-        self.icons = Icons(icons: icons)
-        self.detailImage = DetailImage(detailImage: detailImage)
-        self.headerAction = HeaderAction(headerAction: headerAction)
-        self.counter = Counter(counter: counter)
-        self.row1 = Row1(row1: row1)
-        self.row2 = Row2(row2: row2)
-        self.row3 = Row3(row3: row3)
-        self.kpi = Kpi(kpi: kpi)
-        self.kpiCaption = KpiCaption(kpiCaption: kpiCaption)
+        self.mediaImage = MediaImage(mediaImage: mediaImage, componentIdentifier: componentIdentifier)
+        self.description = Description(description: description, componentIdentifier: componentIdentifier)
+        self.title = Title(title: title, componentIdentifier: componentIdentifier)
+        self.subtitle = Subtitle(subtitle: subtitle, componentIdentifier: componentIdentifier)
+        self.icons = Icons(icons: icons, componentIdentifier: componentIdentifier)
+        self.detailImage = DetailImage(detailImage: detailImage, componentIdentifier: componentIdentifier)
+        self.headerAction = HeaderAction(headerAction: headerAction, componentIdentifier: componentIdentifier)
+        self.counter = Counter(counter: counter, componentIdentifier: componentIdentifier)
+        self.row1 = Row1(row1: row1, componentIdentifier: componentIdentifier)
+        self.row2 = Row2(row2: row2, componentIdentifier: componentIdentifier)
+        self.row3 = Row3(row3: row3, componentIdentifier: componentIdentifier)
+        self.kpi = Kpi(kpi: kpi, componentIdentifier: componentIdentifier)
+        self.kpiCaption = KpiCaption(kpiCaption: kpiCaption, componentIdentifier: componentIdentifier)
+        self.componentIdentifier = componentIdentifier ?? CardHeader.identifier
     }
+}
+
+public extension CardHeader {
+    static let identifier = "fiori_cardheader_component"
 }
 
 public extension CardHeader {
@@ -91,6 +99,7 @@ public extension CardHeader {
         self.kpi = configuration.kpi
         self.kpiCaption = configuration.kpiCaption
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -99,7 +108,7 @@ extension CardHeader: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(mediaImage: .init(self.mediaImage), description: .init(self.description), title: .init(self.title), subtitle: .init(self.subtitle), icons: .init(self.icons), detailImage: .init(self.detailImage), headerAction: .init(self.headerAction), counter: .init(self.counter), row1: .init(self.row1), row2: .init(self.row2), row3: .init(self.row3), kpi: .init(self.kpi), kpiCaption: .init(self.kpiCaption))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, mediaImage: .init(self.mediaImage), description: .init(self.description), title: .init(self.title), subtitle: .init(self.subtitle), icons: .init(self.icons), detailImage: .init(self.detailImage), headerAction: .init(self.headerAction), counter: .init(self.counter), row1: .init(self.row1), row2: .init(self.row2), row3: .init(self.row3), kpi: .init(self.kpi), kpiCaption: .init(self.kpiCaption))).typeErased
                 .transformEnvironment(\.cardHeaderStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -117,7 +126,7 @@ private extension CardHeader {
     }
 
     func defaultStyle() -> some View {
-        CardHeader(.init(mediaImage: .init(self.mediaImage), description: .init(self.description), title: .init(self.title), subtitle: .init(self.subtitle), icons: .init(self.icons), detailImage: .init(self.detailImage), headerAction: .init(self.headerAction), counter: .init(self.counter), row1: .init(self.row1), row2: .init(self.row2), row3: .init(self.row3), kpi: .init(self.kpi), kpiCaption: .init(self.kpiCaption)))
+        CardHeader(.init(componentIdentifier: self.componentIdentifier, mediaImage: .init(self.mediaImage), description: .init(self.description), title: .init(self.title), subtitle: .init(self.subtitle), icons: .init(self.icons), detailImage: .init(self.detailImage), headerAction: .init(self.headerAction), counter: .init(self.counter), row1: .init(self.row1), row2: .init(self.row2), row3: .init(self.row3), kpi: .init(self.kpi), kpiCaption: .init(self.kpiCaption)))
             .shouldApplyDefaultStyle(false)
             .cardHeaderStyle(CardHeaderFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/CardHeader/CardHeaderStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/CardHeader/CardHeaderStyle.generated.swift
@@ -22,6 +22,7 @@ struct AnyCardHeaderStyle: CardHeaderStyle {
 }
 
 public struct CardHeaderConfiguration {
+    public var componentIdentifier: String = "fiori_cardheader_component"
     public let mediaImage: MediaImage
     public let description: Description
     public let title: Title
@@ -49,6 +50,12 @@ public struct CardHeaderConfiguration {
     public typealias Row3 = ConfigurationViewWrapper
     public typealias Kpi = ConfigurationViewWrapper
     public typealias KpiCaption = ConfigurationViewWrapper
+}
+
+extension CardHeaderConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct CardHeaderFioriStyle: CardHeaderStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/CardMainHeader/CardMainHeader.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/CardMainHeader/CardMainHeader.generated.swift
@@ -13,6 +13,8 @@ public struct CardMainHeader {
 
     @Environment(\.cardMainHeaderStyle) var style
 
+    var componentIdentifier: String = CardMainHeader.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder title: () -> any View,
@@ -20,15 +22,21 @@ public struct CardMainHeader {
                 @IconBuilder icons: () -> any View = { EmptyView() },
                 @ViewBuilder detailImage: () -> any View = { EmptyView() },
                 @ViewBuilder headerAction: () -> any View = { EmptyView() },
-                @ViewBuilder counter: () -> any View = { EmptyView() })
+                @ViewBuilder counter: () -> any View = { EmptyView() },
+                componentIdentifier: String? = CardMainHeader.identifier)
     {
-        self.title = Title(title: title)
-        self.subtitle = Subtitle(subtitle: subtitle)
-        self.icons = Icons(icons: icons)
-        self.detailImage = DetailImage(detailImage: detailImage)
-        self.headerAction = HeaderAction(headerAction: headerAction)
-        self.counter = Counter(counter: counter)
+        self.title = Title(title: title, componentIdentifier: componentIdentifier)
+        self.subtitle = Subtitle(subtitle: subtitle, componentIdentifier: componentIdentifier)
+        self.icons = Icons(icons: icons, componentIdentifier: componentIdentifier)
+        self.detailImage = DetailImage(detailImage: detailImage, componentIdentifier: componentIdentifier)
+        self.headerAction = HeaderAction(headerAction: headerAction, componentIdentifier: componentIdentifier)
+        self.counter = Counter(counter: counter, componentIdentifier: componentIdentifier)
+        self.componentIdentifier = componentIdentifier ?? CardMainHeader.identifier
     }
+}
+
+public extension CardMainHeader {
+    static let identifier = "fiori_cardmainheader_component"
 }
 
 public extension CardMainHeader {
@@ -56,6 +64,7 @@ public extension CardMainHeader {
         self.headerAction = configuration.headerAction
         self.counter = configuration.counter
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -64,7 +73,7 @@ extension CardMainHeader: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(title: .init(self.title), subtitle: .init(self.subtitle), icons: .init(self.icons), detailImage: .init(self.detailImage), headerAction: .init(self.headerAction), counter: .init(self.counter))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, title: .init(self.title), subtitle: .init(self.subtitle), icons: .init(self.icons), detailImage: .init(self.detailImage), headerAction: .init(self.headerAction), counter: .init(self.counter))).typeErased
                 .transformEnvironment(\.cardMainHeaderStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -82,7 +91,7 @@ private extension CardMainHeader {
     }
 
     func defaultStyle() -> some View {
-        CardMainHeader(.init(title: .init(self.title), subtitle: .init(self.subtitle), icons: .init(self.icons), detailImage: .init(self.detailImage), headerAction: .init(self.headerAction), counter: .init(self.counter)))
+        CardMainHeader(.init(componentIdentifier: self.componentIdentifier, title: .init(self.title), subtitle: .init(self.subtitle), icons: .init(self.icons), detailImage: .init(self.detailImage), headerAction: .init(self.headerAction), counter: .init(self.counter)))
             .shouldApplyDefaultStyle(false)
             .cardMainHeaderStyle(CardMainHeaderFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/CardMainHeader/CardMainHeaderStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/CardMainHeader/CardMainHeaderStyle.generated.swift
@@ -22,6 +22,7 @@ struct AnyCardMainHeaderStyle: CardMainHeaderStyle {
 }
 
 public struct CardMainHeaderConfiguration {
+    public var componentIdentifier: String = "fiori_cardmainheader_component"
     public let title: Title
     public let subtitle: Subtitle
     public let icons: Icons
@@ -35,6 +36,12 @@ public struct CardMainHeaderConfiguration {
     public typealias DetailImage = ConfigurationViewWrapper
     public typealias HeaderAction = ConfigurationViewWrapper
     public typealias Counter = ConfigurationViewWrapper
+}
+
+extension CardMainHeaderConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct CardMainHeaderFioriStyle: CardMainHeaderStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/CardMedia/CardMedia.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/CardMedia/CardMedia.generated.swift
@@ -9,14 +9,22 @@ public struct CardMedia {
 
     @Environment(\.cardMediaStyle) var style
 
+    var componentIdentifier: String = CardMedia.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder mediaImage: () -> any View = { EmptyView() },
-                @ViewBuilder description: () -> any View = { EmptyView() })
+                @ViewBuilder description: () -> any View = { EmptyView() },
+                componentIdentifier: String? = CardMedia.identifier)
     {
-        self.mediaImage = MediaImage(mediaImage: mediaImage)
-        self.description = Description(description: description)
+        self.mediaImage = MediaImage(mediaImage: mediaImage, componentIdentifier: componentIdentifier)
+        self.description = Description(description: description, componentIdentifier: componentIdentifier)
+        self.componentIdentifier = componentIdentifier ?? CardMedia.identifier
     }
+}
+
+public extension CardMedia {
+    static let identifier = "fiori_cardmedia_component"
 }
 
 public extension CardMedia {
@@ -36,6 +44,7 @@ public extension CardMedia {
         self.mediaImage = configuration.mediaImage
         self.description = configuration.description
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -44,7 +53,7 @@ extension CardMedia: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(mediaImage: .init(self.mediaImage), description: .init(self.description))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, mediaImage: .init(self.mediaImage), description: .init(self.description))).typeErased
                 .transformEnvironment(\.cardMediaStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -62,7 +71,7 @@ private extension CardMedia {
     }
 
     func defaultStyle() -> some View {
-        CardMedia(.init(mediaImage: .init(self.mediaImage), description: .init(self.description)))
+        CardMedia(.init(componentIdentifier: self.componentIdentifier, mediaImage: .init(self.mediaImage), description: .init(self.description)))
             .shouldApplyDefaultStyle(false)
             .cardMediaStyle(CardMediaFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/CardMedia/CardMediaStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/CardMedia/CardMediaStyle.generated.swift
@@ -22,11 +22,18 @@ struct AnyCardMediaStyle: CardMediaStyle {
 }
 
 public struct CardMediaConfiguration {
+    public var componentIdentifier: String = "fiori_cardmedia_component"
     public let mediaImage: MediaImage
     public let description: Description
 
     public typealias MediaImage = ConfigurationViewWrapper
     public typealias Description = ConfigurationViewWrapper
+}
+
+extension CardMediaConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct CardMediaFioriStyle: CardMediaStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/CheckoutIndicator/CheckoutIndicator.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/CheckoutIndicator/CheckoutIndicator.generated.swift
@@ -17,11 +17,20 @@ public struct CheckoutIndicator {
 
     @Environment(\.checkoutIndicatorStyle) var style
 
+    var componentIdentifier: String = CheckoutIndicator.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(displayState: Binding<DisplayState>) {
+    public init(displayState: Binding<DisplayState>,
+                componentIdentifier: String? = CheckoutIndicator.identifier)
+    {
         self._displayState = displayState
+        self.componentIdentifier = componentIdentifier ?? CheckoutIndicator.identifier
     }
+}
+
+public extension CheckoutIndicator {
+    static let identifier = "fiori_checkoutindicator_component"
 }
 
 public extension CheckoutIndicator {
@@ -32,6 +41,7 @@ public extension CheckoutIndicator {
     internal init(_ configuration: CheckoutIndicatorConfiguration, shouldApplyDefaultStyle: Bool) {
         self._displayState = configuration.$displayState
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -40,7 +50,7 @@ extension CheckoutIndicator: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(displayState: self.$displayState)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, displayState: self.$displayState)).typeErased
                 .transformEnvironment(\.checkoutIndicatorStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -58,7 +68,7 @@ private extension CheckoutIndicator {
     }
 
     func defaultStyle() -> some View {
-        CheckoutIndicator(.init(displayState: self.$displayState))
+        CheckoutIndicator(.init(componentIdentifier: self.componentIdentifier, displayState: self.$displayState))
             .shouldApplyDefaultStyle(false)
             .checkoutIndicatorStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/CheckoutIndicator/CheckoutIndicatorStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/CheckoutIndicator/CheckoutIndicatorStyle.generated.swift
@@ -22,5 +22,12 @@ struct AnyCheckoutIndicatorStyle: CheckoutIndicatorStyle {
 }
 
 public struct CheckoutIndicatorConfiguration {
+    public var componentIdentifier: String = "fiori_checkoutindicator_component"
     @Binding public var displayState: DisplayState
+}
+
+extension CheckoutIndicatorConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/CloseAction/CloseAction.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/CloseAction/CloseAction.generated.swift
@@ -8,11 +8,20 @@ public struct CloseAction {
 
     @Environment(\.closeActionStyle) var style
 
+    var componentIdentifier: String = CloseAction.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder closeAction: () -> any View = { FioriButton { _ in Image(systemName: "xmark") } }) {
+    public init(@ViewBuilder closeAction: () -> any View = { FioriButton { _ in Image(systemName: "xmark") } },
+                componentIdentifier: String? = CloseAction.identifier)
+    {
         self.closeAction = closeAction()
+        self.componentIdentifier = componentIdentifier ?? CloseAction.identifier
     }
+}
+
+public extension CloseAction {
+    static let identifier = "fiori_closeaction_component"
 }
 
 public extension CloseAction {
@@ -29,6 +38,7 @@ public extension CloseAction {
     internal init(_ configuration: CloseActionConfiguration, shouldApplyDefaultStyle: Bool) {
         self.closeAction = configuration.closeAction
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension CloseAction: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(closeAction: .init(self.closeAction))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, closeAction: .init(self.closeAction))).typeErased
                 .transformEnvironment(\.closeActionStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension CloseAction {
     }
 
     func defaultStyle() -> some View {
-        CloseAction(.init(closeAction: .init(self.closeAction)))
+        CloseAction(.init(componentIdentifier: self.componentIdentifier, closeAction: .init(self.closeAction)))
             .shouldApplyDefaultStyle(false)
             .closeActionStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/CloseAction/CloseActionStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/CloseAction/CloseActionStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyCloseActionStyle: CloseActionStyle {
 }
 
 public struct CloseActionConfiguration {
+    public var componentIdentifier: String = "fiori_closeaction_component"
     public let closeAction: CloseAction
 
     public typealias CloseAction = ConfigurationViewWrapper
+}
+
+extension CloseActionConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Counter/Counter.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Counter/Counter.generated.swift
@@ -8,11 +8,20 @@ public struct Counter {
 
     @Environment(\.counterStyle) var style
 
+    var componentIdentifier: String = Counter.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder counter: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder counter: () -> any View = { EmptyView() },
+                componentIdentifier: String? = Counter.identifier)
+    {
         self.counter = counter()
+        self.componentIdentifier = componentIdentifier ?? Counter.identifier
     }
+}
+
+public extension Counter {
+    static let identifier = "fiori_counter_component"
 }
 
 public extension Counter {
@@ -29,6 +38,7 @@ public extension Counter {
     internal init(_ configuration: CounterConfiguration, shouldApplyDefaultStyle: Bool) {
         self.counter = configuration.counter
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension Counter: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(counter: .init(self.counter))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, counter: .init(self.counter))).typeErased
                 .transformEnvironment(\.counterStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension Counter {
     }
 
     func defaultStyle() -> some View {
-        Counter(.init(counter: .init(self.counter)))
+        Counter(.init(componentIdentifier: self.componentIdentifier, counter: .init(self.counter)))
             .shouldApplyDefaultStyle(false)
             .counterStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Counter/CounterStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Counter/CounterStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyCounterStyle: CounterStyle {
 }
 
 public struct CounterConfiguration {
+    public var componentIdentifier: String = "fiori_counter_component"
     public let counter: Counter
 
     public typealias Counter = ConfigurationViewWrapper
+}
+
+extension CounterConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/DateTimePicker/DateTimePicker.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/DateTimePicker/DateTimePicker.generated.swift
@@ -36,6 +36,8 @@ public struct DateTimePicker {
 
     @Environment(\.dateTimePickerStyle) var style
 
+    var componentIdentifier: String = DateTimePicker.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder title: () -> any View,
@@ -48,11 +50,12 @@ public struct DateTimePicker {
                 pickerComponents: DatePicker.Components = [.date, .hourAndMinute],
                 dateStyle: Date.FormatStyle.DateStyle = .abbreviated,
                 timeStyle: Date.FormatStyle.TimeStyle = .shortened,
-                noDateSelectedString: String? = nil)
+                noDateSelectedString: String? = nil,
+                componentIdentifier: String? = DateTimePicker.identifier)
     {
-        self.title = Title(title: title)
-        self.valueLabel = ValueLabel(valueLabel: valueLabel)
-        self.mandatoryFieldIndicator = MandatoryFieldIndicator(mandatoryFieldIndicator: mandatoryFieldIndicator)
+        self.title = Title(title: title, componentIdentifier: componentIdentifier)
+        self.valueLabel = ValueLabel(valueLabel: valueLabel, componentIdentifier: componentIdentifier)
+        self.mandatoryFieldIndicator = MandatoryFieldIndicator(mandatoryFieldIndicator: mandatoryFieldIndicator, componentIdentifier: componentIdentifier)
         self.isRequired = isRequired
         self.controlState = controlState
         self.errorMessage = errorMessage
@@ -61,7 +64,12 @@ public struct DateTimePicker {
         self.dateStyle = dateStyle
         self.timeStyle = timeStyle
         self.noDateSelectedString = noDateSelectedString
+        self.componentIdentifier = componentIdentifier ?? DateTimePicker.identifier
     }
+}
+
+public extension DateTimePicker {
+    static let identifier = "fiori_datetimepicker_component"
 }
 
 public extension DateTimePicker {
@@ -99,6 +107,7 @@ public extension DateTimePicker {
         self.timeStyle = configuration.timeStyle
         self.noDateSelectedString = configuration.noDateSelectedString
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -107,7 +116,7 @@ extension DateTimePicker: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(title: .init(self.title), valueLabel: .init(self.valueLabel), mandatoryFieldIndicator: .init(self.mandatoryFieldIndicator), isRequired: self.isRequired, controlState: self.controlState, errorMessage: self.errorMessage, selectedDate: self.$selectedDate, pickerComponents: self.pickerComponents, dateStyle: self.dateStyle, timeStyle: self.timeStyle, noDateSelectedString: self.noDateSelectedString)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, title: .init(self.title), valueLabel: .init(self.valueLabel), mandatoryFieldIndicator: .init(self.mandatoryFieldIndicator), isRequired: self.isRequired, controlState: self.controlState, errorMessage: self.errorMessage, selectedDate: self.$selectedDate, pickerComponents: self.pickerComponents, dateStyle: self.dateStyle, timeStyle: self.timeStyle, noDateSelectedString: self.noDateSelectedString)).typeErased
                 .transformEnvironment(\.dateTimePickerStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -125,7 +134,7 @@ private extension DateTimePicker {
     }
 
     func defaultStyle() -> some View {
-        DateTimePicker(.init(title: .init(self.title), valueLabel: .init(self.valueLabel), mandatoryFieldIndicator: .init(self.mandatoryFieldIndicator), isRequired: self.isRequired, controlState: self.controlState, errorMessage: self.errorMessage, selectedDate: self.$selectedDate, pickerComponents: self.pickerComponents, dateStyle: self.dateStyle, timeStyle: self.timeStyle, noDateSelectedString: self.noDateSelectedString))
+        DateTimePicker(.init(componentIdentifier: self.componentIdentifier, title: .init(self.title), valueLabel: .init(self.valueLabel), mandatoryFieldIndicator: .init(self.mandatoryFieldIndicator), isRequired: self.isRequired, controlState: self.controlState, errorMessage: self.errorMessage, selectedDate: self.$selectedDate, pickerComponents: self.pickerComponents, dateStyle: self.dateStyle, timeStyle: self.timeStyle, noDateSelectedString: self.noDateSelectedString))
             .shouldApplyDefaultStyle(false)
             .dateTimePickerStyle(DateTimePickerFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/DateTimePicker/DateTimePickerStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/DateTimePicker/DateTimePickerStyle.generated.swift
@@ -22,6 +22,7 @@ struct AnyDateTimePickerStyle: DateTimePickerStyle {
 }
 
 public struct DateTimePickerConfiguration {
+    public var componentIdentifier: String = "fiori_datetimepicker_component"
     public let title: Title
     public let valueLabel: ValueLabel
     public let mandatoryFieldIndicator: MandatoryFieldIndicator
@@ -37,6 +38,12 @@ public struct DateTimePickerConfiguration {
     public typealias Title = ConfigurationViewWrapper
     public typealias ValueLabel = ConfigurationViewWrapper
     public typealias MandatoryFieldIndicator = ConfigurationViewWrapper
+}
+
+extension DateTimePickerConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct DateTimePickerFioriStyle: DateTimePickerStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/DecrementAction/DecrementAction.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/DecrementAction/DecrementAction.generated.swift
@@ -10,11 +10,20 @@ public struct DecrementAction {
 
     @Environment(\.decrementActionStyle) var style
 
+    var componentIdentifier: String = DecrementAction.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder decrementAction: () -> any View = { FioriButton { _ in FioriIcon.actions.less } }) {
+    public init(@ViewBuilder decrementAction: () -> any View = { FioriButton { _ in FioriIcon.actions.less } },
+                componentIdentifier: String? = DecrementAction.identifier)
+    {
         self.decrementAction = decrementAction()
+        self.componentIdentifier = componentIdentifier ?? DecrementAction.identifier
     }
+}
+
+public extension DecrementAction {
+    static let identifier = "fiori_decrementaction_component"
 }
 
 public extension DecrementAction {
@@ -31,6 +40,7 @@ public extension DecrementAction {
     internal init(_ configuration: DecrementActionConfiguration, shouldApplyDefaultStyle: Bool) {
         self.decrementAction = configuration.decrementAction
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -39,7 +49,7 @@ extension DecrementAction: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(decrementAction: .init(self.decrementAction))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, decrementAction: .init(self.decrementAction))).typeErased
                 .transformEnvironment(\.decrementActionStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -57,7 +67,7 @@ private extension DecrementAction {
     }
 
     func defaultStyle() -> some View {
-        DecrementAction(.init(decrementAction: .init(self.decrementAction)))
+        DecrementAction(.init(componentIdentifier: self.componentIdentifier, decrementAction: .init(self.decrementAction)))
             .shouldApplyDefaultStyle(false)
             .decrementActionStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/DecrementAction/DecrementActionStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/DecrementAction/DecrementActionStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyDecrementActionStyle: DecrementActionStyle {
 }
 
 public struct DecrementActionConfiguration {
+    public var componentIdentifier: String = "fiori_decrementaction_component"
     public let decrementAction: DecrementAction
 
     public typealias DecrementAction = ConfigurationViewWrapper
+}
+
+extension DecrementActionConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/DemoView/DemoView.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/DemoView/DemoView.generated.swift
@@ -12,20 +12,28 @@ struct DemoView {
 
     @Environment(\.demoViewStyle) var style
 
+    var componentIdentifier: String = DemoView.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder title: () -> any View,
                 @ViewBuilder subtitle: () -> any View = { EmptyView() },
                 @ViewBuilder status: () -> any View = { EmptyView() },
                 @ViewBuilder action: () -> any View = { EmptyView() },
-                isOn: Binding<Bool>)
+                isOn: Binding<Bool>,
+                componentIdentifier: String? = DemoView.identifier)
     {
-        self.title = Title(title: title)
-        self.subtitle = Subtitle(subtitle: subtitle)
-        self.status = Status(status: status)
-        self.action = Action(action: action)
+        self.title = Title(title: title, componentIdentifier: componentIdentifier)
+        self.subtitle = Subtitle(subtitle: subtitle, componentIdentifier: componentIdentifier)
+        self.status = Status(status: status, componentIdentifier: componentIdentifier)
+        self.action = Action(action: action, componentIdentifier: componentIdentifier)
         self._isOn = isOn
+        self.componentIdentifier = componentIdentifier ?? DemoView.identifier
     }
+}
+
+extension DemoView {
+    public static let identifier = "fiori_demoview_component"
 }
 
 extension DemoView {
@@ -51,6 +59,7 @@ extension DemoView {
         self.action = configuration.action
         self._isOn = configuration.$isOn
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -59,7 +68,7 @@ extension DemoView: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(title: .init(self.title), subtitle: .init(self.subtitle), status: .init(self.status), action: .init(self.action), isOn: self.$isOn)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, title: .init(self.title), subtitle: .init(self.subtitle), status: .init(self.status), action: .init(self.action), isOn: self.$isOn)).typeErased
                 .transformEnvironment(\.demoViewStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -77,7 +86,7 @@ private extension DemoView {
     }
 
     func defaultStyle() -> some View {
-        DemoView(.init(title: .init(self.title), subtitle: .init(self.subtitle), status: .init(self.status), action: .init(self.action), isOn: self.$isOn))
+        DemoView(.init(componentIdentifier: self.componentIdentifier, title: .init(self.title), subtitle: .init(self.subtitle), status: .init(self.status), action: .init(self.action), isOn: self.$isOn))
             .shouldApplyDefaultStyle(false)
             .demoViewStyle(DemoViewFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/DemoView/DemoViewStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/DemoView/DemoViewStyle.generated.swift
@@ -22,6 +22,7 @@ struct AnyDemoViewStyle: DemoViewStyle {
 }
 
 struct DemoViewConfiguration {
+    public var componentIdentifier: String = "fiori_demoview_component"
     public let title: Title
     public let subtitle: Subtitle
     public let status: Status
@@ -32,6 +33,12 @@ struct DemoViewConfiguration {
     public typealias Subtitle = ConfigurationViewWrapper
     public typealias Status = ConfigurationViewWrapper
     public typealias Action = ConfigurationViewWrapper
+}
+
+extension DemoViewConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 struct DemoViewFioriStyle: DemoViewStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Description/Description.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Description/Description.generated.swift
@@ -8,11 +8,20 @@ public struct Description {
 
     @Environment(\.descriptionStyle) var style
 
+    var componentIdentifier: String = Description.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder description: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder description: () -> any View = { EmptyView() },
+                componentIdentifier: String? = Description.identifier)
+    {
         self.description = description()
+        self.componentIdentifier = componentIdentifier ?? Description.identifier
     }
+}
+
+public extension Description {
+    static let identifier = "fiori_description_component"
 }
 
 public extension Description {
@@ -29,6 +38,7 @@ public extension Description {
     internal init(_ configuration: DescriptionConfiguration, shouldApplyDefaultStyle: Bool) {
         self.description = configuration.description
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension Description: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(description: .init(self.description))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, description: .init(self.description))).typeErased
                 .transformEnvironment(\.descriptionStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension Description {
     }
 
     func defaultStyle() -> some View {
-        Description(.init(description: .init(self.description)))
+        Description(.init(componentIdentifier: self.componentIdentifier, description: .init(self.description)))
             .shouldApplyDefaultStyle(false)
             .descriptionStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Description/DescriptionStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Description/DescriptionStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyDescriptionStyle: DescriptionStyle {
 }
 
 public struct DescriptionConfiguration {
+    public var componentIdentifier: String = "fiori_description_component"
     public let description: Description
 
     public typealias Description = ConfigurationViewWrapper
+}
+
+extension DescriptionConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/DescriptionText/DescriptionText.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/DescriptionText/DescriptionText.generated.swift
@@ -8,11 +8,20 @@ public struct DescriptionText {
 
     @Environment(\.descriptionTextStyle) var style
 
+    var componentIdentifier: String = DescriptionText.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder descriptionText: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder descriptionText: () -> any View = { EmptyView() },
+                componentIdentifier: String? = DescriptionText.identifier)
+    {
         self.descriptionText = descriptionText()
+        self.componentIdentifier = componentIdentifier ?? DescriptionText.identifier
     }
+}
+
+public extension DescriptionText {
+    static let identifier = "fiori_descriptiontext_component"
 }
 
 public extension DescriptionText {
@@ -29,6 +38,7 @@ public extension DescriptionText {
     internal init(_ configuration: DescriptionTextConfiguration, shouldApplyDefaultStyle: Bool) {
         self.descriptionText = configuration.descriptionText
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension DescriptionText: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(descriptionText: .init(self.descriptionText))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, descriptionText: .init(self.descriptionText))).typeErased
                 .transformEnvironment(\.descriptionTextStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension DescriptionText {
     }
 
     func defaultStyle() -> some View {
-        DescriptionText(.init(descriptionText: .init(self.descriptionText)))
+        DescriptionText(.init(componentIdentifier: self.componentIdentifier, descriptionText: .init(self.descriptionText)))
             .shouldApplyDefaultStyle(false)
             .descriptionTextStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/DescriptionText/DescriptionTextStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/DescriptionText/DescriptionTextStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyDescriptionTextStyle: DescriptionTextStyle {
 }
 
 public struct DescriptionTextConfiguration {
+    public var componentIdentifier: String = "fiori_descriptiontext_component"
     public let descriptionText: DescriptionText
 
     public typealias DescriptionText = ConfigurationViewWrapper
+}
+
+extension DescriptionTextConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/DeselectAllAction/DeselectAllAction.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/DeselectAllAction/DeselectAllAction.generated.swift
@@ -8,11 +8,20 @@ public struct DeselectAllAction {
 
     @Environment(\.deselectAllActionStyle) var style
 
+    var componentIdentifier: String = DeselectAllAction.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder deselectAllAction: () -> any View = { FioriButton { _ in Text("Deselect All".localizedFioriString()) } }) {
+    public init(@ViewBuilder deselectAllAction: () -> any View = { FioriButton { _ in Text("Deselect All".localizedFioriString()) } },
+                componentIdentifier: String? = DeselectAllAction.identifier)
+    {
         self.deselectAllAction = deselectAllAction()
+        self.componentIdentifier = componentIdentifier ?? DeselectAllAction.identifier
     }
+}
+
+public extension DeselectAllAction {
+    static let identifier = "fiori_deselectallaction_component"
 }
 
 public extension DeselectAllAction {
@@ -29,6 +38,7 @@ public extension DeselectAllAction {
     internal init(_ configuration: DeselectAllActionConfiguration, shouldApplyDefaultStyle: Bool) {
         self.deselectAllAction = configuration.deselectAllAction
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension DeselectAllAction: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(deselectAllAction: .init(self.deselectAllAction))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, deselectAllAction: .init(self.deselectAllAction))).typeErased
                 .transformEnvironment(\.deselectAllActionStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension DeselectAllAction {
     }
 
     func defaultStyle() -> some View {
-        DeselectAllAction(.init(deselectAllAction: .init(self.deselectAllAction)))
+        DeselectAllAction(.init(componentIdentifier: self.componentIdentifier, deselectAllAction: .init(self.deselectAllAction)))
             .shouldApplyDefaultStyle(false)
             .deselectAllActionStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/DeselectAllAction/DeselectAllActionStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/DeselectAllAction/DeselectAllActionStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyDeselectAllActionStyle: DeselectAllActionStyle {
 }
 
 public struct DeselectAllActionConfiguration {
+    public var componentIdentifier: String = "fiori_deselectallaction_component"
     public let deselectAllAction: DeselectAllAction
 
     public typealias DeselectAllAction = ConfigurationViewWrapper
+}
+
+extension DeselectAllActionConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/DetailContent/DetailContent.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/DetailContent/DetailContent.generated.swift
@@ -8,11 +8,20 @@ public struct DetailContent {
 
     @Environment(\.detailContentStyle) var style
 
+    var componentIdentifier: String = DetailContent.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder detailContent: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder detailContent: () -> any View = { EmptyView() },
+                componentIdentifier: String? = DetailContent.identifier)
+    {
         self.detailContent = detailContent()
+        self.componentIdentifier = componentIdentifier ?? DetailContent.identifier
     }
+}
+
+public extension DetailContent {
+    static let identifier = "fiori_detailcontent_component"
 }
 
 public extension DetailContent {
@@ -23,6 +32,7 @@ public extension DetailContent {
     internal init(_ configuration: DetailContentConfiguration, shouldApplyDefaultStyle: Bool) {
         self.detailContent = configuration.detailContent
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -31,7 +41,7 @@ extension DetailContent: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(detailContent: .init(self.detailContent))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, detailContent: .init(self.detailContent))).typeErased
                 .transformEnvironment(\.detailContentStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -49,7 +59,7 @@ private extension DetailContent {
     }
 
     func defaultStyle() -> some View {
-        DetailContent(.init(detailContent: .init(self.detailContent)))
+        DetailContent(.init(componentIdentifier: self.componentIdentifier, detailContent: .init(self.detailContent)))
             .shouldApplyDefaultStyle(false)
             .detailContentStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/DetailContent/DetailContentStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/DetailContent/DetailContentStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyDetailContentStyle: DetailContentStyle {
 }
 
 public struct DetailContentConfiguration {
+    public var componentIdentifier: String = "fiori_detailcontent_component"
     public let detailContent: DetailContent
 
     public typealias DetailContent = ConfigurationViewWrapper
+}
+
+extension DetailContentConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/DetailImage/DetailImage.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/DetailImage/DetailImage.generated.swift
@@ -8,11 +8,20 @@ public struct DetailImage {
 
     @Environment(\.detailImageStyle) var style
 
+    var componentIdentifier: String = DetailImage.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder detailImage: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder detailImage: () -> any View = { EmptyView() },
+                componentIdentifier: String? = DetailImage.identifier)
+    {
         self.detailImage = detailImage()
+        self.componentIdentifier = componentIdentifier ?? DetailImage.identifier
     }
+}
+
+public extension DetailImage {
+    static let identifier = "fiori_detailimage_component"
 }
 
 public extension DetailImage {
@@ -29,6 +38,7 @@ public extension DetailImage {
     internal init(_ configuration: DetailImageConfiguration, shouldApplyDefaultStyle: Bool) {
         self.detailImage = configuration.detailImage
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension DetailImage: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(detailImage: .init(self.detailImage))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, detailImage: .init(self.detailImage))).typeErased
                 .transformEnvironment(\.detailImageStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension DetailImage {
     }
 
     func defaultStyle() -> some View {
-        DetailImage(.init(detailImage: .init(self.detailImage)))
+        DetailImage(.init(componentIdentifier: self.componentIdentifier, detailImage: .init(self.detailImage)))
             .shouldApplyDefaultStyle(false)
             .detailImageStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/DetailImage/DetailImageStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/DetailImage/DetailImageStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyDetailImageStyle: DetailImageStyle {
 }
 
 public struct DetailImageConfiguration {
+    public var componentIdentifier: String = "fiori_detailimage_component"
     public let detailImage: DetailImage
 
     public typealias DetailImage = ConfigurationViewWrapper
+}
+
+extension DetailImageConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/FilledIcon/FilledIcon.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/FilledIcon/FilledIcon.generated.swift
@@ -8,11 +8,20 @@ public struct FilledIcon {
 
     @Environment(\.filledIconStyle) var style
 
+    var componentIdentifier: String = FilledIcon.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder filledIcon: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder filledIcon: () -> any View = { EmptyView() },
+                componentIdentifier: String? = FilledIcon.identifier)
+    {
         self.filledIcon = filledIcon()
+        self.componentIdentifier = componentIdentifier ?? FilledIcon.identifier
     }
+}
+
+public extension FilledIcon {
+    static let identifier = "fiori_filledicon_component"
 }
 
 public extension FilledIcon {
@@ -29,6 +38,7 @@ public extension FilledIcon {
     internal init(_ configuration: FilledIconConfiguration, shouldApplyDefaultStyle: Bool) {
         self.filledIcon = configuration.filledIcon
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension FilledIcon: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(filledIcon: .init(self.filledIcon))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, filledIcon: .init(self.filledIcon))).typeErased
                 .transformEnvironment(\.filledIconStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension FilledIcon {
     }
 
     func defaultStyle() -> some View {
-        FilledIcon(.init(filledIcon: .init(self.filledIcon)))
+        FilledIcon(.init(componentIdentifier: self.componentIdentifier, filledIcon: .init(self.filledIcon)))
             .shouldApplyDefaultStyle(false)
             .filledIconStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/FilledIcon/FilledIconStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/FilledIcon/FilledIconStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyFilledIconStyle: FilledIconStyle {
 }
 
 public struct FilledIconConfiguration {
+    public var componentIdentifier: String = "fiori_filledicon_component"
     public let filledIcon: FilledIcon
 
     public typealias FilledIcon = ConfigurationViewWrapper
+}
+
+extension FilledIconConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/FioriSlider/FioriSlider.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/FioriSlider/FioriSlider.generated.swift
@@ -202,6 +202,8 @@ public struct FioriSlider {
 
     @Environment(\.fioriSliderStyle) var style
 
+    var componentIdentifier: String = FioriSlider.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder title: () -> any View,
@@ -232,14 +234,15 @@ public struct FioriSlider {
                 showsLeadingAccessory: Bool = true,
                 showsTrailingAccessory: Bool = true,
                 onValueChange: ((Bool, Double) -> Void)? = nil,
-                onEditFieldFocusStatusChange: ((Bool) -> Void)? = nil)
+                onEditFieldFocusStatusChange: ((Bool) -> Void)? = nil,
+                componentIdentifier: String? = FioriSlider.identifier)
     {
-        self.title = Title(title: title)
-        self.valueLabel = ValueLabel(valueLabel: valueLabel)
-        self.lowerThumb = LowerThumb(lowerThumb: lowerThumb)
-        self.upperThumb = UpperThumb(upperThumb: upperThumb)
-        self.activeTrack = ActiveTrack(activeTrack: activeTrack)
-        self.inactiveTrack = InactiveTrack(inactiveTrack: inactiveTrack)
+        self.title = Title(title: title, componentIdentifier: componentIdentifier)
+        self.valueLabel = ValueLabel(valueLabel: valueLabel, componentIdentifier: componentIdentifier)
+        self.lowerThumb = LowerThumb(lowerThumb: lowerThumb, componentIdentifier: componentIdentifier)
+        self.upperThumb = UpperThumb(upperThumb: upperThumb, componentIdentifier: componentIdentifier)
+        self.activeTrack = ActiveTrack(activeTrack: activeTrack, componentIdentifier: componentIdentifier)
+        self.inactiveTrack = InactiveTrack(inactiveTrack: inactiveTrack, componentIdentifier: componentIdentifier)
         self._lowerValue = lowerValue
         self._upperValue = upperValue
         self.range = range
@@ -249,10 +252,10 @@ public struct FioriSlider {
         self.showsLowerThumb = showsLowerThumb
         self.showsUpperThumb = showsUpperThumb
         self.onRangeValueChange = onRangeValueChange
-        self.icon = Icon(icon: icon)
-        self.description = Description(description: description)
-        self.leadingAccessory = LeadingAccessory(leadingAccessory: leadingAccessory)
-        self.trailingAccessory = TrailingAccessory(trailingAccessory: trailingAccessory)
+        self.icon = Icon(icon: icon, componentIdentifier: componentIdentifier)
+        self.description = Description(description: description, componentIdentifier: componentIdentifier)
+        self.leadingAccessory = LeadingAccessory(leadingAccessory: leadingAccessory, componentIdentifier: componentIdentifier)
+        self.trailingAccessory = TrailingAccessory(trailingAccessory: trailingAccessory, componentIdentifier: componentIdentifier)
         self.isRangeSlider = isRangeSlider
         self.valueFormat = valueFormat
         self.rangeFormat = rangeFormat
@@ -263,7 +266,12 @@ public struct FioriSlider {
         self.showsTrailingAccessory = showsTrailingAccessory
         self.onValueChange = onValueChange
         self.onEditFieldFocusStatusChange = onEditFieldFocusStatusChange
+        self.componentIdentifier = componentIdentifier ?? FioriSlider.identifier
     }
+}
+
+public extension FioriSlider {
+    static let identifier = "fiori_fiorislider_component"
 }
 
 public extension FioriSlider {
@@ -337,6 +345,7 @@ public extension FioriSlider {
         self.onValueChange = configuration.onValueChange
         self.onEditFieldFocusStatusChange = configuration.onEditFieldFocusStatusChange
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -345,7 +354,7 @@ extension FioriSlider: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(title: .init(self.title), valueLabel: .init(self.valueLabel), lowerThumb: .init(self.lowerThumb), upperThumb: .init(self.upperThumb), activeTrack: .init(self.activeTrack), inactiveTrack: .init(self.inactiveTrack), lowerValue: self.$lowerValue, upperValue: self.$upperValue, range: self.range, step: self.step, decimalPlaces: self.decimalPlaces, thumbHalfWidth: self.thumbHalfWidth, showsLowerThumb: self.showsLowerThumb, showsUpperThumb: self.showsUpperThumb, onRangeValueChange: self.onRangeValueChange, icon: .init(self.icon), description: .init(self.description), leadingAccessory: .init(self.leadingAccessory), trailingAccessory: .init(self.trailingAccessory), isRangeSlider: self.isRangeSlider, valueFormat: self.valueFormat, rangeFormat: self.rangeFormat, leadingValueFormat: self.leadingValueFormat, trailingValueFormat: self.trailingValueFormat, showsValueLabel: self.showsValueLabel, showsLeadingAccessory: self.showsLeadingAccessory, showsTrailingAccessory: self.showsTrailingAccessory, onValueChange: self.onValueChange, onEditFieldFocusStatusChange: self.onEditFieldFocusStatusChange)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, title: .init(self.title), valueLabel: .init(self.valueLabel), lowerThumb: .init(self.lowerThumb), upperThumb: .init(self.upperThumb), activeTrack: .init(self.activeTrack), inactiveTrack: .init(self.inactiveTrack), lowerValue: self.$lowerValue, upperValue: self.$upperValue, range: self.range, step: self.step, decimalPlaces: self.decimalPlaces, thumbHalfWidth: self.thumbHalfWidth, showsLowerThumb: self.showsLowerThumb, showsUpperThumb: self.showsUpperThumb, onRangeValueChange: self.onRangeValueChange, icon: .init(self.icon), description: .init(self.description), leadingAccessory: .init(self.leadingAccessory), trailingAccessory: .init(self.trailingAccessory), isRangeSlider: self.isRangeSlider, valueFormat: self.valueFormat, rangeFormat: self.rangeFormat, leadingValueFormat: self.leadingValueFormat, trailingValueFormat: self.trailingValueFormat, showsValueLabel: self.showsValueLabel, showsLeadingAccessory: self.showsLeadingAccessory, showsTrailingAccessory: self.showsTrailingAccessory, onValueChange: self.onValueChange, onEditFieldFocusStatusChange: self.onEditFieldFocusStatusChange)).typeErased
                 .transformEnvironment(\.fioriSliderStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -363,7 +372,7 @@ private extension FioriSlider {
     }
 
     func defaultStyle() -> some View {
-        FioriSlider(.init(title: .init(self.title), valueLabel: .init(self.valueLabel), lowerThumb: .init(self.lowerThumb), upperThumb: .init(self.upperThumb), activeTrack: .init(self.activeTrack), inactiveTrack: .init(self.inactiveTrack), lowerValue: self.$lowerValue, upperValue: self.$upperValue, range: self.range, step: self.step, decimalPlaces: self.decimalPlaces, thumbHalfWidth: self.thumbHalfWidth, showsLowerThumb: self.showsLowerThumb, showsUpperThumb: self.showsUpperThumb, onRangeValueChange: self.onRangeValueChange, icon: .init(self.icon), description: .init(self.description), leadingAccessory: .init(self.leadingAccessory), trailingAccessory: .init(self.trailingAccessory), isRangeSlider: self.isRangeSlider, valueFormat: self.valueFormat, rangeFormat: self.rangeFormat, leadingValueFormat: self.leadingValueFormat, trailingValueFormat: self.trailingValueFormat, showsValueLabel: self.showsValueLabel, showsLeadingAccessory: self.showsLeadingAccessory, showsTrailingAccessory: self.showsTrailingAccessory, onValueChange: self.onValueChange, onEditFieldFocusStatusChange: self.onEditFieldFocusStatusChange))
+        FioriSlider(.init(componentIdentifier: self.componentIdentifier, title: .init(self.title), valueLabel: .init(self.valueLabel), lowerThumb: .init(self.lowerThumb), upperThumb: .init(self.upperThumb), activeTrack: .init(self.activeTrack), inactiveTrack: .init(self.inactiveTrack), lowerValue: self.$lowerValue, upperValue: self.$upperValue, range: self.range, step: self.step, decimalPlaces: self.decimalPlaces, thumbHalfWidth: self.thumbHalfWidth, showsLowerThumb: self.showsLowerThumb, showsUpperThumb: self.showsUpperThumb, onRangeValueChange: self.onRangeValueChange, icon: .init(self.icon), description: .init(self.description), leadingAccessory: .init(self.leadingAccessory), trailingAccessory: .init(self.trailingAccessory), isRangeSlider: self.isRangeSlider, valueFormat: self.valueFormat, rangeFormat: self.rangeFormat, leadingValueFormat: self.leadingValueFormat, trailingValueFormat: self.trailingValueFormat, showsValueLabel: self.showsValueLabel, showsLeadingAccessory: self.showsLeadingAccessory, showsTrailingAccessory: self.showsTrailingAccessory, onValueChange: self.onValueChange, onEditFieldFocusStatusChange: self.onEditFieldFocusStatusChange))
             .shouldApplyDefaultStyle(false)
             .fioriSliderStyle(FioriSliderFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/FioriSlider/FioriSliderStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/FioriSlider/FioriSliderStyle.generated.swift
@@ -22,6 +22,7 @@ struct AnyFioriSliderStyle: FioriSliderStyle {
 }
 
 public struct FioriSliderConfiguration {
+    public var componentIdentifier: String = "fiori_fiorislider_component"
     public let title: Title
     public let valueLabel: ValueLabel
     public let lowerThumb: LowerThumb
@@ -62,6 +63,12 @@ public struct FioriSliderConfiguration {
     public typealias Description = ConfigurationViewWrapper
     public typealias LeadingAccessory = ConfigurationViewWrapper
     public typealias TrailingAccessory = ConfigurationViewWrapper
+}
+
+extension FioriSliderConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct FioriSliderFioriStyle: FioriSliderStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Footnote/Footnote.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Footnote/Footnote.generated.swift
@@ -8,11 +8,20 @@ public struct Footnote {
 
     @Environment(\.footnoteStyle) var style
 
+    var componentIdentifier: String = Footnote.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder footnote: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder footnote: () -> any View = { EmptyView() },
+                componentIdentifier: String? = Footnote.identifier)
+    {
         self.footnote = footnote()
+        self.componentIdentifier = componentIdentifier ?? Footnote.identifier
     }
+}
+
+public extension Footnote {
+    static let identifier = "fiori_footnote_component"
 }
 
 public extension Footnote {
@@ -29,6 +38,7 @@ public extension Footnote {
     internal init(_ configuration: FootnoteConfiguration, shouldApplyDefaultStyle: Bool) {
         self.footnote = configuration.footnote
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension Footnote: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(footnote: .init(self.footnote))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, footnote: .init(self.footnote))).typeErased
                 .transformEnvironment(\.footnoteStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension Footnote {
     }
 
     func defaultStyle() -> some View {
-        Footnote(.init(footnote: .init(self.footnote)))
+        Footnote(.init(componentIdentifier: self.componentIdentifier, footnote: .init(self.footnote)))
             .shouldApplyDefaultStyle(false)
             .footnoteStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Footnote/FootnoteStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Footnote/FootnoteStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyFootnoteStyle: FootnoteStyle {
 }
 
 public struct FootnoteConfiguration {
+    public var componentIdentifier: String = "fiori_footnote_component"
     public let footnote: Footnote
 
     public typealias Footnote = ConfigurationViewWrapper
+}
+
+extension FootnoteConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/FootnoteIcons/FootnoteIcons.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/FootnoteIcons/FootnoteIcons.generated.swift
@@ -8,11 +8,20 @@ public struct FootnoteIcons {
 
     @Environment(\.footnoteIconsStyle) var style
 
+    var componentIdentifier: String = FootnoteIcons.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@FootnoteIconsBuilder footnoteIcons: () -> any View = { EmptyView() }) {
+    public init(@FootnoteIconsBuilder footnoteIcons: () -> any View = { EmptyView() },
+                componentIdentifier: String? = FootnoteIcons.identifier)
+    {
         self.footnoteIcons = footnoteIcons()
+        self.componentIdentifier = componentIdentifier ?? FootnoteIcons.identifier
     }
+}
+
+public extension FootnoteIcons {
+    static let identifier = "fiori_footnoteicons_component"
 }
 
 public extension FootnoteIcons {
@@ -29,6 +38,7 @@ public extension FootnoteIcons {
     internal init(_ configuration: FootnoteIconsConfiguration, shouldApplyDefaultStyle: Bool) {
         self.footnoteIcons = configuration.footnoteIcons
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension FootnoteIcons: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(footnoteIcons: .init(self.footnoteIcons))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, footnoteIcons: .init(self.footnoteIcons))).typeErased
                 .transformEnvironment(\.footnoteIconsStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension FootnoteIcons {
     }
 
     func defaultStyle() -> some View {
-        FootnoteIcons(.init(footnoteIcons: .init(self.footnoteIcons)))
+        FootnoteIcons(.init(componentIdentifier: self.componentIdentifier, footnoteIcons: .init(self.footnoteIcons)))
             .shouldApplyDefaultStyle(false)
             .footnoteIconsStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/FootnoteIcons/FootnoteIconsStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/FootnoteIcons/FootnoteIconsStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyFootnoteIconsStyle: FootnoteIconsStyle {
 }
 
 public struct FootnoteIconsConfiguration {
+    public var componentIdentifier: String = "fiori_footnoteicons_component"
     public let footnoteIcons: FootnoteIcons
 
     public typealias FootnoteIcons = ConfigurationViewWrapper
+}
+
+extension FootnoteIconsConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/FootnoteIconsText/FootnoteIconsText.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/FootnoteIconsText/FootnoteIconsText.generated.swift
@@ -8,11 +8,20 @@ public struct FootnoteIconsText {
 
     @Environment(\.footnoteIconsTextStyle) var style
 
+    var componentIdentifier: String = FootnoteIconsText.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder footnoteIconsText: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder footnoteIconsText: () -> any View = { EmptyView() },
+                componentIdentifier: String? = FootnoteIconsText.identifier)
+    {
         self.footnoteIconsText = footnoteIconsText()
+        self.componentIdentifier = componentIdentifier ?? FootnoteIconsText.identifier
     }
+}
+
+public extension FootnoteIconsText {
+    static let identifier = "fiori_footnoteiconstext_component"
 }
 
 public extension FootnoteIconsText {
@@ -29,6 +38,7 @@ public extension FootnoteIconsText {
     internal init(_ configuration: FootnoteIconsTextConfiguration, shouldApplyDefaultStyle: Bool) {
         self.footnoteIconsText = configuration.footnoteIconsText
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension FootnoteIconsText: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(footnoteIconsText: .init(self.footnoteIconsText))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, footnoteIconsText: .init(self.footnoteIconsText))).typeErased
                 .transformEnvironment(\.footnoteIconsTextStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension FootnoteIconsText {
     }
 
     func defaultStyle() -> some View {
-        FootnoteIconsText(.init(footnoteIconsText: .init(self.footnoteIconsText)))
+        FootnoteIconsText(.init(componentIdentifier: self.componentIdentifier, footnoteIconsText: .init(self.footnoteIconsText)))
             .shouldApplyDefaultStyle(false)
             .footnoteIconsTextStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/FootnoteIconsText/FootnoteIconsTextStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/FootnoteIconsText/FootnoteIconsTextStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyFootnoteIconsTextStyle: FootnoteIconsTextStyle {
 }
 
 public struct FootnoteIconsTextConfiguration {
+    public var componentIdentifier: String = "fiori_footnoteiconstext_component"
     public let footnoteIconsText: FootnoteIconsText
 
     public typealias FootnoteIconsText = ConfigurationViewWrapper
+}
+
+extension FootnoteIconsTextConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/FormView/FormView.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/FormView/FormView.generated.swift
@@ -11,14 +11,22 @@ public struct FormView {
 
     @Environment(\.formViewStyle) var style
 
+    var componentIdentifier: String = FormView.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(controlState: ControlState = .normal,
-                errorMessage: AttributedString? = nil)
+                errorMessage: AttributedString? = nil,
+                componentIdentifier: String? = FormView.identifier)
     {
         self.controlState = controlState
         self.errorMessage = errorMessage
+        self.componentIdentifier = componentIdentifier ?? FormView.identifier
     }
+}
+
+public extension FormView {
+    static let identifier = "fiori_formview_component"
 }
 
 public extension FormView {
@@ -30,6 +38,7 @@ public extension FormView {
         self.controlState = configuration.controlState
         self.errorMessage = configuration.errorMessage
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -38,7 +47,7 @@ extension FormView: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(controlState: self.controlState, errorMessage: self.errorMessage)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, controlState: self.controlState, errorMessage: self.errorMessage)).typeErased
                 .transformEnvironment(\.formViewStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -56,7 +65,7 @@ private extension FormView {
     }
 
     func defaultStyle() -> some View {
-        FormView(.init(controlState: self.controlState, errorMessage: self.errorMessage))
+        FormView(.init(componentIdentifier: self.componentIdentifier, controlState: self.controlState, errorMessage: self.errorMessage))
             .shouldApplyDefaultStyle(false)
             .formViewStyle(FormViewFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/FormView/FormViewStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/FormView/FormViewStyle.generated.swift
@@ -22,8 +22,15 @@ struct AnyFormViewStyle: FormViewStyle {
 }
 
 public struct FormViewConfiguration {
+    public var componentIdentifier: String = "fiori_formview_component"
     public let controlState: ControlState
     public let errorMessage: AttributedString?
+}
+
+extension FormViewConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct FormViewFioriStyle: FormViewStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/GreetingText/GreetingText.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/GreetingText/GreetingText.generated.swift
@@ -8,11 +8,20 @@ public struct GreetingText {
 
     @Environment(\.greetingTextStyle) var style
 
+    var componentIdentifier: String = GreetingText.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder greetingText: () -> any View) {
+    public init(@ViewBuilder greetingText: () -> any View,
+                componentIdentifier: String? = GreetingText.identifier)
+    {
         self.greetingText = greetingText()
+        self.componentIdentifier = componentIdentifier ?? GreetingText.identifier
     }
+}
+
+public extension GreetingText {
+    static let identifier = "fiori_greetingtext_component"
 }
 
 public extension GreetingText {
@@ -29,6 +38,7 @@ public extension GreetingText {
     internal init(_ configuration: GreetingTextConfiguration, shouldApplyDefaultStyle: Bool) {
         self.greetingText = configuration.greetingText
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension GreetingText: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(greetingText: .init(self.greetingText))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, greetingText: .init(self.greetingText))).typeErased
                 .transformEnvironment(\.greetingTextStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension GreetingText {
     }
 
     func defaultStyle() -> some View {
-        GreetingText(.init(greetingText: .init(self.greetingText)))
+        GreetingText(.init(componentIdentifier: self.componentIdentifier, greetingText: .init(self.greetingText)))
             .shouldApplyDefaultStyle(false)
             .greetingTextStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/GreetingText/GreetingTextStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/GreetingText/GreetingTextStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyGreetingTextStyle: GreetingTextStyle {
 }
 
 public struct GreetingTextConfiguration {
+    public var componentIdentifier: String = "fiori_greetingtext_component"
     public let greetingText: GreetingText
 
     public typealias GreetingText = ConfigurationViewWrapper
+}
+
+extension GreetingTextConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/HalfStarImage/HalfStarImage.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/HalfStarImage/HalfStarImage.generated.swift
@@ -11,11 +11,20 @@ public struct HalfStarImage {
 
     @Environment(\.halfStarImageStyle) var style
 
+    var componentIdentifier: String = HalfStarImage.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder halfStarImage: () -> any View) {
+    public init(@ViewBuilder halfStarImage: () -> any View,
+                componentIdentifier: String? = HalfStarImage.identifier)
+    {
         self.halfStarImage = halfStarImage()
+        self.componentIdentifier = componentIdentifier ?? HalfStarImage.identifier
     }
+}
+
+public extension HalfStarImage {
+    static let identifier = "fiori_halfstarimage_component"
 }
 
 public extension HalfStarImage {
@@ -32,6 +41,7 @@ public extension HalfStarImage {
     internal init(_ configuration: HalfStarImageConfiguration, shouldApplyDefaultStyle: Bool) {
         self.halfStarImage = configuration.halfStarImage
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -40,7 +50,7 @@ extension HalfStarImage: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(halfStarImage: .init(self.halfStarImage))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, halfStarImage: .init(self.halfStarImage))).typeErased
                 .transformEnvironment(\.halfStarImageStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -58,7 +68,7 @@ private extension HalfStarImage {
     }
 
     func defaultStyle() -> some View {
-        HalfStarImage(.init(halfStarImage: .init(self.halfStarImage)))
+        HalfStarImage(.init(componentIdentifier: self.componentIdentifier, halfStarImage: .init(self.halfStarImage)))
             .shouldApplyDefaultStyle(false)
             .halfStarImageStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/HalfStarImage/HalfStarImageStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/HalfStarImage/HalfStarImageStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyHalfStarImageStyle: HalfStarImageStyle {
 }
 
 public struct HalfStarImageConfiguration {
+    public var componentIdentifier: String = "fiori_halfstarimage_component"
     public let halfStarImage: HalfStarImage
 
     public typealias HalfStarImage = ConfigurationViewWrapper
+}
+
+extension HalfStarImageConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/HeaderAction/HeaderAction.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/HeaderAction/HeaderAction.generated.swift
@@ -8,11 +8,20 @@ public struct HeaderAction {
 
     @Environment(\.headerActionStyle) var style
 
+    var componentIdentifier: String = HeaderAction.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder headerAction: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder headerAction: () -> any View = { EmptyView() },
+                componentIdentifier: String? = HeaderAction.identifier)
+    {
         self.headerAction = headerAction()
+        self.componentIdentifier = componentIdentifier ?? HeaderAction.identifier
     }
+}
+
+public extension HeaderAction {
+    static let identifier = "fiori_headeraction_component"
 }
 
 public extension HeaderAction {
@@ -29,6 +38,7 @@ public extension HeaderAction {
     internal init(_ configuration: HeaderActionConfiguration, shouldApplyDefaultStyle: Bool) {
         self.headerAction = configuration.headerAction
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension HeaderAction: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(headerAction: .init(self.headerAction))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, headerAction: .init(self.headerAction))).typeErased
                 .transformEnvironment(\.headerActionStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension HeaderAction {
     }
 
     func defaultStyle() -> some View {
-        HeaderAction(.init(headerAction: .init(self.headerAction)))
+        HeaderAction(.init(componentIdentifier: self.componentIdentifier, headerAction: .init(self.headerAction)))
             .shouldApplyDefaultStyle(false)
             .headerActionStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/HeaderAction/HeaderActionStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/HeaderAction/HeaderActionStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyHeaderActionStyle: HeaderActionStyle {
 }
 
 public struct HeaderActionConfiguration {
+    public var componentIdentifier: String = "fiori_headeraction_component"
     public let headerAction: HeaderAction
 
     public typealias HeaderAction = ConfigurationViewWrapper
+}
+
+extension HeaderActionConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/HelperText/HelperText.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/HelperText/HelperText.generated.swift
@@ -8,11 +8,20 @@ public struct HelperText {
 
     @Environment(\.helperTextStyle) var style
 
+    var componentIdentifier: String = HelperText.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder helperText: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder helperText: () -> any View = { EmptyView() },
+                componentIdentifier: String? = HelperText.identifier)
+    {
         self.helperText = helperText()
+        self.componentIdentifier = componentIdentifier ?? HelperText.identifier
     }
+}
+
+public extension HelperText {
+    static let identifier = "fiori_helpertext_component"
 }
 
 public extension HelperText {
@@ -29,6 +38,7 @@ public extension HelperText {
     internal init(_ configuration: HelperTextConfiguration, shouldApplyDefaultStyle: Bool) {
         self.helperText = configuration.helperText
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension HelperText: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(helperText: .init(self.helperText))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, helperText: .init(self.helperText))).typeErased
                 .transformEnvironment(\.helperTextStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension HelperText {
     }
 
     func defaultStyle() -> some View {
-        HelperText(.init(helperText: .init(self.helperText)))
+        HelperText(.init(componentIdentifier: self.componentIdentifier, helperText: .init(self.helperText)))
             .shouldApplyDefaultStyle(false)
             .helperTextStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/HelperText/HelperTextStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/HelperText/HelperTextStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyHelperTextStyle: HelperTextStyle {
 }
 
 public struct HelperTextConfiguration {
+    public var componentIdentifier: String = "fiori_helpertext_component"
     public let helperText: HelperText
 
     public typealias HelperText = ConfigurationViewWrapper
+}
+
+extension HelperTextConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Icon/Icon.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Icon/Icon.generated.swift
@@ -8,11 +8,20 @@ public struct Icon {
 
     @Environment(\.iconStyle) var style
 
+    var componentIdentifier: String = Icon.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder icon: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder icon: () -> any View = { EmptyView() },
+                componentIdentifier: String? = Icon.identifier)
+    {
         self.icon = icon()
+        self.componentIdentifier = componentIdentifier ?? Icon.identifier
     }
+}
+
+public extension Icon {
+    static let identifier = "fiori_icon_component"
 }
 
 public extension Icon {
@@ -29,6 +38,7 @@ public extension Icon {
     internal init(_ configuration: IconConfiguration, shouldApplyDefaultStyle: Bool) {
         self.icon = configuration.icon
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension Icon: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(icon: .init(self.icon))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, icon: .init(self.icon))).typeErased
                 .transformEnvironment(\.iconStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension Icon {
     }
 
     func defaultStyle() -> some View {
-        Icon(.init(icon: .init(self.icon)))
+        Icon(.init(componentIdentifier: self.componentIdentifier, icon: .init(self.icon)))
             .shouldApplyDefaultStyle(false)
             .iconStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Icon/IconStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Icon/IconStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyIconStyle: IconStyle {
 }
 
 public struct IconConfiguration {
+    public var componentIdentifier: String = "fiori_icon_component"
     public let icon: Icon
 
     public typealias Icon = ConfigurationViewWrapper
+}
+
+extension IconConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Icons/Icons.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Icons/Icons.generated.swift
@@ -8,11 +8,20 @@ public struct Icons {
 
     @Environment(\.iconsStyle) var style
 
+    var componentIdentifier: String = Icons.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@IconBuilder icons: () -> any View = { EmptyView() }) {
+    public init(@IconBuilder icons: () -> any View = { EmptyView() },
+                componentIdentifier: String? = Icons.identifier)
+    {
         self.icons = icons()
+        self.componentIdentifier = componentIdentifier ?? Icons.identifier
     }
+}
+
+public extension Icons {
+    static let identifier = "fiori_icons_component"
 }
 
 public extension Icons {
@@ -29,6 +38,7 @@ public extension Icons {
     internal init(_ configuration: IconsConfiguration, shouldApplyDefaultStyle: Bool) {
         self.icons = configuration.icons
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension Icons: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(icons: .init(self.icons))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, icons: .init(self.icons))).typeErased
                 .transformEnvironment(\.iconsStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension Icons {
     }
 
     func defaultStyle() -> some View {
-        Icons(.init(icons: .init(self.icons)))
+        Icons(.init(componentIdentifier: self.componentIdentifier, icons: .init(self.icons)))
             .shouldApplyDefaultStyle(false)
             .iconsStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Icons/IconsStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Icons/IconsStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyIconsStyle: IconsStyle {
 }
 
 public struct IconsConfiguration {
+    public var componentIdentifier: String = "fiori_icons_component"
     public let icons: Icons
 
     public typealias Icons = ConfigurationViewWrapper
+}
+
+extension IconsConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/IllustratedMessage/IllustratedMessage.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/IllustratedMessage/IllustratedMessage.generated.swift
@@ -18,6 +18,8 @@ public struct IllustratedMessage {
 
     @Environment(\.illustratedMessageStyle) var style
 
+    var componentIdentifier: String = IllustratedMessage.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder detailImage: () -> any View = { EmptyView() },
@@ -27,17 +29,23 @@ public struct IllustratedMessage {
                 @ViewBuilder secondaryAction: () -> any View = { EmptyView() },
                 detailImageSize: IllustratedMessage.DetailImageSize? = nil,
                 isActionVerticallyAligned: Bool = false,
-                contentAlignment: HorizontalAlignment = .leading)
+                contentAlignment: HorizontalAlignment = .leading,
+                componentIdentifier: String? = IllustratedMessage.identifier)
     {
-        self.detailImage = DetailImage(detailImage: detailImage)
-        self.title = Title(title: title)
-        self.description = Description(description: description)
-        self.action = Action(action: action)
-        self.secondaryAction = SecondaryAction(secondaryAction: secondaryAction)
+        self.detailImage = DetailImage(detailImage: detailImage, componentIdentifier: componentIdentifier)
+        self.title = Title(title: title, componentIdentifier: componentIdentifier)
+        self.description = Description(description: description, componentIdentifier: componentIdentifier)
+        self.action = Action(action: action, componentIdentifier: componentIdentifier)
+        self.secondaryAction = SecondaryAction(secondaryAction: secondaryAction, componentIdentifier: componentIdentifier)
         self.detailImageSize = detailImageSize
         self.isActionVerticallyAligned = isActionVerticallyAligned
         self.contentAlignment = contentAlignment
+        self.componentIdentifier = componentIdentifier ?? IllustratedMessage.identifier
     }
+}
+
+public extension IllustratedMessage {
+    static let identifier = "fiori_illustratedmessage_component"
 }
 
 public extension IllustratedMessage {
@@ -69,6 +77,7 @@ public extension IllustratedMessage {
         self.isActionVerticallyAligned = configuration.isActionVerticallyAligned
         self.contentAlignment = configuration.contentAlignment
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -77,7 +86,7 @@ extension IllustratedMessage: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(detailImage: .init(self.detailImage), title: .init(self.title), description: .init(self.description), action: .init(self.action), secondaryAction: .init(self.secondaryAction), detailImageSize: self.detailImageSize, isActionVerticallyAligned: self.isActionVerticallyAligned, contentAlignment: self.contentAlignment)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, detailImage: .init(self.detailImage), title: .init(self.title), description: .init(self.description), action: .init(self.action), secondaryAction: .init(self.secondaryAction), detailImageSize: self.detailImageSize, isActionVerticallyAligned: self.isActionVerticallyAligned, contentAlignment: self.contentAlignment)).typeErased
                 .transformEnvironment(\.illustratedMessageStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -95,7 +104,7 @@ private extension IllustratedMessage {
     }
 
     func defaultStyle() -> some View {
-        IllustratedMessage(.init(detailImage: .init(self.detailImage), title: .init(self.title), description: .init(self.description), action: .init(self.action), secondaryAction: .init(self.secondaryAction), detailImageSize: self.detailImageSize, isActionVerticallyAligned: self.isActionVerticallyAligned, contentAlignment: self.contentAlignment))
+        IllustratedMessage(.init(componentIdentifier: self.componentIdentifier, detailImage: .init(self.detailImage), title: .init(self.title), description: .init(self.description), action: .init(self.action), secondaryAction: .init(self.secondaryAction), detailImageSize: self.detailImageSize, isActionVerticallyAligned: self.isActionVerticallyAligned, contentAlignment: self.contentAlignment))
             .shouldApplyDefaultStyle(false)
             .illustratedMessageStyle(IllustratedMessageFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/IllustratedMessage/IllustratedMessageStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/IllustratedMessage/IllustratedMessageStyle.generated.swift
@@ -22,6 +22,7 @@ struct AnyIllustratedMessageStyle: IllustratedMessageStyle {
 }
 
 public struct IllustratedMessageConfiguration {
+    public var componentIdentifier: String = "fiori_illustratedmessage_component"
     public let detailImage: DetailImage
     public let title: Title
     public let description: Description
@@ -36,6 +37,12 @@ public struct IllustratedMessageConfiguration {
     public typealias Description = ConfigurationViewWrapper
     public typealias Action = ConfigurationViewWrapper
     public typealias SecondaryAction = ConfigurationViewWrapper
+}
+
+extension IllustratedMessageConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct IllustratedMessageFioriStyle: IllustratedMessageStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/InactiveTrack/InactiveTrack.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/InactiveTrack/InactiveTrack.generated.swift
@@ -8,11 +8,20 @@ public struct InactiveTrack {
 
     @Environment(\.inactiveTrackStyle) var style
 
+    var componentIdentifier: String = InactiveTrack.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder inactiveTrack: () -> any View) {
+    public init(@ViewBuilder inactiveTrack: () -> any View,
+                componentIdentifier: String? = InactiveTrack.identifier)
+    {
         self.inactiveTrack = inactiveTrack()
+        self.componentIdentifier = componentIdentifier ?? InactiveTrack.identifier
     }
+}
+
+public extension InactiveTrack {
+    static let identifier = "fiori_inactivetrack_component"
 }
 
 public extension InactiveTrack {
@@ -29,6 +38,7 @@ public extension InactiveTrack {
     internal init(_ configuration: InactiveTrackConfiguration, shouldApplyDefaultStyle: Bool) {
         self.inactiveTrack = configuration.inactiveTrack
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension InactiveTrack: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(inactiveTrack: .init(self.inactiveTrack))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, inactiveTrack: .init(self.inactiveTrack))).typeErased
                 .transformEnvironment(\.inactiveTrackStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension InactiveTrack {
     }
 
     func defaultStyle() -> some View {
-        InactiveTrack(.init(inactiveTrack: .init(self.inactiveTrack)))
+        InactiveTrack(.init(componentIdentifier: self.componentIdentifier, inactiveTrack: .init(self.inactiveTrack)))
             .shouldApplyDefaultStyle(false)
             .inactiveTrackStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/InactiveTrack/InactiveTrackStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/InactiveTrack/InactiveTrackStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyInactiveTrackStyle: InactiveTrackStyle {
 }
 
 public struct InactiveTrackConfiguration {
+    public var componentIdentifier: String = "fiori_inactivetrack_component"
     public let inactiveTrack: InactiveTrack
 
     public typealias InactiveTrack = ConfigurationViewWrapper
+}
+
+extension InactiveTrackConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/IncrementAction/IncrementAction.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/IncrementAction/IncrementAction.generated.swift
@@ -10,11 +10,20 @@ public struct IncrementAction {
 
     @Environment(\.incrementActionStyle) var style
 
+    var componentIdentifier: String = IncrementAction.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder incrementAction: () -> any View = { FioriButton { _ in FioriIcon.actions.add } }) {
+    public init(@ViewBuilder incrementAction: () -> any View = { FioriButton { _ in FioriIcon.actions.add } },
+                componentIdentifier: String? = IncrementAction.identifier)
+    {
         self.incrementAction = incrementAction()
+        self.componentIdentifier = componentIdentifier ?? IncrementAction.identifier
     }
+}
+
+public extension IncrementAction {
+    static let identifier = "fiori_incrementaction_component"
 }
 
 public extension IncrementAction {
@@ -31,6 +40,7 @@ public extension IncrementAction {
     internal init(_ configuration: IncrementActionConfiguration, shouldApplyDefaultStyle: Bool) {
         self.incrementAction = configuration.incrementAction
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -39,7 +49,7 @@ extension IncrementAction: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(incrementAction: .init(self.incrementAction))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, incrementAction: .init(self.incrementAction))).typeErased
                 .transformEnvironment(\.incrementActionStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -57,7 +67,7 @@ private extension IncrementAction {
     }
 
     func defaultStyle() -> some View {
-        IncrementAction(.init(incrementAction: .init(self.incrementAction)))
+        IncrementAction(.init(componentIdentifier: self.componentIdentifier, incrementAction: .init(self.incrementAction)))
             .shouldApplyDefaultStyle(false)
             .incrementActionStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/IncrementAction/IncrementActionStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/IncrementAction/IncrementActionStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyIncrementActionStyle: IncrementActionStyle {
 }
 
 public struct IncrementActionConfiguration {
+    public var componentIdentifier: String = "fiori_incrementaction_component"
     public let incrementAction: IncrementAction
 
     public typealias IncrementAction = ConfigurationViewWrapper
+}
+
+extension IncrementActionConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/InformationView/InformationView.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/InformationView/InformationView.generated.swift
@@ -9,14 +9,22 @@ public struct InformationView {
 
     @Environment(\.informationViewStyle) var style
 
+    var componentIdentifier: String = InformationView.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder icon: () -> any View = { EmptyView() },
-                @ViewBuilder description: () -> any View = { EmptyView() })
+                @ViewBuilder description: () -> any View = { EmptyView() },
+                componentIdentifier: String? = InformationView.identifier)
     {
-        self.icon = Icon(icon: icon)
-        self.description = Description(description: description)
+        self.icon = Icon(icon: icon, componentIdentifier: componentIdentifier)
+        self.description = Description(description: description, componentIdentifier: componentIdentifier)
+        self.componentIdentifier = componentIdentifier ?? InformationView.identifier
     }
+}
+
+public extension InformationView {
+    static let identifier = "fiori_informationview_component"
 }
 
 public extension InformationView {
@@ -36,6 +44,7 @@ public extension InformationView {
         self.icon = configuration.icon
         self.description = configuration.description
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -44,7 +53,7 @@ extension InformationView: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(icon: .init(self.icon), description: .init(self.description))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, icon: .init(self.icon), description: .init(self.description))).typeErased
                 .transformEnvironment(\.informationViewStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -62,7 +71,7 @@ private extension InformationView {
     }
 
     func defaultStyle() -> some View {
-        InformationView(.init(icon: .init(self.icon), description: .init(self.description)))
+        InformationView(.init(componentIdentifier: self.componentIdentifier, icon: .init(self.icon), description: .init(self.description)))
             .shouldApplyDefaultStyle(false)
             .informationViewStyle(InformationViewFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/InformationView/InformationViewStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/InformationView/InformationViewStyle.generated.swift
@@ -22,11 +22,18 @@ struct AnyInformationViewStyle: InformationViewStyle {
 }
 
 public struct InformationViewConfiguration {
+    public var componentIdentifier: String = "fiori_informationview_component"
     public let icon: Icon
     public let description: Description
 
     public typealias Icon = ConfigurationViewWrapper
     public typealias Description = ConfigurationViewWrapper
+}
+
+extension InformationViewConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct InformationViewFioriStyle: InformationViewStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/InnerCircle/InnerCircle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/InnerCircle/InnerCircle.generated.swift
@@ -8,11 +8,20 @@ public struct InnerCircle {
 
     @Environment(\.innerCircleStyle) var style
 
+    var componentIdentifier: String = InnerCircle.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder innerCircle: () -> any View) {
+    public init(@ViewBuilder innerCircle: () -> any View,
+                componentIdentifier: String? = InnerCircle.identifier)
+    {
         self.innerCircle = innerCircle()
+        self.componentIdentifier = componentIdentifier ?? InnerCircle.identifier
     }
+}
+
+public extension InnerCircle {
+    static let identifier = "fiori_innercircle_component"
 }
 
 public extension InnerCircle {
@@ -29,6 +38,7 @@ public extension InnerCircle {
     internal init(_ configuration: InnerCircleConfiguration, shouldApplyDefaultStyle: Bool) {
         self.innerCircle = configuration.innerCircle
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension InnerCircle: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(innerCircle: .init(self.innerCircle))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, innerCircle: .init(self.innerCircle))).typeErased
                 .transformEnvironment(\.innerCircleStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension InnerCircle {
     }
 
     func defaultStyle() -> some View {
-        InnerCircle(.init(innerCircle: .init(self.innerCircle)))
+        InnerCircle(.init(componentIdentifier: self.componentIdentifier, innerCircle: .init(self.innerCircle)))
             .shouldApplyDefaultStyle(false)
             .innerCircleStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/InnerCircle/InnerCircleStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/InnerCircle/InnerCircleStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyInnerCircleStyle: InnerCircleStyle {
 }
 
 public struct InnerCircleConfiguration {
+    public var componentIdentifier: String = "fiori_innercircle_component"
     public let innerCircle: InnerCircle
 
     public typealias InnerCircle = ConfigurationViewWrapper
+}
+
+extension InnerCircleConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/JouleWelcomeScreen/JouleWelcomeScreen.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/JouleWelcomeScreen/JouleWelcomeScreen.generated.swift
@@ -12,20 +12,28 @@ public struct JouleWelcomeScreen {
 
     @Environment(\.jouleWelcomeScreenStyle) var style
 
+    var componentIdentifier: String = JouleWelcomeScreen.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder mediaImage: () -> any View = { EmptyView() },
                 @ViewBuilder greetingText: () -> any View,
                 @ViewBuilder title: () -> any View,
                 @ViewBuilder footnote: () -> any View = { EmptyView() },
-                @ViewBuilder messageContent: () -> any View = { EmptyView() })
+                @ViewBuilder messageContent: () -> any View = { EmptyView() },
+                componentIdentifier: String? = JouleWelcomeScreen.identifier)
     {
-        self.mediaImage = MediaImage(mediaImage: mediaImage)
-        self.greetingText = GreetingText(greetingText: greetingText)
-        self.title = Title(title: title)
-        self.footnote = Footnote(footnote: footnote)
-        self.messageContent = MessageContent(messageContent: messageContent)
+        self.mediaImage = MediaImage(mediaImage: mediaImage, componentIdentifier: componentIdentifier)
+        self.greetingText = GreetingText(greetingText: greetingText, componentIdentifier: componentIdentifier)
+        self.title = Title(title: title, componentIdentifier: componentIdentifier)
+        self.footnote = Footnote(footnote: footnote, componentIdentifier: componentIdentifier)
+        self.messageContent = MessageContent(messageContent: messageContent, componentIdentifier: componentIdentifier)
+        self.componentIdentifier = componentIdentifier ?? JouleWelcomeScreen.identifier
     }
+}
+
+public extension JouleWelcomeScreen {
+    static let identifier = "fiori_joulewelcomescreen_component"
 }
 
 public extension JouleWelcomeScreen {
@@ -51,6 +59,7 @@ public extension JouleWelcomeScreen {
         self.footnote = configuration.footnote
         self.messageContent = configuration.messageContent
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -59,7 +68,7 @@ extension JouleWelcomeScreen: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(mediaImage: .init(self.mediaImage), greetingText: .init(self.greetingText), title: .init(self.title), footnote: .init(self.footnote), messageContent: .init(self.messageContent))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, mediaImage: .init(self.mediaImage), greetingText: .init(self.greetingText), title: .init(self.title), footnote: .init(self.footnote), messageContent: .init(self.messageContent))).typeErased
                 .transformEnvironment(\.jouleWelcomeScreenStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -77,7 +86,7 @@ private extension JouleWelcomeScreen {
     }
 
     func defaultStyle() -> some View {
-        JouleWelcomeScreen(.init(mediaImage: .init(self.mediaImage), greetingText: .init(self.greetingText), title: .init(self.title), footnote: .init(self.footnote), messageContent: .init(self.messageContent)))
+        JouleWelcomeScreen(.init(componentIdentifier: self.componentIdentifier, mediaImage: .init(self.mediaImage), greetingText: .init(self.greetingText), title: .init(self.title), footnote: .init(self.footnote), messageContent: .init(self.messageContent)))
             .shouldApplyDefaultStyle(false)
             .jouleWelcomeScreenStyle(JouleWelcomeScreenFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/JouleWelcomeScreen/JouleWelcomeScreenStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/JouleWelcomeScreen/JouleWelcomeScreenStyle.generated.swift
@@ -22,6 +22,7 @@ struct AnyJouleWelcomeScreenStyle: JouleWelcomeScreenStyle {
 }
 
 public struct JouleWelcomeScreenConfiguration {
+    public var componentIdentifier: String = "fiori_joulewelcomescreen_component"
     public let mediaImage: MediaImage
     public let greetingText: GreetingText
     public let title: Title
@@ -33,6 +34,12 @@ public struct JouleWelcomeScreenConfiguration {
     public typealias Title = ConfigurationViewWrapper
     public typealias Footnote = ConfigurationViewWrapper
     public typealias MessageContent = ConfigurationViewWrapper
+}
+
+extension JouleWelcomeScreenConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct JouleWelcomeScreenFioriStyle: JouleWelcomeScreenStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/KPIContent/KPIContent.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/KPIContent/KPIContent.generated.swift
@@ -8,11 +8,20 @@ public struct KPIContent {
 
     @Environment(\.kPIContentStyle) var style
 
+    var componentIdentifier: String = KPIContent.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder kPIContent: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder kPIContent: () -> any View = { EmptyView() },
+                componentIdentifier: String? = KPIContent.identifier)
+    {
         self.kPIContent = kPIContent()
+        self.componentIdentifier = componentIdentifier ?? KPIContent.identifier
     }
+}
+
+public extension KPIContent {
+    static let identifier = "fiori_kpicontent_component"
 }
 
 public extension KPIContent {
@@ -23,6 +32,7 @@ public extension KPIContent {
     internal init(_ configuration: KPIContentConfiguration, shouldApplyDefaultStyle: Bool) {
         self.kPIContent = configuration.kPIContent
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -31,7 +41,7 @@ extension KPIContent: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(kPIContent: .init(self.kPIContent))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, kPIContent: .init(self.kPIContent))).typeErased
                 .transformEnvironment(\.kPIContentStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -49,7 +59,7 @@ private extension KPIContent {
     }
 
     func defaultStyle() -> some View {
-        KPIContent(.init(kPIContent: .init(self.kPIContent)))
+        KPIContent(.init(componentIdentifier: self.componentIdentifier, kPIContent: .init(self.kPIContent)))
             .shouldApplyDefaultStyle(false)
             .kPIContentStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/KPIContent/KPIContentStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/KPIContent/KPIContentStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyKPIContentStyle: KPIContentStyle {
 }
 
 public struct KPIContentConfiguration {
+    public var componentIdentifier: String = "fiori_kpicontent_component"
     public let kPIContent: KPIContent
 
     public typealias KPIContent = ConfigurationViewWrapper
+}
+
+extension KPIContentConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/KPIProgressItem/KPIProgressItem.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/KPIProgressItem/KPIProgressItem.generated.swift
@@ -24,6 +24,8 @@ public struct KPIProgressItem {
 
     @Environment(\.kPIProgressItemStyle) var style
 
+    var componentIdentifier: String = KPIProgressItem.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder kPIContent: () -> any View = { EmptyView() },
@@ -32,16 +34,22 @@ public struct KPIProgressItem {
                 @ViewBuilder innerCircle: () -> any View,
                 @ViewBuilder outerCircle: () -> any View,
                 data: Binding<KPIItemData>,
-                chartSize: KPIProgressItemSize = .large)
+                chartSize: KPIProgressItemSize = .large,
+                componentIdentifier: String? = KPIProgressItem.identifier)
     {
-        self.kPIContent = KPIContent(kPIContent: kPIContent)
-        self.kpiCaption = KpiCaption(kpiCaption: kpiCaption)
-        self.footnote = Footnote(footnote: footnote)
-        self.innerCircle = InnerCircle(innerCircle: innerCircle)
-        self.outerCircle = OuterCircle(outerCircle: outerCircle)
+        self.kPIContent = KPIContent(kPIContent: kPIContent, componentIdentifier: componentIdentifier)
+        self.kpiCaption = KpiCaption(kpiCaption: kpiCaption, componentIdentifier: componentIdentifier)
+        self.footnote = Footnote(footnote: footnote, componentIdentifier: componentIdentifier)
+        self.innerCircle = InnerCircle(innerCircle: innerCircle, componentIdentifier: componentIdentifier)
+        self.outerCircle = OuterCircle(outerCircle: outerCircle, componentIdentifier: componentIdentifier)
         self._data = data
         self.chartSize = chartSize
+        self.componentIdentifier = componentIdentifier ?? KPIProgressItem.identifier
     }
+}
+
+public extension KPIProgressItem {
+    static let identifier = "fiori_kpiprogressitem_component"
 }
 
 public extension KPIProgressItem {
@@ -71,6 +79,7 @@ public extension KPIProgressItem {
         self._data = configuration.$data
         self.chartSize = configuration.chartSize
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -79,7 +88,7 @@ extension KPIProgressItem: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(kPIContent: .init(self.kPIContent), kpiCaption: .init(self.kpiCaption), footnote: .init(self.footnote), innerCircle: .init(self.innerCircle), outerCircle: .init(self.outerCircle), data: self.$data, chartSize: self.chartSize)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, kPIContent: .init(self.kPIContent), kpiCaption: .init(self.kpiCaption), footnote: .init(self.footnote), innerCircle: .init(self.innerCircle), outerCircle: .init(self.outerCircle), data: self.$data, chartSize: self.chartSize)).typeErased
                 .transformEnvironment(\.kPIProgressItemStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -97,7 +106,7 @@ private extension KPIProgressItem {
     }
 
     func defaultStyle() -> some View {
-        KPIProgressItem(.init(kPIContent: .init(self.kPIContent), kpiCaption: .init(self.kpiCaption), footnote: .init(self.footnote), innerCircle: .init(self.innerCircle), outerCircle: .init(self.outerCircle), data: self.$data, chartSize: self.chartSize))
+        KPIProgressItem(.init(componentIdentifier: self.componentIdentifier, kPIContent: .init(self.kPIContent), kpiCaption: .init(self.kpiCaption), footnote: .init(self.footnote), innerCircle: .init(self.innerCircle), outerCircle: .init(self.outerCircle), data: self.$data, chartSize: self.chartSize))
             .shouldApplyDefaultStyle(false)
             .kPIProgressItemStyle(KPIProgressItemFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/KPIProgressItem/KPIProgressItemStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/KPIProgressItem/KPIProgressItemStyle.generated.swift
@@ -22,6 +22,7 @@ struct AnyKPIProgressItemStyle: KPIProgressItemStyle {
 }
 
 public struct KPIProgressItemConfiguration {
+    public var componentIdentifier: String = "fiori_kpiprogressitem_component"
     public let kPIContent: KPIContent
     public let kpiCaption: KpiCaption
     public let footnote: Footnote
@@ -35,6 +36,12 @@ public struct KPIProgressItemConfiguration {
     public typealias Footnote = ConfigurationViewWrapper
     public typealias InnerCircle = ConfigurationViewWrapper
     public typealias OuterCircle = ConfigurationViewWrapper
+}
+
+extension KPIProgressItemConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct KPIProgressItemFioriStyle: KPIProgressItemStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/KeyValueFormView/KeyValueFormView.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/KeyValueFormView/KeyValueFormView.generated.swift
@@ -34,6 +34,8 @@ public struct KeyValueFormView {
 
     @Environment(\.keyValueFormViewStyle) var style
 
+    var componentIdentifier: String = KeyValueFormView.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder title: () -> any View,
@@ -51,11 +53,12 @@ public struct KeyValueFormView {
                 charCountReachLimitMessage: String? = nil,
                 charCountBeyondLimitMsg: String? = nil,
                 @ViewBuilder mandatoryFieldIndicator: () -> any View = { Text("*") },
-                isRequired: Bool = false)
+                isRequired: Bool = false,
+                componentIdentifier: String? = KeyValueFormView.identifier)
     {
-        self.title = Title(title: title)
+        self.title = Title(title: title, componentIdentifier: componentIdentifier)
         self._text = text
-        self.placeholder = Placeholder(placeholder: placeholder)
+        self.placeholder = Placeholder(placeholder: placeholder, componentIdentifier: componentIdentifier)
         self.controlState = controlState
         self.errorMessage = errorMessage
         self.minTextEditorHeight = minTextEditorHeight
@@ -67,9 +70,14 @@ public struct KeyValueFormView {
         self.allowsBeyondLimit = allowsBeyondLimit
         self.charCountReachLimitMessage = charCountReachLimitMessage
         self.charCountBeyondLimitMsg = charCountBeyondLimitMsg
-        self.mandatoryFieldIndicator = MandatoryFieldIndicator(mandatoryFieldIndicator: mandatoryFieldIndicator)
+        self.mandatoryFieldIndicator = MandatoryFieldIndicator(mandatoryFieldIndicator: mandatoryFieldIndicator, componentIdentifier: componentIdentifier)
         self.isRequired = isRequired
+        self.componentIdentifier = componentIdentifier ?? KeyValueFormView.identifier
     }
+}
+
+public extension KeyValueFormView {
+    static let identifier = "fiori_keyvalueformview_component"
 }
 
 public extension KeyValueFormView {
@@ -117,6 +125,7 @@ public extension KeyValueFormView {
         self.mandatoryFieldIndicator = configuration.mandatoryFieldIndicator
         self.isRequired = configuration.isRequired
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -125,7 +134,7 @@ extension KeyValueFormView: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(title: .init(self.title), text: self.$text, placeholder: .init(self.placeholder), controlState: self.controlState, errorMessage: self.errorMessage, minTextEditorHeight: self.minTextEditorHeight, maxTextEditorHeight: self.maxTextEditorHeight, maxTextLength: self.maxTextLength, hintText: self.hintText, hidesReadOnlyHint: self.hidesReadOnlyHint, isCharCountEnabled: self.isCharCountEnabled, allowsBeyondLimit: self.allowsBeyondLimit, charCountReachLimitMessage: self.charCountReachLimitMessage, charCountBeyondLimitMsg: self.charCountBeyondLimitMsg, mandatoryFieldIndicator: .init(self.mandatoryFieldIndicator), isRequired: self.isRequired)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, title: .init(self.title), text: self.$text, placeholder: .init(self.placeholder), controlState: self.controlState, errorMessage: self.errorMessage, minTextEditorHeight: self.minTextEditorHeight, maxTextEditorHeight: self.maxTextEditorHeight, maxTextLength: self.maxTextLength, hintText: self.hintText, hidesReadOnlyHint: self.hidesReadOnlyHint, isCharCountEnabled: self.isCharCountEnabled, allowsBeyondLimit: self.allowsBeyondLimit, charCountReachLimitMessage: self.charCountReachLimitMessage, charCountBeyondLimitMsg: self.charCountBeyondLimitMsg, mandatoryFieldIndicator: .init(self.mandatoryFieldIndicator), isRequired: self.isRequired)).typeErased
                 .transformEnvironment(\.keyValueFormViewStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -143,7 +152,7 @@ private extension KeyValueFormView {
     }
 
     func defaultStyle() -> some View {
-        KeyValueFormView(.init(title: .init(self.title), text: self.$text, placeholder: .init(self.placeholder), controlState: self.controlState, errorMessage: self.errorMessage, minTextEditorHeight: self.minTextEditorHeight, maxTextEditorHeight: self.maxTextEditorHeight, maxTextLength: self.maxTextLength, hintText: self.hintText, hidesReadOnlyHint: self.hidesReadOnlyHint, isCharCountEnabled: self.isCharCountEnabled, allowsBeyondLimit: self.allowsBeyondLimit, charCountReachLimitMessage: self.charCountReachLimitMessage, charCountBeyondLimitMsg: self.charCountBeyondLimitMsg, mandatoryFieldIndicator: .init(self.mandatoryFieldIndicator), isRequired: self.isRequired))
+        KeyValueFormView(.init(componentIdentifier: self.componentIdentifier, title: .init(self.title), text: self.$text, placeholder: .init(self.placeholder), controlState: self.controlState, errorMessage: self.errorMessage, minTextEditorHeight: self.minTextEditorHeight, maxTextEditorHeight: self.maxTextEditorHeight, maxTextLength: self.maxTextLength, hintText: self.hintText, hidesReadOnlyHint: self.hidesReadOnlyHint, isCharCountEnabled: self.isCharCountEnabled, allowsBeyondLimit: self.allowsBeyondLimit, charCountReachLimitMessage: self.charCountReachLimitMessage, charCountBeyondLimitMsg: self.charCountBeyondLimitMsg, mandatoryFieldIndicator: .init(self.mandatoryFieldIndicator), isRequired: self.isRequired))
             .shouldApplyDefaultStyle(false)
             .keyValueFormViewStyle(KeyValueFormViewFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/KeyValueFormView/KeyValueFormViewStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/KeyValueFormView/KeyValueFormViewStyle.generated.swift
@@ -22,6 +22,7 @@ struct AnyKeyValueFormViewStyle: KeyValueFormViewStyle {
 }
 
 public struct KeyValueFormViewConfiguration {
+    public var componentIdentifier: String = "fiori_keyvalueformview_component"
     public let title: Title
     @Binding public var text: String
     public let placeholder: Placeholder
@@ -42,6 +43,12 @@ public struct KeyValueFormViewConfiguration {
     public typealias Title = ConfigurationViewWrapper
     public typealias Placeholder = ConfigurationViewWrapper
     public typealias MandatoryFieldIndicator = ConfigurationViewWrapper
+}
+
+extension KeyValueFormViewConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct KeyValueFormViewFioriStyle: KeyValueFormViewStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Kpi/Kpi.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Kpi/Kpi.generated.swift
@@ -8,11 +8,20 @@ public struct Kpi {
 
     @Environment(\.kpiStyle) var style
 
+    var componentIdentifier: String = Kpi.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder kpi: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder kpi: () -> any View = { EmptyView() },
+                componentIdentifier: String? = Kpi.identifier)
+    {
         self.kpi = kpi()
+        self.componentIdentifier = componentIdentifier ?? Kpi.identifier
     }
+}
+
+public extension Kpi {
+    static let identifier = "fiori_kpi_component"
 }
 
 public extension Kpi {
@@ -29,6 +38,7 @@ public extension Kpi {
     internal init(_ configuration: KpiConfiguration, shouldApplyDefaultStyle: Bool) {
         self.kpi = configuration.kpi
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension Kpi: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(kpi: .init(self.kpi))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, kpi: .init(self.kpi))).typeErased
                 .transformEnvironment(\.kpiStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension Kpi {
     }
 
     func defaultStyle() -> some View {
-        Kpi(.init(kpi: .init(self.kpi)))
+        Kpi(.init(componentIdentifier: self.componentIdentifier, kpi: .init(self.kpi)))
             .shouldApplyDefaultStyle(false)
             .kpiStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Kpi/KpiStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Kpi/KpiStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyKpiStyle: KpiStyle {
 }
 
 public struct KpiConfiguration {
+    public var componentIdentifier: String = "fiori_kpi_component"
     public let kpi: Kpi
 
     public typealias Kpi = ConfigurationViewWrapper
+}
+
+extension KpiConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/KpiCaption/KpiCaption.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/KpiCaption/KpiCaption.generated.swift
@@ -8,11 +8,20 @@ public struct KpiCaption {
 
     @Environment(\.kpiCaptionStyle) var style
 
+    var componentIdentifier: String = KpiCaption.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder kpiCaption: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder kpiCaption: () -> any View = { EmptyView() },
+                componentIdentifier: String? = KpiCaption.identifier)
+    {
         self.kpiCaption = kpiCaption()
+        self.componentIdentifier = componentIdentifier ?? KpiCaption.identifier
     }
+}
+
+public extension KpiCaption {
+    static let identifier = "fiori_kpicaption_component"
 }
 
 public extension KpiCaption {
@@ -29,6 +38,7 @@ public extension KpiCaption {
     internal init(_ configuration: KpiCaptionConfiguration, shouldApplyDefaultStyle: Bool) {
         self.kpiCaption = configuration.kpiCaption
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension KpiCaption: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(kpiCaption: .init(self.kpiCaption))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, kpiCaption: .init(self.kpiCaption))).typeErased
                 .transformEnvironment(\.kpiCaptionStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension KpiCaption {
     }
 
     func defaultStyle() -> some View {
-        KpiCaption(.init(kpiCaption: .init(self.kpiCaption)))
+        KpiCaption(.init(componentIdentifier: self.componentIdentifier, kpiCaption: .init(self.kpiCaption)))
             .shouldApplyDefaultStyle(false)
             .kpiCaptionStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/KpiCaption/KpiCaptionStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/KpiCaption/KpiCaptionStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyKpiCaptionStyle: KpiCaptionStyle {
 }
 
 public struct KpiCaptionConfiguration {
+    public var componentIdentifier: String = "fiori_kpicaption_component"
     public let kpiCaption: KpiCaption
 
     public typealias KpiCaption = ConfigurationViewWrapper
+}
+
+extension KpiCaptionConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/LabelItem/LabelItem.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/LabelItem/LabelItem.generated.swift
@@ -11,16 +11,24 @@ public struct LabelItem {
 
     @Environment(\.labelItemStyle) var style
 
+    var componentIdentifier: String = LabelItem.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder icon: () -> any View = { EmptyView() },
                 @ViewBuilder title: () -> any View,
-                alignment: HorizontalAlignment? = nil)
+                alignment: HorizontalAlignment? = nil,
+                componentIdentifier: String? = LabelItem.identifier)
     {
-        self.icon = Icon(icon: icon)
-        self.title = Title(title: title)
+        self.icon = Icon(icon: icon, componentIdentifier: componentIdentifier)
+        self.title = Title(title: title, componentIdentifier: componentIdentifier)
         self.alignment = alignment
+        self.componentIdentifier = componentIdentifier ?? LabelItem.identifier
     }
+}
+
+public extension LabelItem {
+    static let identifier = "fiori_labelitem_component"
 }
 
 public extension LabelItem {
@@ -42,6 +50,7 @@ public extension LabelItem {
         self.title = configuration.title
         self.alignment = configuration.alignment
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -50,7 +59,7 @@ extension LabelItem: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(icon: .init(self.icon), title: .init(self.title), alignment: self.alignment)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, icon: .init(self.icon), title: .init(self.title), alignment: self.alignment)).typeErased
                 .transformEnvironment(\.labelItemStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -68,7 +77,7 @@ private extension LabelItem {
     }
 
     func defaultStyle() -> some View {
-        LabelItem(.init(icon: .init(self.icon), title: .init(self.title), alignment: self.alignment))
+        LabelItem(.init(componentIdentifier: self.componentIdentifier, icon: .init(self.icon), title: .init(self.title), alignment: self.alignment))
             .shouldApplyDefaultStyle(false)
             .labelItemStyle(LabelItemFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/LabelItem/LabelItemStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/LabelItem/LabelItemStyle.generated.swift
@@ -22,12 +22,19 @@ struct AnyLabelItemStyle: LabelItemStyle {
 }
 
 public struct LabelItemConfiguration {
+    public var componentIdentifier: String = "fiori_labelitem_component"
     public let icon: Icon
     public let title: Title
     public let alignment: HorizontalAlignment?
 
     public typealias Icon = ConfigurationViewWrapper
     public typealias Title = ConfigurationViewWrapper
+}
+
+extension LabelItemConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct LabelItemFioriStyle: LabelItemStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/LeadingAccessory/LeadingAccessory.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/LeadingAccessory/LeadingAccessory.generated.swift
@@ -8,11 +8,20 @@ public struct LeadingAccessory {
 
     @Environment(\.leadingAccessoryStyle) var style
 
+    var componentIdentifier: String = LeadingAccessory.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder leadingAccessory: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder leadingAccessory: () -> any View = { EmptyView() },
+                componentIdentifier: String? = LeadingAccessory.identifier)
+    {
         self.leadingAccessory = leadingAccessory()
+        self.componentIdentifier = componentIdentifier ?? LeadingAccessory.identifier
     }
+}
+
+public extension LeadingAccessory {
+    static let identifier = "fiori_leadingaccessory_component"
 }
 
 public extension LeadingAccessory {
@@ -23,6 +32,7 @@ public extension LeadingAccessory {
     internal init(_ configuration: LeadingAccessoryConfiguration, shouldApplyDefaultStyle: Bool) {
         self.leadingAccessory = configuration.leadingAccessory
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -31,7 +41,7 @@ extension LeadingAccessory: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(leadingAccessory: .init(self.leadingAccessory))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, leadingAccessory: .init(self.leadingAccessory))).typeErased
                 .transformEnvironment(\.leadingAccessoryStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -49,7 +59,7 @@ private extension LeadingAccessory {
     }
 
     func defaultStyle() -> some View {
-        LeadingAccessory(.init(leadingAccessory: .init(self.leadingAccessory)))
+        LeadingAccessory(.init(componentIdentifier: self.componentIdentifier, leadingAccessory: .init(self.leadingAccessory)))
             .shouldApplyDefaultStyle(false)
             .leadingAccessoryStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/LeadingAccessory/LeadingAccessoryStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/LeadingAccessory/LeadingAccessoryStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyLeadingAccessoryStyle: LeadingAccessoryStyle {
 }
 
 public struct LeadingAccessoryConfiguration {
+    public var componentIdentifier: String = "fiori_leadingaccessory_component"
     public let leadingAccessory: LeadingAccessory
 
     public typealias LeadingAccessory = ConfigurationViewWrapper
+}
+
+extension LeadingAccessoryConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Line/Line.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Line/Line.generated.swift
@@ -8,11 +8,20 @@ public struct Line {
 
     @Environment(\.lineStyle) var style
 
+    var componentIdentifier: String = Line.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder line: () -> any View = { Rectangle() }) {
+    public init(@ViewBuilder line: () -> any View = { Rectangle() },
+                componentIdentifier: String? = Line.identifier)
+    {
         self.line = line()
+        self.componentIdentifier = componentIdentifier ?? Line.identifier
     }
+}
+
+public extension Line {
+    static let identifier = "fiori_line_component"
 }
 
 public extension Line {
@@ -23,6 +32,7 @@ public extension Line {
     internal init(_ configuration: LineConfiguration, shouldApplyDefaultStyle: Bool) {
         self.line = configuration.line
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -31,7 +41,7 @@ extension Line: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(line: .init(self.line))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, line: .init(self.line))).typeErased
                 .transformEnvironment(\.lineStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -49,7 +59,7 @@ private extension Line {
     }
 
     func defaultStyle() -> some View {
-        Line(.init(line: .init(self.line)))
+        Line(.init(componentIdentifier: self.componentIdentifier, line: .init(self.line)))
             .shouldApplyDefaultStyle(false)
             .lineStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Line/LineStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Line/LineStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyLineStyle: LineStyle {
 }
 
 public struct LineConfiguration {
+    public var componentIdentifier: String = "fiori_line_component"
     public let line: Line
 
     public typealias Line = ConfigurationViewWrapper
+}
+
+extension LineConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/LinearProgressIndicator/LinearProgressIndicator.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/LinearProgressIndicator/LinearProgressIndicator.generated.swift
@@ -8,11 +8,20 @@ public struct LinearProgressIndicator {
 
     @Environment(\.linearProgressIndicatorStyle) var style
 
+    var componentIdentifier: String = LinearProgressIndicator.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(indicatorProgress: Binding<Double>) {
+    public init(indicatorProgress: Binding<Double>,
+                componentIdentifier: String? = LinearProgressIndicator.identifier)
+    {
         self._indicatorProgress = indicatorProgress
+        self.componentIdentifier = componentIdentifier ?? LinearProgressIndicator.identifier
     }
+}
+
+public extension LinearProgressIndicator {
+    static let identifier = "fiori_linearprogressindicator_component"
 }
 
 public extension LinearProgressIndicator {
@@ -23,6 +32,7 @@ public extension LinearProgressIndicator {
     internal init(_ configuration: LinearProgressIndicatorConfiguration, shouldApplyDefaultStyle: Bool) {
         self._indicatorProgress = configuration.$indicatorProgress
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -31,7 +41,7 @@ extension LinearProgressIndicator: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(indicatorProgress: self.$indicatorProgress)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, indicatorProgress: self.$indicatorProgress)).typeErased
                 .transformEnvironment(\.linearProgressIndicatorStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -49,7 +59,7 @@ private extension LinearProgressIndicator {
     }
 
     func defaultStyle() -> some View {
-        LinearProgressIndicator(.init(indicatorProgress: self.$indicatorProgress))
+        LinearProgressIndicator(.init(componentIdentifier: self.componentIdentifier, indicatorProgress: self.$indicatorProgress))
             .shouldApplyDefaultStyle(false)
             .linearProgressIndicatorStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/LinearProgressIndicator/LinearProgressIndicatorStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/LinearProgressIndicator/LinearProgressIndicatorStyle.generated.swift
@@ -22,5 +22,12 @@ struct AnyLinearProgressIndicatorStyle: LinearProgressIndicatorStyle {
 }
 
 public struct LinearProgressIndicatorConfiguration {
+    public var componentIdentifier: String = "fiori_linearprogressindicator_component"
     @Binding public var indicatorProgress: Double
+}
+
+extension LinearProgressIndicatorConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/LinearProgressIndicatorView/LinearProgressIndicatorView.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/LinearProgressIndicatorView/LinearProgressIndicatorView.generated.swift
@@ -10,16 +10,24 @@ public struct LinearProgressIndicatorView {
 
     @Environment(\.linearProgressIndicatorViewStyle) var style
 
+    var componentIdentifier: String = LinearProgressIndicatorView.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(indicatorProgress: Binding<Double>,
                 @ViewBuilder icon: () -> any View = { EmptyView() },
-                @ViewBuilder description: () -> any View = { EmptyView() })
+                @ViewBuilder description: () -> any View = { EmptyView() },
+                componentIdentifier: String? = LinearProgressIndicatorView.identifier)
     {
         self._indicatorProgress = indicatorProgress
-        self.icon = Icon(icon: icon)
-        self.description = Description(description: description)
+        self.icon = Icon(icon: icon, componentIdentifier: componentIdentifier)
+        self.description = Description(description: description, componentIdentifier: componentIdentifier)
+        self.componentIdentifier = componentIdentifier ?? LinearProgressIndicatorView.identifier
     }
+}
+
+public extension LinearProgressIndicatorView {
+    static let identifier = "fiori_linearprogressindicatorview_component"
 }
 
 public extension LinearProgressIndicatorView {
@@ -41,6 +49,7 @@ public extension LinearProgressIndicatorView {
         self.icon = configuration.icon
         self.description = configuration.description
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -49,7 +58,7 @@ extension LinearProgressIndicatorView: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(indicatorProgress: self.$indicatorProgress, icon: .init(self.icon), description: .init(self.description))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, indicatorProgress: self.$indicatorProgress, icon: .init(self.icon), description: .init(self.description))).typeErased
                 .transformEnvironment(\.linearProgressIndicatorViewStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -67,7 +76,7 @@ private extension LinearProgressIndicatorView {
     }
 
     func defaultStyle() -> some View {
-        LinearProgressIndicatorView(.init(indicatorProgress: self.$indicatorProgress, icon: .init(self.icon), description: .init(self.description)))
+        LinearProgressIndicatorView(.init(componentIdentifier: self.componentIdentifier, indicatorProgress: self.$indicatorProgress, icon: .init(self.icon), description: .init(self.description)))
             .shouldApplyDefaultStyle(false)
             .linearProgressIndicatorViewStyle(LinearProgressIndicatorViewFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/LinearProgressIndicatorView/LinearProgressIndicatorViewStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/LinearProgressIndicatorView/LinearProgressIndicatorViewStyle.generated.swift
@@ -22,12 +22,19 @@ struct AnyLinearProgressIndicatorViewStyle: LinearProgressIndicatorViewStyle {
 }
 
 public struct LinearProgressIndicatorViewConfiguration {
+    public var componentIdentifier: String = "fiori_linearprogressindicatorview_component"
     @Binding public var indicatorProgress: Double
     public let icon: Icon
     public let description: Description
 
     public typealias Icon = ConfigurationViewWrapper
     public typealias Description = ConfigurationViewWrapper
+}
+
+extension LinearProgressIndicatorViewConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct LinearProgressIndicatorViewFioriStyle: LinearProgressIndicatorViewStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/ListPickerContent/ListPickerContent.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/ListPickerContent/ListPickerContent.generated.swift
@@ -8,11 +8,20 @@ public struct ListPickerContent {
 
     @Environment(\.listPickerContentStyle) var style
 
+    var componentIdentifier: String = ListPickerContent.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder listPickerContent: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder listPickerContent: () -> any View = { EmptyView() },
+                componentIdentifier: String? = ListPickerContent.identifier)
+    {
         self.listPickerContent = listPickerContent()
+        self.componentIdentifier = componentIdentifier ?? ListPickerContent.identifier
     }
+}
+
+public extension ListPickerContent {
+    static let identifier = "fiori_listpickercontent_component"
 }
 
 public extension ListPickerContent {
@@ -23,6 +32,7 @@ public extension ListPickerContent {
     internal init(_ configuration: ListPickerContentConfiguration, shouldApplyDefaultStyle: Bool) {
         self.listPickerContent = configuration.listPickerContent
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -31,7 +41,7 @@ extension ListPickerContent: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(listPickerContent: .init(self.listPickerContent))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, listPickerContent: .init(self.listPickerContent))).typeErased
                 .transformEnvironment(\.listPickerContentStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -49,7 +59,7 @@ private extension ListPickerContent {
     }
 
     func defaultStyle() -> some View {
-        ListPickerContent(.init(listPickerContent: .init(self.listPickerContent)))
+        ListPickerContent(.init(componentIdentifier: self.componentIdentifier, listPickerContent: .init(self.listPickerContent)))
             .shouldApplyDefaultStyle(false)
             .listPickerContentStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/ListPickerContent/ListPickerContentStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/ListPickerContent/ListPickerContentStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyListPickerContentStyle: ListPickerContentStyle {
 }
 
 public struct ListPickerContentConfiguration {
+    public var componentIdentifier: String = "fiori_listpickercontent_component"
     public let listPickerContent: ListPickerContent
 
     public typealias ListPickerContent = ConfigurationViewWrapper
+}
+
+extension ListPickerContentConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/ListPickerDestination/ListPickerDestination.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/ListPickerDestination/ListPickerDestination.generated.swift
@@ -16,6 +16,8 @@ public struct ListPickerDestination {
 
     @Environment(\.listPickerDestinationStyle) var style
 
+    var componentIdentifier: String = ListPickerDestination.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder cancelAction: () -> any View = { FioriButton { _ in Text("Cancel".localizedFioriString()) } },
@@ -24,16 +26,22 @@ public struct ListPickerDestination {
                 @ViewBuilder selectAllAction: () -> any View = { FioriButton { _ in Text("Select All".localizedFioriString()) } },
                 @ViewBuilder deselectAllAction: () -> any View = { FioriButton { _ in Text("Deselect All".localizedFioriString()) } },
                 @ViewBuilder allEntriesSectionTitle: () -> any View = { Text("All".localizedFioriString()) },
-                @ViewBuilder listPickerContent: () -> any View = { EmptyView() })
+                @ViewBuilder listPickerContent: () -> any View = { EmptyView() },
+                componentIdentifier: String? = ListPickerDestination.identifier)
     {
-        self.cancelAction = CancelAction(cancelAction: cancelAction)
-        self.applyAction = ApplyAction(applyAction: applyAction)
-        self.selectedEntriesSectionTitle = SelectedEntriesSectionTitle(selectedEntriesSectionTitle: selectedEntriesSectionTitle)
-        self.selectAllAction = SelectAllAction(selectAllAction: selectAllAction)
-        self.deselectAllAction = DeselectAllAction(deselectAllAction: deselectAllAction)
-        self.allEntriesSectionTitle = AllEntriesSectionTitle(allEntriesSectionTitle: allEntriesSectionTitle)
-        self.listPickerContent = ListPickerContent(listPickerContent: listPickerContent)
+        self.cancelAction = CancelAction(cancelAction: cancelAction, componentIdentifier: componentIdentifier)
+        self.applyAction = ApplyAction(applyAction: applyAction, componentIdentifier: componentIdentifier)
+        self.selectedEntriesSectionTitle = SelectedEntriesSectionTitle(selectedEntriesSectionTitle: selectedEntriesSectionTitle, componentIdentifier: componentIdentifier)
+        self.selectAllAction = SelectAllAction(selectAllAction: selectAllAction, componentIdentifier: componentIdentifier)
+        self.deselectAllAction = DeselectAllAction(deselectAllAction: deselectAllAction, componentIdentifier: componentIdentifier)
+        self.allEntriesSectionTitle = AllEntriesSectionTitle(allEntriesSectionTitle: allEntriesSectionTitle, componentIdentifier: componentIdentifier)
+        self.listPickerContent = ListPickerContent(listPickerContent: listPickerContent, componentIdentifier: componentIdentifier)
+        self.componentIdentifier = componentIdentifier ?? ListPickerDestination.identifier
     }
+}
+
+public extension ListPickerDestination {
+    static let identifier = "fiori_listpickerdestination_component"
 }
 
 public extension ListPickerDestination {
@@ -63,6 +71,7 @@ public extension ListPickerDestination {
         self.allEntriesSectionTitle = configuration.allEntriesSectionTitle
         self.listPickerContent = configuration.listPickerContent
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -71,7 +80,7 @@ extension ListPickerDestination: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(cancelAction: .init(self.cancelAction), applyAction: .init(self.applyAction), selectedEntriesSectionTitle: .init(self.selectedEntriesSectionTitle), selectAllAction: .init(self.selectAllAction), deselectAllAction: .init(self.deselectAllAction), allEntriesSectionTitle: .init(self.allEntriesSectionTitle), listPickerContent: .init(self.listPickerContent))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, cancelAction: .init(self.cancelAction), applyAction: .init(self.applyAction), selectedEntriesSectionTitle: .init(self.selectedEntriesSectionTitle), selectAllAction: .init(self.selectAllAction), deselectAllAction: .init(self.deselectAllAction), allEntriesSectionTitle: .init(self.allEntriesSectionTitle), listPickerContent: .init(self.listPickerContent))).typeErased
                 .transformEnvironment(\.listPickerDestinationStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -89,7 +98,7 @@ private extension ListPickerDestination {
     }
 
     func defaultStyle() -> some View {
-        ListPickerDestination(.init(cancelAction: .init(self.cancelAction), applyAction: .init(self.applyAction), selectedEntriesSectionTitle: .init(self.selectedEntriesSectionTitle), selectAllAction: .init(self.selectAllAction), deselectAllAction: .init(self.deselectAllAction), allEntriesSectionTitle: .init(self.allEntriesSectionTitle), listPickerContent: .init(self.listPickerContent)))
+        ListPickerDestination(.init(componentIdentifier: self.componentIdentifier, cancelAction: .init(self.cancelAction), applyAction: .init(self.applyAction), selectedEntriesSectionTitle: .init(self.selectedEntriesSectionTitle), selectAllAction: .init(self.selectAllAction), deselectAllAction: .init(self.deselectAllAction), allEntriesSectionTitle: .init(self.allEntriesSectionTitle), listPickerContent: .init(self.listPickerContent)))
             .shouldApplyDefaultStyle(false)
             .listPickerDestinationStyle(ListPickerDestinationFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/ListPickerDestination/ListPickerDestinationStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/ListPickerDestination/ListPickerDestinationStyle.generated.swift
@@ -22,6 +22,7 @@ struct AnyListPickerDestinationStyle: ListPickerDestinationStyle {
 }
 
 public struct ListPickerDestinationConfiguration {
+    public var componentIdentifier: String = "fiori_listpickerdestination_component"
     public let cancelAction: CancelAction
     public let applyAction: ApplyAction
     public let selectedEntriesSectionTitle: SelectedEntriesSectionTitle
@@ -37,6 +38,12 @@ public struct ListPickerDestinationConfiguration {
     public typealias DeselectAllAction = ConfigurationViewWrapper
     public typealias AllEntriesSectionTitle = ConfigurationViewWrapper
     public typealias ListPickerContent = ConfigurationViewWrapper
+}
+
+extension ListPickerDestinationConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct ListPickerDestinationFioriStyle: ListPickerDestinationStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/ListPickerItem/ListPickerItem.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/ListPickerItem/ListPickerItem.generated.swift
@@ -58,6 +58,8 @@ public struct ListPickerItem {
 
     @Environment(\.listPickerItemStyle) var style
 
+    var componentIdentifier: String = ListPickerItem.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder title: () -> any View,
@@ -67,17 +69,23 @@ public struct ListPickerItem {
                 controlState: ControlState = .normal,
                 errorMessage: AttributedString? = nil,
                 axis: Axis = .horizontal,
-                @ViewBuilder destination: () -> any View = { EmptyView() })
+                @ViewBuilder destination: () -> any View = { EmptyView() },
+                componentIdentifier: String? = ListPickerItem.identifier)
     {
-        self.title = Title(title: title)
-        self.value = Value(value: value)
-        self.mandatoryFieldIndicator = MandatoryFieldIndicator(mandatoryFieldIndicator: mandatoryFieldIndicator)
+        self.title = Title(title: title, componentIdentifier: componentIdentifier)
+        self.value = Value(value: value, componentIdentifier: componentIdentifier)
+        self.mandatoryFieldIndicator = MandatoryFieldIndicator(mandatoryFieldIndicator: mandatoryFieldIndicator, componentIdentifier: componentIdentifier)
         self.isRequired = isRequired
         self.controlState = controlState
         self.errorMessage = errorMessage
         self.axis = axis
         self.destination = destination()
+        self.componentIdentifier = componentIdentifier ?? ListPickerItem.identifier
     }
+}
+
+public extension ListPickerItem {
+    static let identifier = "fiori_listpickeritem_component"
 }
 
 public extension ListPickerItem {
@@ -109,6 +117,7 @@ public extension ListPickerItem {
         self.axis = configuration.axis
         self.destination = configuration.destination
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -117,7 +126,7 @@ extension ListPickerItem: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(title: .init(self.title), value: .init(self.value), mandatoryFieldIndicator: .init(self.mandatoryFieldIndicator), isRequired: self.isRequired, controlState: self.controlState, errorMessage: self.errorMessage, axis: self.axis, destination: .init(self.destination))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, title: .init(self.title), value: .init(self.value), mandatoryFieldIndicator: .init(self.mandatoryFieldIndicator), isRequired: self.isRequired, controlState: self.controlState, errorMessage: self.errorMessage, axis: self.axis, destination: .init(self.destination))).typeErased
                 .transformEnvironment(\.listPickerItemStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -135,7 +144,7 @@ private extension ListPickerItem {
     }
 
     func defaultStyle() -> some View {
-        ListPickerItem(.init(title: .init(self.title), value: .init(self.value), mandatoryFieldIndicator: .init(self.mandatoryFieldIndicator), isRequired: self.isRequired, controlState: self.controlState, errorMessage: self.errorMessage, axis: self.axis, destination: .init(self.destination)))
+        ListPickerItem(.init(componentIdentifier: self.componentIdentifier, title: .init(self.title), value: .init(self.value), mandatoryFieldIndicator: .init(self.mandatoryFieldIndicator), isRequired: self.isRequired, controlState: self.controlState, errorMessage: self.errorMessage, axis: self.axis, destination: .init(self.destination)))
             .shouldApplyDefaultStyle(false)
             .listPickerItemStyle(ListPickerItemFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/ListPickerItem/ListPickerItemStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/ListPickerItem/ListPickerItemStyle.generated.swift
@@ -22,6 +22,7 @@ struct AnyListPickerItemStyle: ListPickerItemStyle {
 }
 
 public struct ListPickerItemConfiguration {
+    public var componentIdentifier: String = "fiori_listpickeritem_component"
     public let title: Title
     public let value: Value
     public let mandatoryFieldIndicator: MandatoryFieldIndicator
@@ -35,6 +36,12 @@ public struct ListPickerItemConfiguration {
     public typealias Value = ConfigurationViewWrapper
     public typealias MandatoryFieldIndicator = ConfigurationViewWrapper
     public typealias Destination = ConfigurationViewWrapper
+}
+
+extension ListPickerItemConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct ListPickerItemFioriStyle: ListPickerItemStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/LoadingIndicator/LoadingIndicator.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/LoadingIndicator/LoadingIndicator.generated.swift
@@ -12,18 +12,26 @@ public struct LoadingIndicator {
 
     @Environment(\.loadingIndicatorStyle) var style
 
+    var componentIdentifier: String = LoadingIndicator.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder title: () -> any View,
                 @ViewBuilder progress: () -> any View,
                 duration: Double = 0,
-                isPresented: Binding<Bool>)
+                isPresented: Binding<Bool>,
+                componentIdentifier: String? = LoadingIndicator.identifier)
     {
-        self.title = Title(title: title)
-        self.progress = Progress(progress: progress)
+        self.title = Title(title: title, componentIdentifier: componentIdentifier)
+        self.progress = Progress(progress: progress, componentIdentifier: componentIdentifier)
         self.duration = duration
         self._isPresented = isPresented
+        self.componentIdentifier = componentIdentifier ?? LoadingIndicator.identifier
     }
+}
+
+public extension LoadingIndicator {
+    static let identifier = "fiori_loadingindicator_component"
 }
 
 public extension LoadingIndicator {
@@ -47,6 +55,7 @@ public extension LoadingIndicator {
         self.duration = configuration.duration
         self._isPresented = configuration.$isPresented
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -55,7 +64,7 @@ extension LoadingIndicator: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(title: .init(self.title), progress: .init(self.progress), duration: self.duration, isPresented: self.$isPresented)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, title: .init(self.title), progress: .init(self.progress), duration: self.duration, isPresented: self.$isPresented)).typeErased
                 .transformEnvironment(\.loadingIndicatorStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -73,7 +82,7 @@ private extension LoadingIndicator {
     }
 
     func defaultStyle() -> some View {
-        LoadingIndicator(.init(title: .init(self.title), progress: .init(self.progress), duration: self.duration, isPresented: self.$isPresented))
+        LoadingIndicator(.init(componentIdentifier: self.componentIdentifier, title: .init(self.title), progress: .init(self.progress), duration: self.duration, isPresented: self.$isPresented))
             .shouldApplyDefaultStyle(false)
             .loadingIndicatorStyle(LoadingIndicatorFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/LoadingIndicator/LoadingIndicatorStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/LoadingIndicator/LoadingIndicatorStyle.generated.swift
@@ -22,6 +22,7 @@ struct AnyLoadingIndicatorStyle: LoadingIndicatorStyle {
 }
 
 public struct LoadingIndicatorConfiguration {
+    public var componentIdentifier: String = "fiori_loadingindicator_component"
     public let title: Title
     public let progress: Progress
     public let duration: Double
@@ -29,6 +30,12 @@ public struct LoadingIndicatorConfiguration {
 
     public typealias Title = ConfigurationViewWrapper
     public typealias Progress = ConfigurationViewWrapper
+}
+
+extension LoadingIndicatorConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct LoadingIndicatorFioriStyle: LoadingIndicatorStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/LowerThumb/LowerThumb.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/LowerThumb/LowerThumb.generated.swift
@@ -8,11 +8,20 @@ public struct LowerThumb {
 
     @Environment(\.lowerThumbStyle) var style
 
+    var componentIdentifier: String = LowerThumb.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder lowerThumb: () -> any View) {
+    public init(@ViewBuilder lowerThumb: () -> any View,
+                componentIdentifier: String? = LowerThumb.identifier)
+    {
         self.lowerThumb = lowerThumb()
+        self.componentIdentifier = componentIdentifier ?? LowerThumb.identifier
     }
+}
+
+public extension LowerThumb {
+    static let identifier = "fiori_lowerthumb_component"
 }
 
 public extension LowerThumb {
@@ -29,6 +38,7 @@ public extension LowerThumb {
     internal init(_ configuration: LowerThumbConfiguration, shouldApplyDefaultStyle: Bool) {
         self.lowerThumb = configuration.lowerThumb
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension LowerThumb: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(lowerThumb: .init(self.lowerThumb))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, lowerThumb: .init(self.lowerThumb))).typeErased
                 .transformEnvironment(\.lowerThumbStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension LowerThumb {
     }
 
     func defaultStyle() -> some View {
-        LowerThumb(.init(lowerThumb: .init(self.lowerThumb)))
+        LowerThumb(.init(componentIdentifier: self.componentIdentifier, lowerThumb: .init(self.lowerThumb)))
             .shouldApplyDefaultStyle(false)
             .lowerThumbStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/LowerThumb/LowerThumbStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/LowerThumb/LowerThumbStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyLowerThumbStyle: LowerThumbStyle {
 }
 
 public struct LowerThumbConfiguration {
+    public var componentIdentifier: String = "fiori_lowerthumb_component"
     public let lowerThumb: LowerThumb
 
     public typealias LowerThumb = ConfigurationViewWrapper
+}
+
+extension LowerThumbConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/MandatoryFieldIndicator/MandatoryFieldIndicator.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/MandatoryFieldIndicator/MandatoryFieldIndicator.generated.swift
@@ -8,11 +8,20 @@ public struct MandatoryFieldIndicator {
 
     @Environment(\.mandatoryFieldIndicatorStyle) var style
 
+    var componentIdentifier: String = MandatoryFieldIndicator.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder mandatoryFieldIndicator: () -> any View = { Text("*") }) {
+    public init(@ViewBuilder mandatoryFieldIndicator: () -> any View = { Text("*") },
+                componentIdentifier: String? = MandatoryFieldIndicator.identifier)
+    {
         self.mandatoryFieldIndicator = mandatoryFieldIndicator()
+        self.componentIdentifier = componentIdentifier ?? MandatoryFieldIndicator.identifier
     }
+}
+
+public extension MandatoryFieldIndicator {
+    static let identifier = "fiori_mandatoryfieldindicator_component"
 }
 
 public extension MandatoryFieldIndicator {
@@ -29,6 +38,7 @@ public extension MandatoryFieldIndicator {
     internal init(_ configuration: MandatoryFieldIndicatorConfiguration, shouldApplyDefaultStyle: Bool) {
         self.mandatoryFieldIndicator = configuration.mandatoryFieldIndicator
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension MandatoryFieldIndicator: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(mandatoryFieldIndicator: .init(self.mandatoryFieldIndicator))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, mandatoryFieldIndicator: .init(self.mandatoryFieldIndicator))).typeErased
                 .transformEnvironment(\.mandatoryFieldIndicatorStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension MandatoryFieldIndicator {
     }
 
     func defaultStyle() -> some View {
-        MandatoryFieldIndicator(.init(mandatoryFieldIndicator: .init(self.mandatoryFieldIndicator)))
+        MandatoryFieldIndicator(.init(componentIdentifier: self.componentIdentifier, mandatoryFieldIndicator: .init(self.mandatoryFieldIndicator)))
             .shouldApplyDefaultStyle(false)
             .mandatoryFieldIndicatorStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/MandatoryFieldIndicator/MandatoryFieldIndicatorStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/MandatoryFieldIndicator/MandatoryFieldIndicatorStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyMandatoryFieldIndicatorStyle: MandatoryFieldIndicatorStyle {
 }
 
 public struct MandatoryFieldIndicatorConfiguration {
+    public var componentIdentifier: String = "fiori_mandatoryfieldindicator_component"
     public let mandatoryFieldIndicator: MandatoryFieldIndicator
 
     public typealias MandatoryFieldIndicator = ConfigurationViewWrapper
+}
+
+extension MandatoryFieldIndicatorConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/MediaImage/MediaImage.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/MediaImage/MediaImage.generated.swift
@@ -8,11 +8,20 @@ public struct MediaImage {
 
     @Environment(\.mediaImageStyle) var style
 
+    var componentIdentifier: String = MediaImage.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder mediaImage: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder mediaImage: () -> any View = { EmptyView() },
+                componentIdentifier: String? = MediaImage.identifier)
+    {
         self.mediaImage = mediaImage()
+        self.componentIdentifier = componentIdentifier ?? MediaImage.identifier
     }
+}
+
+public extension MediaImage {
+    static let identifier = "fiori_mediaimage_component"
 }
 
 public extension MediaImage {
@@ -29,6 +38,7 @@ public extension MediaImage {
     internal init(_ configuration: MediaImageConfiguration, shouldApplyDefaultStyle: Bool) {
         self.mediaImage = configuration.mediaImage
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension MediaImage: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(mediaImage: .init(self.mediaImage))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, mediaImage: .init(self.mediaImage))).typeErased
                 .transformEnvironment(\.mediaImageStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension MediaImage {
     }
 
     func defaultStyle() -> some View {
-        MediaImage(.init(mediaImage: .init(self.mediaImage)))
+        MediaImage(.init(componentIdentifier: self.componentIdentifier, mediaImage: .init(self.mediaImage)))
             .shouldApplyDefaultStyle(false)
             .mediaImageStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/MediaImage/MediaImageStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/MediaImage/MediaImageStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyMediaImageStyle: MediaImageStyle {
 }
 
 public struct MediaImageConfiguration {
+    public var componentIdentifier: String = "fiori_mediaimage_component"
     public let mediaImage: MediaImage
 
     public typealias MediaImage = ConfigurationViewWrapper
+}
+
+extension MediaImageConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/MenuSelection/MenuSelection.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/MenuSelection/MenuSelection.generated.swift
@@ -10,16 +10,24 @@ public struct MenuSelection {
 
     @Environment(\.menuSelectionStyle) var style
 
+    var componentIdentifier: String = MenuSelection.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder action: () -> any View = { EmptyView() },
                 isExpanded: Binding<Bool>,
-                @ViewBuilder items: () -> any View = { EmptyView() })
+                @ViewBuilder items: () -> any View = { EmptyView() },
+                componentIdentifier: String? = MenuSelection.identifier)
     {
-        self.action = Action(action: action)
+        self.action = Action(action: action, componentIdentifier: componentIdentifier)
         self._isExpanded = isExpanded
         self.items = items()
+        self.componentIdentifier = componentIdentifier ?? MenuSelection.identifier
     }
+}
+
+public extension MenuSelection {
+    static let identifier = "fiori_menuselection_component"
 }
 
 public extension MenuSelection {
@@ -41,6 +49,7 @@ public extension MenuSelection {
         self._isExpanded = configuration.$isExpanded
         self.items = configuration.items
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -49,7 +58,7 @@ extension MenuSelection: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(action: .init(self.action), isExpanded: self.$isExpanded, items: .init(self.items))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, action: .init(self.action), isExpanded: self.$isExpanded, items: .init(self.items))).typeErased
                 .transformEnvironment(\.menuSelectionStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -67,7 +76,7 @@ private extension MenuSelection {
     }
 
     func defaultStyle() -> some View {
-        MenuSelection(.init(action: .init(self.action), isExpanded: self.$isExpanded, items: .init(self.items)))
+        MenuSelection(.init(componentIdentifier: self.componentIdentifier, action: .init(self.action), isExpanded: self.$isExpanded, items: .init(self.items)))
             .shouldApplyDefaultStyle(false)
             .menuSelectionStyle(MenuSelectionFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/MenuSelection/MenuSelectionStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/MenuSelection/MenuSelectionStyle.generated.swift
@@ -22,12 +22,19 @@ struct AnyMenuSelectionStyle: MenuSelectionStyle {
 }
 
 public struct MenuSelectionConfiguration {
+    public var componentIdentifier: String = "fiori_menuselection_component"
     public let action: Action
     @Binding public var isExpanded: Bool
     public let items: Items
 
     public typealias Action = ConfigurationViewWrapper
     public typealias Items = ConfigurationViewWrapper
+}
+
+extension MenuSelectionConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct MenuSelectionFioriStyle: MenuSelectionStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/MenuSelectionItem/MenuSelectionItem.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/MenuSelectionItem/MenuSelectionItem.generated.swift
@@ -10,16 +10,24 @@ public struct MenuSelectionItem {
 
     @Environment(\.menuSelectionItemStyle) var style
 
+    var componentIdentifier: String = MenuSelectionItem.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder icon: () -> any View = { EmptyView() },
                 @ViewBuilder title: () -> any View,
-                action: (() -> Void)? = nil)
+                action: (() -> Void)? = nil,
+                componentIdentifier: String? = MenuSelectionItem.identifier)
     {
-        self.icon = Icon(icon: icon)
-        self.title = Title(title: title)
+        self.icon = Icon(icon: icon, componentIdentifier: componentIdentifier)
+        self.title = Title(title: title, componentIdentifier: componentIdentifier)
         self.action = action
+        self.componentIdentifier = componentIdentifier ?? MenuSelectionItem.identifier
     }
+}
+
+public extension MenuSelectionItem {
+    static let identifier = "fiori_menuselectionitem_component"
 }
 
 public extension MenuSelectionItem {
@@ -41,6 +49,7 @@ public extension MenuSelectionItem {
         self.title = configuration.title
         self.action = configuration.action
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -49,7 +58,7 @@ extension MenuSelectionItem: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(icon: .init(self.icon), title: .init(self.title), action: self.action)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, icon: .init(self.icon), title: .init(self.title), action: self.action)).typeErased
                 .transformEnvironment(\.menuSelectionItemStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -67,7 +76,7 @@ private extension MenuSelectionItem {
     }
 
     func defaultStyle() -> some View {
-        MenuSelectionItem(.init(icon: .init(self.icon), title: .init(self.title), action: self.action))
+        MenuSelectionItem(.init(componentIdentifier: self.componentIdentifier, icon: .init(self.icon), title: .init(self.title), action: self.action))
             .shouldApplyDefaultStyle(false)
             .menuSelectionItemStyle(MenuSelectionItemFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/MenuSelectionItem/MenuSelectionItemStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/MenuSelectionItem/MenuSelectionItemStyle.generated.swift
@@ -22,12 +22,19 @@ struct AnyMenuSelectionItemStyle: MenuSelectionItemStyle {
 }
 
 public struct MenuSelectionItemConfiguration {
+    public var componentIdentifier: String = "fiori_menuselectionitem_component"
     public let icon: Icon
     public let title: Title
     public let action: (() -> Void)?
 
     public typealias Icon = ConfigurationViewWrapper
     public typealias Title = ConfigurationViewWrapper
+}
+
+extension MenuSelectionItemConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct MenuSelectionItemFioriStyle: MenuSelectionItemStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/MessageContent/MessageContent.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/MessageContent/MessageContent.generated.swift
@@ -8,11 +8,20 @@ public struct MessageContent {
 
     @Environment(\.messageContentStyle) var style
 
+    var componentIdentifier: String = MessageContent.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder messageContent: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder messageContent: () -> any View = { EmptyView() },
+                componentIdentifier: String? = MessageContent.identifier)
+    {
         self.messageContent = messageContent()
+        self.componentIdentifier = componentIdentifier ?? MessageContent.identifier
     }
+}
+
+public extension MessageContent {
+    static let identifier = "fiori_messagecontent_component"
 }
 
 public extension MessageContent {
@@ -23,6 +32,7 @@ public extension MessageContent {
     internal init(_ configuration: MessageContentConfiguration, shouldApplyDefaultStyle: Bool) {
         self.messageContent = configuration.messageContent
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -31,7 +41,7 @@ extension MessageContent: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(messageContent: .init(self.messageContent))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, messageContent: .init(self.messageContent))).typeErased
                 .transformEnvironment(\.messageContentStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -49,7 +59,7 @@ private extension MessageContent {
     }
 
     func defaultStyle() -> some View {
-        MessageContent(.init(messageContent: .init(self.messageContent)))
+        MessageContent(.init(componentIdentifier: self.componentIdentifier, messageContent: .init(self.messageContent)))
             .shouldApplyDefaultStyle(false)
             .messageContentStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/MessageContent/MessageContentStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/MessageContent/MessageContentStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyMessageContentStyle: MessageContentStyle {
 }
 
 public struct MessageContentConfiguration {
+    public var componentIdentifier: String = "fiori_messagecontent_component"
     public let messageContent: MessageContent
 
     public typealias MessageContent = ConfigurationViewWrapper
+}
+
+extension MessageContentConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/MoreActionOverflow/MoreActionOverflow.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/MoreActionOverflow/MoreActionOverflow.generated.swift
@@ -8,11 +8,20 @@ public struct MoreActionOverflow {
 
     @Environment(\.moreActionOverflowStyle) var style
 
+    var componentIdentifier: String = MoreActionOverflow.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder moreActionOverflow: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder moreActionOverflow: () -> any View = { EmptyView() },
+                componentIdentifier: String? = MoreActionOverflow.identifier)
+    {
         self.moreActionOverflow = moreActionOverflow()
+        self.componentIdentifier = componentIdentifier ?? MoreActionOverflow.identifier
     }
+}
+
+public extension MoreActionOverflow {
+    static let identifier = "fiori_moreactionoverflow_component"
 }
 
 public extension MoreActionOverflow {
@@ -23,6 +32,7 @@ public extension MoreActionOverflow {
     internal init(_ configuration: MoreActionOverflowConfiguration, shouldApplyDefaultStyle: Bool) {
         self.moreActionOverflow = configuration.moreActionOverflow
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -31,7 +41,7 @@ extension MoreActionOverflow: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(moreActionOverflow: .init(self.moreActionOverflow))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, moreActionOverflow: .init(self.moreActionOverflow))).typeErased
                 .transformEnvironment(\.moreActionOverflowStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -49,7 +59,7 @@ private extension MoreActionOverflow {
     }
 
     func defaultStyle() -> some View {
-        MoreActionOverflow(.init(moreActionOverflow: .init(self.moreActionOverflow)))
+        MoreActionOverflow(.init(componentIdentifier: self.componentIdentifier, moreActionOverflow: .init(self.moreActionOverflow)))
             .shouldApplyDefaultStyle(false)
             .moreActionOverflowStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/MoreActionOverflow/MoreActionOverflowStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/MoreActionOverflow/MoreActionOverflowStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyMoreActionOverflowStyle: MoreActionOverflowStyle {
 }
 
 public struct MoreActionOverflowConfiguration {
+    public var componentIdentifier: String = "fiori_moreactionoverflow_component"
     public let moreActionOverflow: MoreActionOverflow
 
     public typealias MoreActionOverflow = ConfigurationViewWrapper
+}
+
+extension MoreActionOverflowConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Node/Node.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Node/Node.generated.swift
@@ -8,11 +8,20 @@ public struct Node {
 
     @Environment(\.nodeStyle) var style
 
+    var componentIdentifier: String = Node.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder node: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder node: () -> any View = { EmptyView() },
+                componentIdentifier: String? = Node.identifier)
+    {
         self.node = node()
+        self.componentIdentifier = componentIdentifier ?? Node.identifier
     }
+}
+
+public extension Node {
+    static let identifier = "fiori_node_component"
 }
 
 public extension Node {
@@ -29,6 +38,7 @@ public extension Node {
     internal init(_ configuration: NodeConfiguration, shouldApplyDefaultStyle: Bool) {
         self.node = configuration.node
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension Node: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(node: .init(self.node))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, node: .init(self.node))).typeErased
                 .transformEnvironment(\.nodeStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension Node {
     }
 
     func defaultStyle() -> some View {
-        Node(.init(node: .init(self.node)))
+        Node(.init(componentIdentifier: self.componentIdentifier, node: .init(self.node)))
             .shouldApplyDefaultStyle(false)
             .nodeStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Node/NodeStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Node/NodeStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyNodeStyle: NodeStyle {
 }
 
 public struct NodeConfiguration {
+    public var componentIdentifier: String = "fiori_node_component"
     public let node: Node
 
     public typealias Node = ConfigurationViewWrapper
+}
+
+extension NodeConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/NoteFormView/NoteFormView.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/NoteFormView/NoteFormView.generated.swift
@@ -31,6 +31,8 @@ public struct NoteFormView {
 
     @Environment(\.noteFormViewStyle) var style
 
+    var componentIdentifier: String = NoteFormView.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(text: Binding<String>,
@@ -45,10 +47,11 @@ public struct NoteFormView {
                 isCharCountEnabled: Bool = false,
                 allowsBeyondLimit: Bool = false,
                 charCountReachLimitMessage: String? = nil,
-                charCountBeyondLimitMsg: String? = nil)
+                charCountBeyondLimitMsg: String? = nil,
+                componentIdentifier: String? = NoteFormView.identifier)
     {
         self._text = text
-        self.placeholder = Placeholder(placeholder: placeholder)
+        self.placeholder = Placeholder(placeholder: placeholder, componentIdentifier: componentIdentifier)
         self.controlState = controlState
         self.errorMessage = errorMessage
         self.minTextEditorHeight = minTextEditorHeight
@@ -60,7 +63,12 @@ public struct NoteFormView {
         self.allowsBeyondLimit = allowsBeyondLimit
         self.charCountReachLimitMessage = charCountReachLimitMessage
         self.charCountBeyondLimitMsg = charCountBeyondLimitMsg
+        self.componentIdentifier = componentIdentifier ?? NoteFormView.identifier
     }
+}
+
+public extension NoteFormView {
+    static let identifier = "fiori_noteformview_component"
 }
 
 public extension NoteFormView {
@@ -102,6 +110,7 @@ public extension NoteFormView {
         self.charCountReachLimitMessage = configuration.charCountReachLimitMessage
         self.charCountBeyondLimitMsg = configuration.charCountBeyondLimitMsg
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -110,7 +119,7 @@ extension NoteFormView: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(text: self.$text, placeholder: .init(self.placeholder), controlState: self.controlState, errorMessage: self.errorMessage, minTextEditorHeight: self.minTextEditorHeight, maxTextEditorHeight: self.maxTextEditorHeight, maxTextLength: self.maxTextLength, hintText: self.hintText, hidesReadOnlyHint: self.hidesReadOnlyHint, isCharCountEnabled: self.isCharCountEnabled, allowsBeyondLimit: self.allowsBeyondLimit, charCountReachLimitMessage: self.charCountReachLimitMessage, charCountBeyondLimitMsg: self.charCountBeyondLimitMsg)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, text: self.$text, placeholder: .init(self.placeholder), controlState: self.controlState, errorMessage: self.errorMessage, minTextEditorHeight: self.minTextEditorHeight, maxTextEditorHeight: self.maxTextEditorHeight, maxTextLength: self.maxTextLength, hintText: self.hintText, hidesReadOnlyHint: self.hidesReadOnlyHint, isCharCountEnabled: self.isCharCountEnabled, allowsBeyondLimit: self.allowsBeyondLimit, charCountReachLimitMessage: self.charCountReachLimitMessage, charCountBeyondLimitMsg: self.charCountBeyondLimitMsg)).typeErased
                 .transformEnvironment(\.noteFormViewStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -128,7 +137,7 @@ private extension NoteFormView {
     }
 
     func defaultStyle() -> some View {
-        NoteFormView(.init(text: self.$text, placeholder: .init(self.placeholder), controlState: self.controlState, errorMessage: self.errorMessage, minTextEditorHeight: self.minTextEditorHeight, maxTextEditorHeight: self.maxTextEditorHeight, maxTextLength: self.maxTextLength, hintText: self.hintText, hidesReadOnlyHint: self.hidesReadOnlyHint, isCharCountEnabled: self.isCharCountEnabled, allowsBeyondLimit: self.allowsBeyondLimit, charCountReachLimitMessage: self.charCountReachLimitMessage, charCountBeyondLimitMsg: self.charCountBeyondLimitMsg))
+        NoteFormView(.init(componentIdentifier: self.componentIdentifier, text: self.$text, placeholder: .init(self.placeholder), controlState: self.controlState, errorMessage: self.errorMessage, minTextEditorHeight: self.minTextEditorHeight, maxTextEditorHeight: self.maxTextEditorHeight, maxTextLength: self.maxTextLength, hintText: self.hintText, hidesReadOnlyHint: self.hidesReadOnlyHint, isCharCountEnabled: self.isCharCountEnabled, allowsBeyondLimit: self.allowsBeyondLimit, charCountReachLimitMessage: self.charCountReachLimitMessage, charCountBeyondLimitMsg: self.charCountBeyondLimitMsg))
             .shouldApplyDefaultStyle(false)
             .noteFormViewStyle(NoteFormViewFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/NoteFormView/NoteFormViewStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/NoteFormView/NoteFormViewStyle.generated.swift
@@ -22,6 +22,7 @@ struct AnyNoteFormViewStyle: NoteFormViewStyle {
 }
 
 public struct NoteFormViewConfiguration {
+    public var componentIdentifier: String = "fiori_noteformview_component"
     @Binding public var text: String
     public let placeholder: Placeholder
     public let controlState: ControlState
@@ -37,6 +38,12 @@ public struct NoteFormViewConfiguration {
     public let charCountBeyondLimitMsg: String?
 
     public typealias Placeholder = ConfigurationViewWrapper
+}
+
+extension NoteFormViewConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct NoteFormViewFioriStyle: NoteFormViewStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/NowIndicatorNode/NowIndicatorNode.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/NowIndicatorNode/NowIndicatorNode.generated.swift
@@ -8,11 +8,20 @@ public struct NowIndicatorNode {
 
     @Environment(\.nowIndicatorNodeStyle) var style
 
+    var componentIdentifier: String = NowIndicatorNode.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder nowIndicatorNode: () -> any View = { Image(systemName: "circle.fill") }) {
+    public init(@ViewBuilder nowIndicatorNode: () -> any View = { Image(systemName: "circle.fill") },
+                componentIdentifier: String? = NowIndicatorNode.identifier)
+    {
         self.nowIndicatorNode = nowIndicatorNode()
+        self.componentIdentifier = componentIdentifier ?? NowIndicatorNode.identifier
     }
+}
+
+public extension NowIndicatorNode {
+    static let identifier = "fiori_nowindicatornode_component"
 }
 
 public extension NowIndicatorNode {
@@ -23,6 +32,7 @@ public extension NowIndicatorNode {
     internal init(_ configuration: NowIndicatorNodeConfiguration, shouldApplyDefaultStyle: Bool) {
         self.nowIndicatorNode = configuration.nowIndicatorNode
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -31,7 +41,7 @@ extension NowIndicatorNode: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(nowIndicatorNode: .init(self.nowIndicatorNode))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, nowIndicatorNode: .init(self.nowIndicatorNode))).typeErased
                 .transformEnvironment(\.nowIndicatorNodeStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -49,7 +59,7 @@ private extension NowIndicatorNode {
     }
 
     func defaultStyle() -> some View {
-        NowIndicatorNode(.init(nowIndicatorNode: .init(self.nowIndicatorNode)))
+        NowIndicatorNode(.init(componentIdentifier: self.componentIdentifier, nowIndicatorNode: .init(self.nowIndicatorNode)))
             .shouldApplyDefaultStyle(false)
             .nowIndicatorNodeStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/NowIndicatorNode/NowIndicatorNodeStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/NowIndicatorNode/NowIndicatorNodeStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyNowIndicatorNodeStyle: NowIndicatorNodeStyle {
 }
 
 public struct NowIndicatorNodeConfiguration {
+    public var componentIdentifier: String = "fiori_nowindicatornode_component"
     public let nowIndicatorNode: NowIndicatorNode
 
     public typealias NowIndicatorNode = ConfigurationViewWrapper
+}
+
+extension NowIndicatorNodeConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/ObjectHeader/ObjectHeader.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/ObjectHeader/ObjectHeader.generated.swift
@@ -42,6 +42,8 @@ public struct ObjectHeader {
 
     @Environment(\.objectHeaderStyle) var style
 
+    var componentIdentifier: String = ObjectHeader.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder title: () -> any View,
@@ -53,19 +55,25 @@ public struct ObjectHeader {
                 @ViewBuilder status: () -> any View = { EmptyView() },
                 @ViewBuilder substatus: () -> any View = { EmptyView() },
                 @ViewBuilder detailImage: () -> any View = { EmptyView() },
-                @ViewBuilder detailContent: () -> any View = { EmptyView() })
+                @ViewBuilder detailContent: () -> any View = { EmptyView() },
+                componentIdentifier: String? = ObjectHeader.identifier)
     {
-        self.title = Title(title: title)
-        self.subtitle = Subtitle(subtitle: subtitle)
-        self.tags = Tags(tags: tags)
-        self.bodyText = BodyText(bodyText: bodyText)
-        self.footnote = Footnote(footnote: footnote)
-        self.descriptionText = DescriptionText(descriptionText: descriptionText)
-        self.status = Status(status: status)
-        self.substatus = Substatus(substatus: substatus)
-        self.detailImage = DetailImage(detailImage: detailImage)
-        self.detailContent = DetailContent(detailContent: detailContent)
+        self.title = Title(title: title, componentIdentifier: componentIdentifier)
+        self.subtitle = Subtitle(subtitle: subtitle, componentIdentifier: componentIdentifier)
+        self.tags = Tags(tags: tags, componentIdentifier: componentIdentifier)
+        self.bodyText = BodyText(bodyText: bodyText, componentIdentifier: componentIdentifier)
+        self.footnote = Footnote(footnote: footnote, componentIdentifier: componentIdentifier)
+        self.descriptionText = DescriptionText(descriptionText: descriptionText, componentIdentifier: componentIdentifier)
+        self.status = Status(status: status, componentIdentifier: componentIdentifier)
+        self.substatus = Substatus(substatus: substatus, componentIdentifier: componentIdentifier)
+        self.detailImage = DetailImage(detailImage: detailImage, componentIdentifier: componentIdentifier)
+        self.detailContent = DetailContent(detailContent: detailContent, componentIdentifier: componentIdentifier)
+        self.componentIdentifier = componentIdentifier ?? ObjectHeader.identifier
     }
+}
+
+public extension ObjectHeader {
+    static let identifier = "fiori_objectheader_component"
 }
 
 public extension ObjectHeader {
@@ -101,6 +109,7 @@ public extension ObjectHeader {
         self.detailImage = configuration.detailImage
         self.detailContent = configuration.detailContent
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -109,7 +118,7 @@ extension ObjectHeader: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(title: .init(self.title), subtitle: .init(self.subtitle), tags: .init(self.tags), bodyText: .init(self.bodyText), footnote: .init(self.footnote), descriptionText: .init(self.descriptionText), status: .init(self.status), substatus: .init(self.substatus), detailImage: .init(self.detailImage), detailContent: .init(self.detailContent))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, title: .init(self.title), subtitle: .init(self.subtitle), tags: .init(self.tags), bodyText: .init(self.bodyText), footnote: .init(self.footnote), descriptionText: .init(self.descriptionText), status: .init(self.status), substatus: .init(self.substatus), detailImage: .init(self.detailImage), detailContent: .init(self.detailContent))).typeErased
                 .transformEnvironment(\.objectHeaderStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -127,7 +136,7 @@ private extension ObjectHeader {
     }
 
     func defaultStyle() -> some View {
-        ObjectHeader(.init(title: .init(self.title), subtitle: .init(self.subtitle), tags: .init(self.tags), bodyText: .init(self.bodyText), footnote: .init(self.footnote), descriptionText: .init(self.descriptionText), status: .init(self.status), substatus: .init(self.substatus), detailImage: .init(self.detailImage), detailContent: .init(self.detailContent)))
+        ObjectHeader(.init(componentIdentifier: self.componentIdentifier, title: .init(self.title), subtitle: .init(self.subtitle), tags: .init(self.tags), bodyText: .init(self.bodyText), footnote: .init(self.footnote), descriptionText: .init(self.descriptionText), status: .init(self.status), substatus: .init(self.substatus), detailImage: .init(self.detailImage), detailContent: .init(self.detailContent)))
             .shouldApplyDefaultStyle(false)
             .objectHeaderStyle(ObjectHeaderFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/ObjectHeader/ObjectHeaderStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/ObjectHeader/ObjectHeaderStyle.generated.swift
@@ -22,6 +22,7 @@ struct AnyObjectHeaderStyle: ObjectHeaderStyle {
 }
 
 public struct ObjectHeaderConfiguration {
+    public var componentIdentifier: String = "fiori_objectheader_component"
     public let title: Title
     public let subtitle: Subtitle
     public let tags: Tags
@@ -43,6 +44,12 @@ public struct ObjectHeaderConfiguration {
     public typealias Substatus = ConfigurationViewWrapper
     public typealias DetailImage = ConfigurationViewWrapper
     public typealias DetailContent = ConfigurationViewWrapper
+}
+
+extension ObjectHeaderConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct ObjectHeaderFioriStyle: ObjectHeaderStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/ObjectItem/ObjectItem.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/ObjectItem/ObjectItem.generated.swift
@@ -23,6 +23,8 @@ public struct ObjectItem {
 
     @Environment(\.objectItemStyle) var style
 
+    var componentIdentifier: String = ObjectItem.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder title: () -> any View,
@@ -38,23 +40,29 @@ public struct ObjectItem {
                 @ViewBuilder footnoteIconsText: () -> any View = { EmptyView() },
                 @TagBuilder tags: () -> any View = { EmptyView() },
                 @ViewBuilder action: () -> any View = { EmptyView() },
-                @ViewBuilder objectItemButton: () -> any View = { EmptyView() })
+                @ViewBuilder objectItemButton: () -> any View = { EmptyView() },
+                componentIdentifier: String? = ObjectItem.identifier)
     {
-        self.title = Title(title: title)
-        self.subtitle = Subtitle(subtitle: subtitle)
-        self.footnote = Footnote(footnote: footnote)
-        self.description = Description(description: description)
-        self.status = Status(status: status)
-        self.substatus = Substatus(substatus: substatus)
-        self.detailImage = DetailImage(detailImage: detailImage)
-        self.icons = Icons(icons: icons)
-        self.avatars = Avatars(avatars: avatars)
-        self.footnoteIcons = FootnoteIcons(footnoteIcons: footnoteIcons)
-        self.footnoteIconsText = FootnoteIconsText(footnoteIconsText: footnoteIconsText)
-        self.tags = Tags(tags: tags)
-        self.action = Action(action: action)
+        self.title = Title(title: title, componentIdentifier: componentIdentifier)
+        self.subtitle = Subtitle(subtitle: subtitle, componentIdentifier: componentIdentifier)
+        self.footnote = Footnote(footnote: footnote, componentIdentifier: componentIdentifier)
+        self.description = Description(description: description, componentIdentifier: componentIdentifier)
+        self.status = Status(status: status, componentIdentifier: componentIdentifier)
+        self.substatus = Substatus(substatus: substatus, componentIdentifier: componentIdentifier)
+        self.detailImage = DetailImage(detailImage: detailImage, componentIdentifier: componentIdentifier)
+        self.icons = Icons(icons: icons, componentIdentifier: componentIdentifier)
+        self.avatars = Avatars(avatars: avatars, componentIdentifier: componentIdentifier)
+        self.footnoteIcons = FootnoteIcons(footnoteIcons: footnoteIcons, componentIdentifier: componentIdentifier)
+        self.footnoteIconsText = FootnoteIconsText(footnoteIconsText: footnoteIconsText, componentIdentifier: componentIdentifier)
+        self.tags = Tags(tags: tags, componentIdentifier: componentIdentifier)
+        self.action = Action(action: action, componentIdentifier: componentIdentifier)
         self.objectItemButton = objectItemButton()
+        self.componentIdentifier = componentIdentifier ?? ObjectItem.identifier
     }
+}
+
+public extension ObjectItem {
+    static let identifier = "fiori_objectitem_component"
 }
 
 public extension ObjectItem {
@@ -98,6 +106,7 @@ public extension ObjectItem {
         self.action = configuration.action
         self.objectItemButton = configuration.objectItemButton
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -106,7 +115,7 @@ extension ObjectItem: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(title: .init(self.title), subtitle: .init(self.subtitle), footnote: .init(self.footnote), description: .init(self.description), status: .init(self.status), substatus: .init(self.substatus), detailImage: .init(self.detailImage), icons: .init(self.icons), avatars: .init(self.avatars), footnoteIcons: .init(self.footnoteIcons), footnoteIconsText: .init(self.footnoteIconsText), tags: .init(self.tags), action: .init(self.action), objectItemButton: .init(self.objectItemButton))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, title: .init(self.title), subtitle: .init(self.subtitle), footnote: .init(self.footnote), description: .init(self.description), status: .init(self.status), substatus: .init(self.substatus), detailImage: .init(self.detailImage), icons: .init(self.icons), avatars: .init(self.avatars), footnoteIcons: .init(self.footnoteIcons), footnoteIconsText: .init(self.footnoteIconsText), tags: .init(self.tags), action: .init(self.action), objectItemButton: .init(self.objectItemButton))).typeErased
                 .transformEnvironment(\.objectItemStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -124,7 +133,7 @@ private extension ObjectItem {
     }
 
     func defaultStyle() -> some View {
-        ObjectItem(.init(title: .init(self.title), subtitle: .init(self.subtitle), footnote: .init(self.footnote), description: .init(self.description), status: .init(self.status), substatus: .init(self.substatus), detailImage: .init(self.detailImage), icons: .init(self.icons), avatars: .init(self.avatars), footnoteIcons: .init(self.footnoteIcons), footnoteIconsText: .init(self.footnoteIconsText), tags: .init(self.tags), action: .init(self.action), objectItemButton: .init(self.objectItemButton)))
+        ObjectItem(.init(componentIdentifier: self.componentIdentifier, title: .init(self.title), subtitle: .init(self.subtitle), footnote: .init(self.footnote), description: .init(self.description), status: .init(self.status), substatus: .init(self.substatus), detailImage: .init(self.detailImage), icons: .init(self.icons), avatars: .init(self.avatars), footnoteIcons: .init(self.footnoteIcons), footnoteIconsText: .init(self.footnoteIconsText), tags: .init(self.tags), action: .init(self.action), objectItemButton: .init(self.objectItemButton)))
             .shouldApplyDefaultStyle(false)
             .objectItemStyle(ObjectItemFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/ObjectItem/ObjectItemStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/ObjectItem/ObjectItemStyle.generated.swift
@@ -22,6 +22,7 @@ struct AnyObjectItemStyle: ObjectItemStyle {
 }
 
 public struct ObjectItemConfiguration {
+    public var componentIdentifier: String = "fiori_objectitem_component"
     public let title: Title
     public let subtitle: Subtitle
     public let footnote: Footnote
@@ -51,6 +52,12 @@ public struct ObjectItemConfiguration {
     public typealias Tags = ConfigurationViewWrapper
     public typealias Action = ConfigurationViewWrapper
     public typealias ObjectItemButton = ConfigurationViewWrapper
+}
+
+extension ObjectItemConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct ObjectItemFioriStyle: ObjectItemStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/OffStarImage/OffStarImage.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/OffStarImage/OffStarImage.generated.swift
@@ -11,11 +11,20 @@ public struct OffStarImage {
 
     @Environment(\.offStarImageStyle) var style
 
+    var componentIdentifier: String = OffStarImage.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder offStarImage: () -> any View) {
+    public init(@ViewBuilder offStarImage: () -> any View,
+                componentIdentifier: String? = OffStarImage.identifier)
+    {
         self.offStarImage = offStarImage()
+        self.componentIdentifier = componentIdentifier ?? OffStarImage.identifier
     }
+}
+
+public extension OffStarImage {
+    static let identifier = "fiori_offstarimage_component"
 }
 
 public extension OffStarImage {
@@ -32,6 +41,7 @@ public extension OffStarImage {
     internal init(_ configuration: OffStarImageConfiguration, shouldApplyDefaultStyle: Bool) {
         self.offStarImage = configuration.offStarImage
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -40,7 +50,7 @@ extension OffStarImage: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(offStarImage: .init(self.offStarImage))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, offStarImage: .init(self.offStarImage))).typeErased
                 .transformEnvironment(\.offStarImageStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -58,7 +68,7 @@ private extension OffStarImage {
     }
 
     func defaultStyle() -> some View {
-        OffStarImage(.init(offStarImage: .init(self.offStarImage)))
+        OffStarImage(.init(componentIdentifier: self.componentIdentifier, offStarImage: .init(self.offStarImage)))
             .shouldApplyDefaultStyle(false)
             .offStarImageStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/OffStarImage/OffStarImageStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/OffStarImage/OffStarImageStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyOffStarImageStyle: OffStarImageStyle {
 }
 
 public struct OffStarImageConfiguration {
+    public var componentIdentifier: String = "fiori_offstarimage_component"
     public let offStarImage: OffStarImage
 
     public typealias OffStarImage = ConfigurationViewWrapper
+}
+
+extension OffStarImageConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/OnStarImage/OnStarImage.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/OnStarImage/OnStarImage.generated.swift
@@ -11,11 +11,20 @@ public struct OnStarImage {
 
     @Environment(\.onStarImageStyle) var style
 
+    var componentIdentifier: String = OnStarImage.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder onStarImage: () -> any View) {
+    public init(@ViewBuilder onStarImage: () -> any View,
+                componentIdentifier: String? = OnStarImage.identifier)
+    {
         self.onStarImage = onStarImage()
+        self.componentIdentifier = componentIdentifier ?? OnStarImage.identifier
     }
+}
+
+public extension OnStarImage {
+    static let identifier = "fiori_onstarimage_component"
 }
 
 public extension OnStarImage {
@@ -32,6 +41,7 @@ public extension OnStarImage {
     internal init(_ configuration: OnStarImageConfiguration, shouldApplyDefaultStyle: Bool) {
         self.onStarImage = configuration.onStarImage
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -40,7 +50,7 @@ extension OnStarImage: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(onStarImage: .init(self.onStarImage))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, onStarImage: .init(self.onStarImage))).typeErased
                 .transformEnvironment(\.onStarImageStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -58,7 +68,7 @@ private extension OnStarImage {
     }
 
     func defaultStyle() -> some View {
-        OnStarImage(.init(onStarImage: .init(self.onStarImage)))
+        OnStarImage(.init(componentIdentifier: self.componentIdentifier, onStarImage: .init(self.onStarImage)))
             .shouldApplyDefaultStyle(false)
             .onStarImageStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/OnStarImage/OnStarImageStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/OnStarImage/OnStarImageStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyOnStarImageStyle: OnStarImageStyle {
 }
 
 public struct OnStarImageConfiguration {
+    public var componentIdentifier: String = "fiori_onstarimage_component"
     public let onStarImage: OnStarImage
 
     public typealias OnStarImage = ConfigurationViewWrapper
+}
+
+extension OnStarImageConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/OptionalTitle/OptionalTitle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/OptionalTitle/OptionalTitle.generated.swift
@@ -8,11 +8,20 @@ public struct OptionalTitle {
 
     @Environment(\.optionalTitleStyle) var style
 
+    var componentIdentifier: String = OptionalTitle.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder optionalTitle: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder optionalTitle: () -> any View = { EmptyView() },
+                componentIdentifier: String? = OptionalTitle.identifier)
+    {
         self.optionalTitle = optionalTitle()
+        self.componentIdentifier = componentIdentifier ?? OptionalTitle.identifier
     }
+}
+
+public extension OptionalTitle {
+    static let identifier = "fiori_optionaltitle_component"
 }
 
 public extension OptionalTitle {
@@ -29,6 +38,7 @@ public extension OptionalTitle {
     internal init(_ configuration: OptionalTitleConfiguration, shouldApplyDefaultStyle: Bool) {
         self.optionalTitle = configuration.optionalTitle
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension OptionalTitle: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(optionalTitle: .init(self.optionalTitle))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, optionalTitle: .init(self.optionalTitle))).typeErased
                 .transformEnvironment(\.optionalTitleStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension OptionalTitle {
     }
 
     func defaultStyle() -> some View {
-        OptionalTitle(.init(optionalTitle: .init(self.optionalTitle)))
+        OptionalTitle(.init(componentIdentifier: self.componentIdentifier, optionalTitle: .init(self.optionalTitle)))
             .shouldApplyDefaultStyle(false)
             .optionalTitleStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/OptionalTitle/OptionalTitleStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/OptionalTitle/OptionalTitleStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyOptionalTitleStyle: OptionalTitleStyle {
 }
 
 public struct OptionalTitleConfiguration {
+    public var componentIdentifier: String = "fiori_optionaltitle_component"
     public let optionalTitle: OptionalTitle
 
     public typealias OptionalTitle = ConfigurationViewWrapper
+}
+
+extension OptionalTitleConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Options/Options.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Options/Options.generated.swift
@@ -8,11 +8,20 @@ public struct Options {
 
     @Environment(\.optionsStyle) var style
 
+    var componentIdentifier: String = Options.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(options: [AttributedString] = []) {
+    public init(options: [AttributedString] = [],
+                componentIdentifier: String? = Options.identifier)
+    {
         self.options = options
+        self.componentIdentifier = componentIdentifier ?? Options.identifier
     }
+}
+
+public extension Options {
+    static let identifier = "fiori_options_component"
 }
 
 public extension Options {
@@ -23,6 +32,7 @@ public extension Options {
     internal init(_ configuration: OptionsConfiguration, shouldApplyDefaultStyle: Bool) {
         self.options = configuration.options
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -31,7 +41,7 @@ extension Options: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(options: self.options)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, options: self.options)).typeErased
                 .transformEnvironment(\.optionsStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -49,7 +59,7 @@ private extension Options {
     }
 
     func defaultStyle() -> some View {
-        Options(.init(options: self.options))
+        Options(.init(componentIdentifier: self.componentIdentifier, options: self.options))
             .shouldApplyDefaultStyle(false)
             .optionsStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Options/OptionsStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Options/OptionsStyle.generated.swift
@@ -22,5 +22,12 @@ struct AnyOptionsStyle: OptionsStyle {
 }
 
 public struct OptionsConfiguration {
+    public var componentIdentifier: String = "fiori_options_component"
     public let options: [AttributedString]
+}
+
+extension OptionsConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/OuterCircle/OuterCircle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/OuterCircle/OuterCircle.generated.swift
@@ -8,11 +8,20 @@ public struct OuterCircle {
 
     @Environment(\.outerCircleStyle) var style
 
+    var componentIdentifier: String = OuterCircle.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder outerCircle: () -> any View) {
+    public init(@ViewBuilder outerCircle: () -> any View,
+                componentIdentifier: String? = OuterCircle.identifier)
+    {
         self.outerCircle = outerCircle()
+        self.componentIdentifier = componentIdentifier ?? OuterCircle.identifier
     }
+}
+
+public extension OuterCircle {
+    static let identifier = "fiori_outercircle_component"
 }
 
 public extension OuterCircle {
@@ -29,6 +38,7 @@ public extension OuterCircle {
     internal init(_ configuration: OuterCircleConfiguration, shouldApplyDefaultStyle: Bool) {
         self.outerCircle = configuration.outerCircle
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension OuterCircle: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(outerCircle: .init(self.outerCircle))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, outerCircle: .init(self.outerCircle))).typeErased
                 .transformEnvironment(\.outerCircleStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension OuterCircle {
     }
 
     func defaultStyle() -> some View {
-        OuterCircle(.init(outerCircle: .init(self.outerCircle)))
+        OuterCircle(.init(componentIdentifier: self.componentIdentifier, outerCircle: .init(self.outerCircle)))
             .shouldApplyDefaultStyle(false)
             .outerCircleStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/OuterCircle/OuterCircleStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/OuterCircle/OuterCircleStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyOuterCircleStyle: OuterCircleStyle {
 }
 
 public struct OuterCircleConfiguration {
+    public var componentIdentifier: String = "fiori_outercircle_component"
     public let outerCircle: OuterCircle
 
     public typealias OuterCircle = ConfigurationViewWrapper
+}
+
+extension OuterCircleConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/OverflowAction/OverflowAction.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/OverflowAction/OverflowAction.generated.swift
@@ -8,11 +8,20 @@ public struct OverflowAction {
 
     @Environment(\.overflowActionStyle) var style
 
+    var componentIdentifier: String = OverflowAction.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder overflowAction: () -> any View = { FioriButton { _ in Image(systemName: "ellipsis") } }) {
+    public init(@ViewBuilder overflowAction: () -> any View = { FioriButton { _ in Image(systemName: "ellipsis") } },
+                componentIdentifier: String? = OverflowAction.identifier)
+    {
         self.overflowAction = overflowAction()
+        self.componentIdentifier = componentIdentifier ?? OverflowAction.identifier
     }
+}
+
+public extension OverflowAction {
+    static let identifier = "fiori_overflowaction_component"
 }
 
 public extension OverflowAction {
@@ -29,6 +38,7 @@ public extension OverflowAction {
     internal init(_ configuration: OverflowActionConfiguration, shouldApplyDefaultStyle: Bool) {
         self.overflowAction = configuration.overflowAction
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension OverflowAction: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(overflowAction: .init(self.overflowAction))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, overflowAction: .init(self.overflowAction))).typeErased
                 .transformEnvironment(\.overflowActionStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension OverflowAction {
     }
 
     func defaultStyle() -> some View {
-        OverflowAction(.init(overflowAction: .init(self.overflowAction)))
+        OverflowAction(.init(componentIdentifier: self.componentIdentifier, overflowAction: .init(self.overflowAction)))
             .shouldApplyDefaultStyle(false)
             .overflowActionStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/OverflowAction/OverflowActionStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/OverflowAction/OverflowActionStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyOverflowActionStyle: OverflowActionStyle {
 }
 
 public struct OverflowActionConfiguration {
+    public var componentIdentifier: String = "fiori_overflowaction_component"
     public let overflowAction: OverflowAction
 
     public typealias OverflowAction = ConfigurationViewWrapper
+}
+
+extension OverflowActionConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Placeholder/Placeholder.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Placeholder/Placeholder.generated.swift
@@ -8,11 +8,20 @@ public struct Placeholder {
 
     @Environment(\.placeholderStyle) var style
 
+    var componentIdentifier: String = Placeholder.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder placeholder: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder placeholder: () -> any View = { EmptyView() },
+                componentIdentifier: String? = Placeholder.identifier)
+    {
         self.placeholder = placeholder()
+        self.componentIdentifier = componentIdentifier ?? Placeholder.identifier
     }
+}
+
+public extension Placeholder {
+    static let identifier = "fiori_placeholder_component"
 }
 
 public extension Placeholder {
@@ -29,6 +38,7 @@ public extension Placeholder {
     internal init(_ configuration: PlaceholderConfiguration, shouldApplyDefaultStyle: Bool) {
         self.placeholder = configuration.placeholder
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension Placeholder: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(placeholder: .init(self.placeholder))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, placeholder: .init(self.placeholder))).typeErased
                 .transformEnvironment(\.placeholderStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension Placeholder {
     }
 
     func defaultStyle() -> some View {
-        Placeholder(.init(placeholder: .init(self.placeholder)))
+        Placeholder(.init(componentIdentifier: self.componentIdentifier, placeholder: .init(self.placeholder)))
             .shouldApplyDefaultStyle(false)
             .placeholderStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Placeholder/PlaceholderStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Placeholder/PlaceholderStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyPlaceholderStyle: PlaceholderStyle {
 }
 
 public struct PlaceholderConfiguration {
+    public var componentIdentifier: String = "fiori_placeholder_component"
     public let placeholder: Placeholder
 
     public typealias Placeholder = ConfigurationViewWrapper
+}
+
+extension PlaceholderConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/PlaceholderTextEditor/PlaceholderTextEditor.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/PlaceholderTextEditor/PlaceholderTextEditor.generated.swift
@@ -9,14 +9,22 @@ public struct PlaceholderTextEditor {
 
     @Environment(\.placeholderTextEditorStyle) var style
 
+    var componentIdentifier: String = PlaceholderTextEditor.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(text: Binding<String>,
-                @ViewBuilder placeholder: () -> any View = { EmptyView() })
+                @ViewBuilder placeholder: () -> any View = { EmptyView() },
+                componentIdentifier: String? = PlaceholderTextEditor.identifier)
     {
         self._text = text
-        self.placeholder = Placeholder(placeholder: placeholder)
+        self.placeholder = Placeholder(placeholder: placeholder, componentIdentifier: componentIdentifier)
+        self.componentIdentifier = componentIdentifier ?? PlaceholderTextEditor.identifier
     }
+}
+
+public extension PlaceholderTextEditor {
+    static let identifier = "fiori_placeholdertexteditor_component"
 }
 
 public extension PlaceholderTextEditor {
@@ -36,6 +44,7 @@ public extension PlaceholderTextEditor {
         self._text = configuration.$text
         self.placeholder = configuration.placeholder
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -44,7 +53,7 @@ extension PlaceholderTextEditor: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(text: self.$text, placeholder: .init(self.placeholder))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, text: self.$text, placeholder: .init(self.placeholder))).typeErased
                 .transformEnvironment(\.placeholderTextEditorStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -62,7 +71,7 @@ private extension PlaceholderTextEditor {
     }
 
     func defaultStyle() -> some View {
-        PlaceholderTextEditor(.init(text: self.$text, placeholder: .init(self.placeholder)))
+        PlaceholderTextEditor(.init(componentIdentifier: self.componentIdentifier, text: self.$text, placeholder: .init(self.placeholder)))
             .shouldApplyDefaultStyle(false)
             .placeholderTextEditorStyle(PlaceholderTextEditorFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/PlaceholderTextEditor/PlaceholderTextEditorStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/PlaceholderTextEditor/PlaceholderTextEditorStyle.generated.swift
@@ -22,10 +22,17 @@ struct AnyPlaceholderTextEditorStyle: PlaceholderTextEditorStyle {
 }
 
 public struct PlaceholderTextEditorConfiguration {
+    public var componentIdentifier: String = "fiori_placeholdertexteditor_component"
     @Binding public var text: String
     public let placeholder: Placeholder
 
     public typealias Placeholder = ConfigurationViewWrapper
+}
+
+extension PlaceholderTextEditorConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct PlaceholderTextEditorFioriStyle: PlaceholderTextEditorStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/PlaceholderTextField/PlaceholderTextField.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/PlaceholderTextField/PlaceholderTextField.generated.swift
@@ -9,14 +9,22 @@ public struct PlaceholderTextField {
 
     @Environment(\.placeholderTextFieldStyle) var style
 
+    var componentIdentifier: String = PlaceholderTextField.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(text: Binding<String>,
-                @ViewBuilder placeholder: () -> any View = { EmptyView() })
+                @ViewBuilder placeholder: () -> any View = { EmptyView() },
+                componentIdentifier: String? = PlaceholderTextField.identifier)
     {
         self._text = text
-        self.placeholder = Placeholder(placeholder: placeholder)
+        self.placeholder = Placeholder(placeholder: placeholder, componentIdentifier: componentIdentifier)
+        self.componentIdentifier = componentIdentifier ?? PlaceholderTextField.identifier
     }
+}
+
+public extension PlaceholderTextField {
+    static let identifier = "fiori_placeholdertextfield_component"
 }
 
 public extension PlaceholderTextField {
@@ -36,6 +44,7 @@ public extension PlaceholderTextField {
         self._text = configuration.$text
         self.placeholder = configuration.placeholder
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -44,7 +53,7 @@ extension PlaceholderTextField: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(text: self.$text, placeholder: .init(self.placeholder))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, text: self.$text, placeholder: .init(self.placeholder))).typeErased
                 .transformEnvironment(\.placeholderTextFieldStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -62,7 +71,7 @@ private extension PlaceholderTextField {
     }
 
     func defaultStyle() -> some View {
-        PlaceholderTextField(.init(text: self.$text, placeholder: .init(self.placeholder)))
+        PlaceholderTextField(.init(componentIdentifier: self.componentIdentifier, text: self.$text, placeholder: .init(self.placeholder)))
             .shouldApplyDefaultStyle(false)
             .placeholderTextFieldStyle(PlaceholderTextFieldFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/PlaceholderTextField/PlaceholderTextFieldStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/PlaceholderTextField/PlaceholderTextFieldStyle.generated.swift
@@ -22,10 +22,17 @@ struct AnyPlaceholderTextFieldStyle: PlaceholderTextFieldStyle {
 }
 
 public struct PlaceholderTextFieldConfiguration {
+    public var componentIdentifier: String = "fiori_placeholdertextfield_component"
     @Binding public var text: String
     public let placeholder: Placeholder
 
     public typealias Placeholder = ConfigurationViewWrapper
+}
+
+extension PlaceholderTextFieldConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct PlaceholderTextFieldFioriStyle: PlaceholderTextFieldStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/ProcessingIndicator/ProcessingIndicator.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/ProcessingIndicator/ProcessingIndicator.generated.swift
@@ -14,11 +14,20 @@ public struct ProcessingIndicator {
 
     @Environment(\.processingIndicatorStyle) var style
 
+    var componentIdentifier: String = ProcessingIndicator.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder optionalTitle: () -> any View = { EmptyView() }) {
-        self.optionalTitle = OptionalTitle(optionalTitle: optionalTitle)
+    public init(@ViewBuilder optionalTitle: () -> any View = { EmptyView() },
+                componentIdentifier: String? = ProcessingIndicator.identifier)
+    {
+        self.optionalTitle = OptionalTitle(optionalTitle: optionalTitle, componentIdentifier: componentIdentifier)
+        self.componentIdentifier = componentIdentifier ?? ProcessingIndicator.identifier
     }
+}
+
+public extension ProcessingIndicator {
+    static let identifier = "fiori_processingindicator_component"
 }
 
 public extension ProcessingIndicator {
@@ -35,6 +44,7 @@ public extension ProcessingIndicator {
     internal init(_ configuration: ProcessingIndicatorConfiguration, shouldApplyDefaultStyle: Bool) {
         self.optionalTitle = configuration.optionalTitle
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -43,7 +53,7 @@ extension ProcessingIndicator: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(optionalTitle: .init(self.optionalTitle))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, optionalTitle: .init(self.optionalTitle))).typeErased
                 .transformEnvironment(\.processingIndicatorStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -61,7 +71,7 @@ private extension ProcessingIndicator {
     }
 
     func defaultStyle() -> some View {
-        ProcessingIndicator(.init(optionalTitle: .init(self.optionalTitle)))
+        ProcessingIndicator(.init(componentIdentifier: self.componentIdentifier, optionalTitle: .init(self.optionalTitle)))
             .shouldApplyDefaultStyle(false)
             .processingIndicatorStyle(ProcessingIndicatorFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/ProcessingIndicator/ProcessingIndicatorStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/ProcessingIndicator/ProcessingIndicatorStyle.generated.swift
@@ -22,9 +22,16 @@ struct AnyProcessingIndicatorStyle: ProcessingIndicatorStyle {
 }
 
 public struct ProcessingIndicatorConfiguration {
+    public var componentIdentifier: String = "fiori_processingindicator_component"
     public let optionalTitle: OptionalTitle
 
     public typealias OptionalTitle = ConfigurationViewWrapper
+}
+
+extension ProcessingIndicatorConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct ProcessingIndicatorFioriStyle: ProcessingIndicatorStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/ProfileHeader/ProfileHeader.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/ProfileHeader/ProfileHeader.generated.swift
@@ -15,6 +15,8 @@ public struct ProfileHeader {
 
     @Environment(\.profileHeaderStyle) var style
 
+    var componentIdentifier: String = ProfileHeader.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder detailImage: () -> any View = { EmptyView() },
@@ -22,15 +24,21 @@ public struct ProfileHeader {
                 @ViewBuilder subtitle: () -> any View = { EmptyView() },
                 @ViewBuilder description: () -> any View = { EmptyView() },
                 animatable: Bool = false,
-                @ViewBuilder detailContent: () -> any View = { EmptyView() })
+                @ViewBuilder detailContent: () -> any View = { EmptyView() },
+                componentIdentifier: String? = ProfileHeader.identifier)
     {
-        self.detailImage = DetailImage(detailImage: detailImage)
-        self.title = Title(title: title)
-        self.subtitle = Subtitle(subtitle: subtitle)
-        self.description = Description(description: description)
+        self.detailImage = DetailImage(detailImage: detailImage, componentIdentifier: componentIdentifier)
+        self.title = Title(title: title, componentIdentifier: componentIdentifier)
+        self.subtitle = Subtitle(subtitle: subtitle, componentIdentifier: componentIdentifier)
+        self.description = Description(description: description, componentIdentifier: componentIdentifier)
         self.animatable = animatable
         self.detailContent = detailContent()
+        self.componentIdentifier = componentIdentifier ?? ProfileHeader.identifier
     }
+}
+
+public extension ProfileHeader {
+    static let identifier = "fiori_profileheader_component"
 }
 
 public extension ProfileHeader {
@@ -58,6 +66,7 @@ public extension ProfileHeader {
         self.animatable = configuration.animatable
         self.detailContent = configuration.detailContent
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -66,7 +75,7 @@ extension ProfileHeader: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(detailImage: .init(self.detailImage), title: .init(self.title), subtitle: .init(self.subtitle), description: .init(self.description), animatable: self.animatable, detailContent: .init(self.detailContent))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, detailImage: .init(self.detailImage), title: .init(self.title), subtitle: .init(self.subtitle), description: .init(self.description), animatable: self.animatable, detailContent: .init(self.detailContent))).typeErased
                 .transformEnvironment(\.profileHeaderStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -84,7 +93,7 @@ private extension ProfileHeader {
     }
 
     func defaultStyle() -> some View {
-        ProfileHeader(.init(detailImage: .init(self.detailImage), title: .init(self.title), subtitle: .init(self.subtitle), description: .init(self.description), animatable: self.animatable, detailContent: .init(self.detailContent)))
+        ProfileHeader(.init(componentIdentifier: self.componentIdentifier, detailImage: .init(self.detailImage), title: .init(self.title), subtitle: .init(self.subtitle), description: .init(self.description), animatable: self.animatable, detailContent: .init(self.detailContent)))
             .shouldApplyDefaultStyle(false)
             .profileHeaderStyle(ProfileHeaderFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/ProfileHeader/ProfileHeaderStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/ProfileHeader/ProfileHeaderStyle.generated.swift
@@ -22,6 +22,7 @@ struct AnyProfileHeaderStyle: ProfileHeaderStyle {
 }
 
 public struct ProfileHeaderConfiguration {
+    public var componentIdentifier: String = "fiori_profileheader_component"
     public let detailImage: DetailImage
     public let title: Title
     public let subtitle: Subtitle
@@ -34,6 +35,12 @@ public struct ProfileHeaderConfiguration {
     public typealias Subtitle = ConfigurationViewWrapper
     public typealias Description = ConfigurationViewWrapper
     public typealias DetailContent = ConfigurationViewWrapper
+}
+
+extension ProfileHeaderConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct ProfileHeaderFioriStyle: ProfileHeaderStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Progress/Progress.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Progress/Progress.generated.swift
@@ -8,11 +8,20 @@ public struct Progress {
 
     @Environment(\.progressStyle) var style
 
+    var componentIdentifier: String = Progress.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder progress: () -> any View) {
+    public init(@ViewBuilder progress: () -> any View,
+                componentIdentifier: String? = Progress.identifier)
+    {
         self.progress = progress()
+        self.componentIdentifier = componentIdentifier ?? Progress.identifier
     }
+}
+
+public extension Progress {
+    static let identifier = "fiori_progress_component"
 }
 
 public extension Progress {
@@ -29,6 +38,7 @@ public extension Progress {
     internal init(_ configuration: ProgressConfiguration, shouldApplyDefaultStyle: Bool) {
         self.progress = configuration.progress
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension Progress: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(progress: .init(self.progress))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, progress: .init(self.progress))).typeErased
                 .transformEnvironment(\.progressStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension Progress {
     }
 
     func defaultStyle() -> some View {
-        Progress(.init(progress: .init(self.progress)))
+        Progress(.init(componentIdentifier: self.componentIdentifier, progress: .init(self.progress)))
             .shouldApplyDefaultStyle(false)
             .progressStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Progress/ProgressStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Progress/ProgressStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyProgressStyle: ProgressStyle {
 }
 
 public struct ProgressConfiguration {
+    public var componentIdentifier: String = "fiori_progress_component"
     public let progress: Progress
 
     public typealias Progress = ConfigurationViewWrapper
+}
+
+extension ProgressConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/ProgressIndicator/ProgressIndicator.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/ProgressIndicator/ProgressIndicator.generated.swift
@@ -20,11 +20,20 @@ public struct ProgressIndicator {
 
     @Environment(\.progressIndicatorStyle) var style
 
+    var componentIdentifier: String = ProgressIndicator.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(progress: Binding<Double>) {
+    public init(progress: Binding<Double>,
+                componentIdentifier: String? = ProgressIndicator.identifier)
+    {
         self._progress = progress
+        self.componentIdentifier = componentIdentifier ?? ProgressIndicator.identifier
     }
+}
+
+public extension ProgressIndicator {
+    static let identifier = "fiori_progressindicator_component"
 }
 
 public extension ProgressIndicator {
@@ -35,6 +44,7 @@ public extension ProgressIndicator {
     internal init(_ configuration: ProgressIndicatorConfiguration, shouldApplyDefaultStyle: Bool) {
         self._progress = configuration.$progress
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -43,7 +53,7 @@ extension ProgressIndicator: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(progress: self.$progress)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, progress: self.$progress)).typeErased
                 .transformEnvironment(\.progressIndicatorStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -61,7 +71,7 @@ private extension ProgressIndicator {
     }
 
     func defaultStyle() -> some View {
-        ProgressIndicator(.init(progress: self.$progress))
+        ProgressIndicator(.init(componentIdentifier: self.componentIdentifier, progress: self.$progress))
             .shouldApplyDefaultStyle(false)
             .progressIndicatorStyle(ProgressIndicatorFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/ProgressIndicator/ProgressIndicatorStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/ProgressIndicator/ProgressIndicatorStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyProgressIndicatorStyle: ProgressIndicatorStyle {
 }
 
 public struct ProgressIndicatorConfiguration {
+    public var componentIdentifier: String = "fiori_progressindicator_component"
     @Binding public var progress: Double
+}
+
+extension ProgressIndicatorConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct ProgressIndicatorFioriStyle: ProgressIndicatorStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/ProgressIndicatorProtocol/ProgressIndicatorProtocol.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/ProgressIndicatorProtocol/ProgressIndicatorProtocol.generated.swift
@@ -8,11 +8,20 @@ public struct ProgressIndicatorProtocol {
 
     @Environment(\.progressIndicatorProtocolStyle) var style
 
+    var componentIdentifier: String = ProgressIndicatorProtocol.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(progress: Binding<Double>) {
+    public init(progress: Binding<Double>,
+                componentIdentifier: String? = ProgressIndicatorProtocol.identifier)
+    {
         self._progress = progress
+        self.componentIdentifier = componentIdentifier ?? ProgressIndicatorProtocol.identifier
     }
+}
+
+public extension ProgressIndicatorProtocol {
+    static let identifier = "fiori_progressindicatorprotocol_component"
 }
 
 public extension ProgressIndicatorProtocol {
@@ -23,6 +32,7 @@ public extension ProgressIndicatorProtocol {
     internal init(_ configuration: ProgressIndicatorProtocolConfiguration, shouldApplyDefaultStyle: Bool) {
         self._progress = configuration.$progress
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -31,7 +41,7 @@ extension ProgressIndicatorProtocol: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(progress: self.$progress)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, progress: self.$progress)).typeErased
                 .transformEnvironment(\.progressIndicatorProtocolStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -49,7 +59,7 @@ private extension ProgressIndicatorProtocol {
     }
 
     func defaultStyle() -> some View {
-        ProgressIndicatorProtocol(.init(progress: self.$progress))
+        ProgressIndicatorProtocol(.init(componentIdentifier: self.componentIdentifier, progress: self.$progress))
             .shouldApplyDefaultStyle(false)
             .progressIndicatorProtocolStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/ProgressIndicatorProtocol/ProgressIndicatorProtocolStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/ProgressIndicatorProtocol/ProgressIndicatorProtocolStyle.generated.swift
@@ -22,5 +22,12 @@ struct AnyProgressIndicatorProtocolStyle: ProgressIndicatorProtocolStyle {
 }
 
 public struct ProgressIndicatorProtocolConfiguration {
+    public var componentIdentifier: String = "fiori_progressindicatorprotocol_component"
     @Binding public var progress: Double
+}
+
+extension ProgressIndicatorProtocolConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/RangeSliderControl/RangeSliderControl.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/RangeSliderControl/RangeSliderControl.generated.swift
@@ -29,6 +29,8 @@ public struct RangeSliderControl {
 
     @Environment(\.rangeSliderControlStyle) var style
 
+    var componentIdentifier: String = RangeSliderControl.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder lowerThumb: () -> any View,
@@ -43,12 +45,13 @@ public struct RangeSliderControl {
                 thumbHalfWidth: CGFloat = 14,
                 showsLowerThumb: Bool = true,
                 showsUpperThumb: Bool = true,
-                onRangeValueChange: ((Bool, Double, Double) -> Void)? = nil)
+                onRangeValueChange: ((Bool, Double, Double) -> Void)? = nil,
+                componentIdentifier: String? = RangeSliderControl.identifier)
     {
-        self.lowerThumb = LowerThumb(lowerThumb: lowerThumb)
-        self.upperThumb = UpperThumb(upperThumb: upperThumb)
-        self.activeTrack = ActiveTrack(activeTrack: activeTrack)
-        self.inactiveTrack = InactiveTrack(inactiveTrack: inactiveTrack)
+        self.lowerThumb = LowerThumb(lowerThumb: lowerThumb, componentIdentifier: componentIdentifier)
+        self.upperThumb = UpperThumb(upperThumb: upperThumb, componentIdentifier: componentIdentifier)
+        self.activeTrack = ActiveTrack(activeTrack: activeTrack, componentIdentifier: componentIdentifier)
+        self.inactiveTrack = InactiveTrack(inactiveTrack: inactiveTrack, componentIdentifier: componentIdentifier)
         self._lowerValue = lowerValue
         self._upperValue = upperValue
         self.range = range
@@ -58,7 +61,12 @@ public struct RangeSliderControl {
         self.showsLowerThumb = showsLowerThumb
         self.showsUpperThumb = showsUpperThumb
         self.onRangeValueChange = onRangeValueChange
+        self.componentIdentifier = componentIdentifier ?? RangeSliderControl.identifier
     }
+}
+
+public extension RangeSliderControl {
+    static let identifier = "fiori_rangeslidercontrol_component"
 }
 
 public extension RangeSliderControl {
@@ -100,6 +108,7 @@ public extension RangeSliderControl {
         self.showsUpperThumb = configuration.showsUpperThumb
         self.onRangeValueChange = configuration.onRangeValueChange
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -108,7 +117,7 @@ extension RangeSliderControl: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(lowerThumb: .init(self.lowerThumb), upperThumb: .init(self.upperThumb), activeTrack: .init(self.activeTrack), inactiveTrack: .init(self.inactiveTrack), lowerValue: self.$lowerValue, upperValue: self.$upperValue, range: self.range, step: self.step, decimalPlaces: self.decimalPlaces, thumbHalfWidth: self.thumbHalfWidth, showsLowerThumb: self.showsLowerThumb, showsUpperThumb: self.showsUpperThumb, onRangeValueChange: self.onRangeValueChange)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, lowerThumb: .init(self.lowerThumb), upperThumb: .init(self.upperThumb), activeTrack: .init(self.activeTrack), inactiveTrack: .init(self.inactiveTrack), lowerValue: self.$lowerValue, upperValue: self.$upperValue, range: self.range, step: self.step, decimalPlaces: self.decimalPlaces, thumbHalfWidth: self.thumbHalfWidth, showsLowerThumb: self.showsLowerThumb, showsUpperThumb: self.showsUpperThumb, onRangeValueChange: self.onRangeValueChange)).typeErased
                 .transformEnvironment(\.rangeSliderControlStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -126,7 +135,7 @@ private extension RangeSliderControl {
     }
 
     func defaultStyle() -> some View {
-        RangeSliderControl(.init(lowerThumb: .init(self.lowerThumb), upperThumb: .init(self.upperThumb), activeTrack: .init(self.activeTrack), inactiveTrack: .init(self.inactiveTrack), lowerValue: self.$lowerValue, upperValue: self.$upperValue, range: self.range, step: self.step, decimalPlaces: self.decimalPlaces, thumbHalfWidth: self.thumbHalfWidth, showsLowerThumb: self.showsLowerThumb, showsUpperThumb: self.showsUpperThumb, onRangeValueChange: self.onRangeValueChange))
+        RangeSliderControl(.init(componentIdentifier: self.componentIdentifier, lowerThumb: .init(self.lowerThumb), upperThumb: .init(self.upperThumb), activeTrack: .init(self.activeTrack), inactiveTrack: .init(self.inactiveTrack), lowerValue: self.$lowerValue, upperValue: self.$upperValue, range: self.range, step: self.step, decimalPlaces: self.decimalPlaces, thumbHalfWidth: self.thumbHalfWidth, showsLowerThumb: self.showsLowerThumb, showsUpperThumb: self.showsUpperThumb, onRangeValueChange: self.onRangeValueChange))
             .shouldApplyDefaultStyle(false)
             .rangeSliderControlStyle(RangeSliderControlFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/RangeSliderControl/RangeSliderControlStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/RangeSliderControl/RangeSliderControlStyle.generated.swift
@@ -22,6 +22,7 @@ struct AnyRangeSliderControlStyle: RangeSliderControlStyle {
 }
 
 public struct RangeSliderControlConfiguration {
+    public var componentIdentifier: String = "fiori_rangeslidercontrol_component"
     public let lowerThumb: LowerThumb
     public let upperThumb: UpperThumb
     public let activeTrack: ActiveTrack
@@ -40,6 +41,12 @@ public struct RangeSliderControlConfiguration {
     public typealias UpperThumb = ConfigurationViewWrapper
     public typealias ActiveTrack = ConfigurationViewWrapper
     public typealias InactiveTrack = ConfigurationViewWrapper
+}
+
+extension RangeSliderControlConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct RangeSliderControlFioriStyle: RangeSliderControlStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/RatingControl/RatingControl.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/RatingControl/RatingControl.generated.swift
@@ -51,6 +51,8 @@ public struct RatingControl {
 
     @Environment(\.ratingControlStyle) var style
 
+    var componentIdentifier: String = RatingControl.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder valueLabel: () -> any View = { EmptyView() },
@@ -71,13 +73,14 @@ public struct RatingControl {
                 reviewCountFormat: String? = nil,
                 reviewCountCeiling: Int? = nil,
                 reviewCountCeilingFormat: String? = nil,
-                showsReviewCountLabel: Bool = false)
+                showsReviewCountLabel: Bool = false,
+                componentIdentifier: String? = RatingControl.identifier)
     {
-        self.valueLabel = ValueLabel(valueLabel: valueLabel)
-        self.onStarImage = OnStarImage(onStarImage: onStarImage)
-        self.offStarImage = OffStarImage(offStarImage: offStarImage)
-        self.halfStarImage = HalfStarImage(halfStarImage: halfStarImage)
-        self.reviewCountLabel = ReviewCountLabel(reviewCountLabel: reviewCountLabel)
+        self.valueLabel = ValueLabel(valueLabel: valueLabel, componentIdentifier: componentIdentifier)
+        self.onStarImage = OnStarImage(onStarImage: onStarImage, componentIdentifier: componentIdentifier)
+        self.offStarImage = OffStarImage(offStarImage: offStarImage, componentIdentifier: componentIdentifier)
+        self.halfStarImage = HalfStarImage(halfStarImage: halfStarImage, componentIdentifier: componentIdentifier)
+        self.reviewCountLabel = ReviewCountLabel(reviewCountLabel: reviewCountLabel, componentIdentifier: componentIdentifier)
         self._rating = rating
         self.ratingControlStyle = ratingControlStyle
         self.ratingBounds = ratingBounds
@@ -92,7 +95,12 @@ public struct RatingControl {
         self.reviewCountCeiling = reviewCountCeiling
         self.reviewCountCeilingFormat = reviewCountCeilingFormat
         self.showsReviewCountLabel = showsReviewCountLabel
+        self.componentIdentifier = componentIdentifier ?? RatingControl.identifier
     }
+}
+
+public extension RatingControl {
+    static let identifier = "fiori_ratingcontrol_component"
 }
 
 public extension RatingControl {
@@ -146,6 +154,7 @@ public extension RatingControl {
         self.reviewCountCeilingFormat = configuration.reviewCountCeilingFormat
         self.showsReviewCountLabel = configuration.showsReviewCountLabel
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -154,7 +163,7 @@ extension RatingControl: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(valueLabel: .init(self.valueLabel), onStarImage: .init(self.onStarImage), offStarImage: .init(self.offStarImage), halfStarImage: .init(self.halfStarImage), reviewCountLabel: .init(self.reviewCountLabel), rating: self.$rating, ratingControlStyle: self.ratingControlStyle, ratingBounds: self.ratingBounds, itemSize: self.itemSize, interItemSpacing: self.interItemSpacing, ratingValueFormat: self.ratingValueFormat, showsValueLabel: self.showsValueLabel, averageRating: self.averageRating, averageRatingFormat: self.averageRatingFormat, reviewCount: self.reviewCount, reviewCountFormat: self.reviewCountFormat, reviewCountCeiling: self.reviewCountCeiling, reviewCountCeilingFormat: self.reviewCountCeilingFormat, showsReviewCountLabel: self.showsReviewCountLabel)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, valueLabel: .init(self.valueLabel), onStarImage: .init(self.onStarImage), offStarImage: .init(self.offStarImage), halfStarImage: .init(self.halfStarImage), reviewCountLabel: .init(self.reviewCountLabel), rating: self.$rating, ratingControlStyle: self.ratingControlStyle, ratingBounds: self.ratingBounds, itemSize: self.itemSize, interItemSpacing: self.interItemSpacing, ratingValueFormat: self.ratingValueFormat, showsValueLabel: self.showsValueLabel, averageRating: self.averageRating, averageRatingFormat: self.averageRatingFormat, reviewCount: self.reviewCount, reviewCountFormat: self.reviewCountFormat, reviewCountCeiling: self.reviewCountCeiling, reviewCountCeilingFormat: self.reviewCountCeilingFormat, showsReviewCountLabel: self.showsReviewCountLabel)).typeErased
                 .transformEnvironment(\.ratingControlStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -172,7 +181,7 @@ private extension RatingControl {
     }
 
     func defaultStyle() -> some View {
-        RatingControl(.init(valueLabel: .init(self.valueLabel), onStarImage: .init(self.onStarImage), offStarImage: .init(self.offStarImage), halfStarImage: .init(self.halfStarImage), reviewCountLabel: .init(self.reviewCountLabel), rating: self.$rating, ratingControlStyle: self.ratingControlStyle, ratingBounds: self.ratingBounds, itemSize: self.itemSize, interItemSpacing: self.interItemSpacing, ratingValueFormat: self.ratingValueFormat, showsValueLabel: self.showsValueLabel, averageRating: self.averageRating, averageRatingFormat: self.averageRatingFormat, reviewCount: self.reviewCount, reviewCountFormat: self.reviewCountFormat, reviewCountCeiling: self.reviewCountCeiling, reviewCountCeilingFormat: self.reviewCountCeilingFormat, showsReviewCountLabel: self.showsReviewCountLabel))
+        RatingControl(.init(componentIdentifier: self.componentIdentifier, valueLabel: .init(self.valueLabel), onStarImage: .init(self.onStarImage), offStarImage: .init(self.offStarImage), halfStarImage: .init(self.halfStarImage), reviewCountLabel: .init(self.reviewCountLabel), rating: self.$rating, ratingControlStyle: self.ratingControlStyle, ratingBounds: self.ratingBounds, itemSize: self.itemSize, interItemSpacing: self.interItemSpacing, ratingValueFormat: self.ratingValueFormat, showsValueLabel: self.showsValueLabel, averageRating: self.averageRating, averageRatingFormat: self.averageRatingFormat, reviewCount: self.reviewCount, reviewCountFormat: self.reviewCountFormat, reviewCountCeiling: self.reviewCountCeiling, reviewCountCeilingFormat: self.reviewCountCeilingFormat, showsReviewCountLabel: self.showsReviewCountLabel))
             .shouldApplyDefaultStyle(false)
             .ratingControlStyle(RatingControlFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/RatingControl/RatingControlStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/RatingControl/RatingControlStyle.generated.swift
@@ -22,6 +22,7 @@ struct AnyRatingControlStyle: RatingControlStyle {
 }
 
 public struct RatingControlConfiguration {
+    public var componentIdentifier: String = "fiori_ratingcontrol_component"
     public let valueLabel: ValueLabel
     public let onStarImage: OnStarImage
     public let offStarImage: OffStarImage
@@ -47,6 +48,12 @@ public struct RatingControlConfiguration {
     public typealias OffStarImage = ConfigurationViewWrapper
     public typealias HalfStarImage = ConfigurationViewWrapper
     public typealias ReviewCountLabel = ConfigurationViewWrapper
+}
+
+extension RatingControlConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct RatingControlFioriStyle: RatingControlStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/RatingControlFormView/RatingControlFormView.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/RatingControlFormView/RatingControlFormView.generated.swift
@@ -51,6 +51,8 @@ public struct RatingControlFormView {
 
     @Environment(\.ratingControlFormViewStyle) var style
 
+    var componentIdentifier: String = RatingControlFormView.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder title: () -> any View,
@@ -74,14 +76,15 @@ public struct RatingControlFormView {
                 reviewCountCeilingFormat: String? = nil,
                 showsReviewCountLabel: Bool = false,
                 @ViewBuilder subtitle: () -> any View = { EmptyView() },
-                axis: Axis = .horizontal)
+                axis: Axis = .horizontal,
+                componentIdentifier: String? = RatingControlFormView.identifier)
     {
-        self.title = Title(title: title)
-        self.valueLabel = ValueLabel(valueLabel: valueLabel)
-        self.onStarImage = OnStarImage(onStarImage: onStarImage)
-        self.offStarImage = OffStarImage(offStarImage: offStarImage)
-        self.halfStarImage = HalfStarImage(halfStarImage: halfStarImage)
-        self.reviewCountLabel = ReviewCountLabel(reviewCountLabel: reviewCountLabel)
+        self.title = Title(title: title, componentIdentifier: componentIdentifier)
+        self.valueLabel = ValueLabel(valueLabel: valueLabel, componentIdentifier: componentIdentifier)
+        self.onStarImage = OnStarImage(onStarImage: onStarImage, componentIdentifier: componentIdentifier)
+        self.offStarImage = OffStarImage(offStarImage: offStarImage, componentIdentifier: componentIdentifier)
+        self.halfStarImage = HalfStarImage(halfStarImage: halfStarImage, componentIdentifier: componentIdentifier)
+        self.reviewCountLabel = ReviewCountLabel(reviewCountLabel: reviewCountLabel, componentIdentifier: componentIdentifier)
         self._rating = rating
         self.ratingControlStyle = ratingControlStyle
         self.ratingBounds = ratingBounds
@@ -96,9 +99,14 @@ public struct RatingControlFormView {
         self.reviewCountCeiling = reviewCountCeiling
         self.reviewCountCeilingFormat = reviewCountCeilingFormat
         self.showsReviewCountLabel = showsReviewCountLabel
-        self.subtitle = Subtitle(subtitle: subtitle)
+        self.subtitle = Subtitle(subtitle: subtitle, componentIdentifier: componentIdentifier)
         self.axis = axis
+        self.componentIdentifier = componentIdentifier ?? RatingControlFormView.identifier
     }
+}
+
+public extension RatingControlFormView {
+    static let identifier = "fiori_ratingcontrolformview_component"
 }
 
 public extension RatingControlFormView {
@@ -158,6 +166,7 @@ public extension RatingControlFormView {
         self.subtitle = configuration.subtitle
         self.axis = configuration.axis
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -166,7 +175,7 @@ extension RatingControlFormView: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(title: .init(self.title), valueLabel: .init(self.valueLabel), onStarImage: .init(self.onStarImage), offStarImage: .init(self.offStarImage), halfStarImage: .init(self.halfStarImage), reviewCountLabel: .init(self.reviewCountLabel), rating: self.$rating, ratingControlStyle: self.ratingControlStyle, ratingBounds: self.ratingBounds, itemSize: self.itemSize, interItemSpacing: self.interItemSpacing, ratingValueFormat: self.ratingValueFormat, showsValueLabel: self.showsValueLabel, averageRating: self.averageRating, averageRatingFormat: self.averageRatingFormat, reviewCount: self.reviewCount, reviewCountFormat: self.reviewCountFormat, reviewCountCeiling: self.reviewCountCeiling, reviewCountCeilingFormat: self.reviewCountCeilingFormat, showsReviewCountLabel: self.showsReviewCountLabel, subtitle: .init(self.subtitle), axis: self.axis)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, title: .init(self.title), valueLabel: .init(self.valueLabel), onStarImage: .init(self.onStarImage), offStarImage: .init(self.offStarImage), halfStarImage: .init(self.halfStarImage), reviewCountLabel: .init(self.reviewCountLabel), rating: self.$rating, ratingControlStyle: self.ratingControlStyle, ratingBounds: self.ratingBounds, itemSize: self.itemSize, interItemSpacing: self.interItemSpacing, ratingValueFormat: self.ratingValueFormat, showsValueLabel: self.showsValueLabel, averageRating: self.averageRating, averageRatingFormat: self.averageRatingFormat, reviewCount: self.reviewCount, reviewCountFormat: self.reviewCountFormat, reviewCountCeiling: self.reviewCountCeiling, reviewCountCeilingFormat: self.reviewCountCeilingFormat, showsReviewCountLabel: self.showsReviewCountLabel, subtitle: .init(self.subtitle), axis: self.axis)).typeErased
                 .transformEnvironment(\.ratingControlFormViewStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -184,7 +193,7 @@ private extension RatingControlFormView {
     }
 
     func defaultStyle() -> some View {
-        RatingControlFormView(.init(title: .init(self.title), valueLabel: .init(self.valueLabel), onStarImage: .init(self.onStarImage), offStarImage: .init(self.offStarImage), halfStarImage: .init(self.halfStarImage), reviewCountLabel: .init(self.reviewCountLabel), rating: self.$rating, ratingControlStyle: self.ratingControlStyle, ratingBounds: self.ratingBounds, itemSize: self.itemSize, interItemSpacing: self.interItemSpacing, ratingValueFormat: self.ratingValueFormat, showsValueLabel: self.showsValueLabel, averageRating: self.averageRating, averageRatingFormat: self.averageRatingFormat, reviewCount: self.reviewCount, reviewCountFormat: self.reviewCountFormat, reviewCountCeiling: self.reviewCountCeiling, reviewCountCeilingFormat: self.reviewCountCeilingFormat, showsReviewCountLabel: self.showsReviewCountLabel, subtitle: .init(self.subtitle), axis: self.axis))
+        RatingControlFormView(.init(componentIdentifier: self.componentIdentifier, title: .init(self.title), valueLabel: .init(self.valueLabel), onStarImage: .init(self.onStarImage), offStarImage: .init(self.offStarImage), halfStarImage: .init(self.halfStarImage), reviewCountLabel: .init(self.reviewCountLabel), rating: self.$rating, ratingControlStyle: self.ratingControlStyle, ratingBounds: self.ratingBounds, itemSize: self.itemSize, interItemSpacing: self.interItemSpacing, ratingValueFormat: self.ratingValueFormat, showsValueLabel: self.showsValueLabel, averageRating: self.averageRating, averageRatingFormat: self.averageRatingFormat, reviewCount: self.reviewCount, reviewCountFormat: self.reviewCountFormat, reviewCountCeiling: self.reviewCountCeiling, reviewCountCeilingFormat: self.reviewCountCeilingFormat, showsReviewCountLabel: self.showsReviewCountLabel, subtitle: .init(self.subtitle), axis: self.axis))
             .shouldApplyDefaultStyle(false)
             .ratingControlFormViewStyle(RatingControlFormViewFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/RatingControlFormView/RatingControlFormViewStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/RatingControlFormView/RatingControlFormViewStyle.generated.swift
@@ -22,6 +22,7 @@ struct AnyRatingControlFormViewStyle: RatingControlFormViewStyle {
 }
 
 public struct RatingControlFormViewConfiguration {
+    public var componentIdentifier: String = "fiori_ratingcontrolformview_component"
     public let title: Title
     public let valueLabel: ValueLabel
     public let onStarImage: OnStarImage
@@ -52,6 +53,12 @@ public struct RatingControlFormViewConfiguration {
     public typealias HalfStarImage = ConfigurationViewWrapper
     public typealias ReviewCountLabel = ConfigurationViewWrapper
     public typealias Subtitle = ConfigurationViewWrapper
+}
+
+extension RatingControlFormViewConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct RatingControlFormViewFioriStyle: RatingControlFormViewStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/ReviewCountLabel/ReviewCountLabel.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/ReviewCountLabel/ReviewCountLabel.generated.swift
@@ -8,11 +8,20 @@ public struct ReviewCountLabel {
 
     @Environment(\.reviewCountLabelStyle) var style
 
+    var componentIdentifier: String = ReviewCountLabel.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder reviewCountLabel: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder reviewCountLabel: () -> any View = { EmptyView() },
+                componentIdentifier: String? = ReviewCountLabel.identifier)
+    {
         self.reviewCountLabel = reviewCountLabel()
+        self.componentIdentifier = componentIdentifier ?? ReviewCountLabel.identifier
     }
+}
+
+public extension ReviewCountLabel {
+    static let identifier = "fiori_reviewcountlabel_component"
 }
 
 public extension ReviewCountLabel {
@@ -29,6 +38,7 @@ public extension ReviewCountLabel {
     internal init(_ configuration: ReviewCountLabelConfiguration, shouldApplyDefaultStyle: Bool) {
         self.reviewCountLabel = configuration.reviewCountLabel
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension ReviewCountLabel: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(reviewCountLabel: .init(self.reviewCountLabel))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, reviewCountLabel: .init(self.reviewCountLabel))).typeErased
                 .transformEnvironment(\.reviewCountLabelStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension ReviewCountLabel {
     }
 
     func defaultStyle() -> some View {
-        ReviewCountLabel(.init(reviewCountLabel: .init(self.reviewCountLabel)))
+        ReviewCountLabel(.init(componentIdentifier: self.componentIdentifier, reviewCountLabel: .init(self.reviewCountLabel)))
             .shouldApplyDefaultStyle(false)
             .reviewCountLabelStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/ReviewCountLabel/ReviewCountLabelStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/ReviewCountLabel/ReviewCountLabelStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyReviewCountLabelStyle: ReviewCountLabelStyle {
 }
 
 public struct ReviewCountLabelConfiguration {
+    public var componentIdentifier: String = "fiori_reviewcountlabel_component"
     public let reviewCountLabel: ReviewCountLabel
 
     public typealias ReviewCountLabel = ConfigurationViewWrapper
+}
+
+extension ReviewCountLabelConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Row1/Row1.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Row1/Row1.generated.swift
@@ -8,11 +8,20 @@ public struct Row1 {
 
     @Environment(\.row1Style) var style
 
+    var componentIdentifier: String = Row1.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder row1: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder row1: () -> any View = { EmptyView() },
+                componentIdentifier: String? = Row1.identifier)
+    {
         self.row1 = row1()
+        self.componentIdentifier = componentIdentifier ?? Row1.identifier
     }
+}
+
+public extension Row1 {
+    static let identifier = "fiori_row1_component"
 }
 
 public extension Row1 {
@@ -23,6 +32,7 @@ public extension Row1 {
     internal init(_ configuration: Row1Configuration, shouldApplyDefaultStyle: Bool) {
         self.row1 = configuration.row1
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -31,7 +41,7 @@ extension Row1: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(row1: .init(self.row1))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, row1: .init(self.row1))).typeErased
                 .transformEnvironment(\.row1StyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -49,7 +59,7 @@ private extension Row1 {
     }
 
     func defaultStyle() -> some View {
-        Row1(.init(row1: .init(self.row1)))
+        Row1(.init(componentIdentifier: self.componentIdentifier, row1: .init(self.row1)))
             .shouldApplyDefaultStyle(false)
             .row1Style(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Row1/Row1Style.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Row1/Row1Style.generated.swift
@@ -22,7 +22,14 @@ struct AnyRow1Style: Row1Style {
 }
 
 public struct Row1Configuration {
+    public var componentIdentifier: String = "fiori_row1_component"
     public let row1: Row1
 
     public typealias Row1 = ConfigurationViewWrapper
+}
+
+extension Row1Configuration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Row2/Row2.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Row2/Row2.generated.swift
@@ -8,11 +8,20 @@ public struct Row2 {
 
     @Environment(\.row2Style) var style
 
+    var componentIdentifier: String = Row2.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder row2: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder row2: () -> any View = { EmptyView() },
+                componentIdentifier: String? = Row2.identifier)
+    {
         self.row2 = row2()
+        self.componentIdentifier = componentIdentifier ?? Row2.identifier
     }
+}
+
+public extension Row2 {
+    static let identifier = "fiori_row2_component"
 }
 
 public extension Row2 {
@@ -23,6 +32,7 @@ public extension Row2 {
     internal init(_ configuration: Row2Configuration, shouldApplyDefaultStyle: Bool) {
         self.row2 = configuration.row2
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -31,7 +41,7 @@ extension Row2: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(row2: .init(self.row2))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, row2: .init(self.row2))).typeErased
                 .transformEnvironment(\.row2StyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -49,7 +59,7 @@ private extension Row2 {
     }
 
     func defaultStyle() -> some View {
-        Row2(.init(row2: .init(self.row2)))
+        Row2(.init(componentIdentifier: self.componentIdentifier, row2: .init(self.row2)))
             .shouldApplyDefaultStyle(false)
             .row2Style(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Row2/Row2Style.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Row2/Row2Style.generated.swift
@@ -22,7 +22,14 @@ struct AnyRow2Style: Row2Style {
 }
 
 public struct Row2Configuration {
+    public var componentIdentifier: String = "fiori_row2_component"
     public let row2: Row2
 
     public typealias Row2 = ConfigurationViewWrapper
+}
+
+extension Row2Configuration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Row3/Row3.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Row3/Row3.generated.swift
@@ -8,11 +8,20 @@ public struct Row3 {
 
     @Environment(\.row3Style) var style
 
+    var componentIdentifier: String = Row3.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder row3: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder row3: () -> any View = { EmptyView() },
+                componentIdentifier: String? = Row3.identifier)
+    {
         self.row3 = row3()
+        self.componentIdentifier = componentIdentifier ?? Row3.identifier
     }
+}
+
+public extension Row3 {
+    static let identifier = "fiori_row3_component"
 }
 
 public extension Row3 {
@@ -23,6 +32,7 @@ public extension Row3 {
     internal init(_ configuration: Row3Configuration, shouldApplyDefaultStyle: Bool) {
         self.row3 = configuration.row3
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -31,7 +41,7 @@ extension Row3: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(row3: .init(self.row3))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, row3: .init(self.row3))).typeErased
                 .transformEnvironment(\.row3StyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -49,7 +59,7 @@ private extension Row3 {
     }
 
     func defaultStyle() -> some View {
-        Row3(.init(row3: .init(self.row3)))
+        Row3(.init(componentIdentifier: self.componentIdentifier, row3: .init(self.row3)))
             .shouldApplyDefaultStyle(false)
             .row3Style(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Row3/Row3Style.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Row3/Row3Style.generated.swift
@@ -22,7 +22,14 @@ struct AnyRow3Style: Row3Style {
 }
 
 public struct Row3Configuration {
+    public var componentIdentifier: String = "fiori_row3_component"
     public let row3: Row3
 
     public typealias Row3 = ConfigurationViewWrapper
+}
+
+extension Row3Configuration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/SecondaryAction/SecondaryAction.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/SecondaryAction/SecondaryAction.generated.swift
@@ -8,11 +8,20 @@ public struct SecondaryAction {
 
     @Environment(\.secondaryActionStyle) var style
 
+    var componentIdentifier: String = SecondaryAction.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder secondaryAction: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder secondaryAction: () -> any View = { EmptyView() },
+                componentIdentifier: String? = SecondaryAction.identifier)
+    {
         self.secondaryAction = secondaryAction()
+        self.componentIdentifier = componentIdentifier ?? SecondaryAction.identifier
     }
+}
+
+public extension SecondaryAction {
+    static let identifier = "fiori_secondaryaction_component"
 }
 
 public extension SecondaryAction {
@@ -29,6 +38,7 @@ public extension SecondaryAction {
     internal init(_ configuration: SecondaryActionConfiguration, shouldApplyDefaultStyle: Bool) {
         self.secondaryAction = configuration.secondaryAction
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension SecondaryAction: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(secondaryAction: .init(self.secondaryAction))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, secondaryAction: .init(self.secondaryAction))).typeErased
                 .transformEnvironment(\.secondaryActionStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension SecondaryAction {
     }
 
     func defaultStyle() -> some View {
-        SecondaryAction(.init(secondaryAction: .init(self.secondaryAction)))
+        SecondaryAction(.init(componentIdentifier: self.componentIdentifier, secondaryAction: .init(self.secondaryAction)))
             .shouldApplyDefaultStyle(false)
             .secondaryActionStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/SecondaryAction/SecondaryActionStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/SecondaryAction/SecondaryActionStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnySecondaryActionStyle: SecondaryActionStyle {
 }
 
 public struct SecondaryActionConfiguration {
+    public var componentIdentifier: String = "fiori_secondaryaction_component"
     public let secondaryAction: SecondaryAction
 
     public typealias SecondaryAction = ConfigurationViewWrapper
+}
+
+extension SecondaryActionConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/SecondaryTimestamp/SecondaryTimestamp.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/SecondaryTimestamp/SecondaryTimestamp.generated.swift
@@ -8,11 +8,20 @@ public struct SecondaryTimestamp {
 
     @Environment(\.secondaryTimestampStyle) var style
 
+    var componentIdentifier: String = SecondaryTimestamp.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder secondaryTimestamp: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder secondaryTimestamp: () -> any View = { EmptyView() },
+                componentIdentifier: String? = SecondaryTimestamp.identifier)
+    {
         self.secondaryTimestamp = secondaryTimestamp()
+        self.componentIdentifier = componentIdentifier ?? SecondaryTimestamp.identifier
     }
+}
+
+public extension SecondaryTimestamp {
+    static let identifier = "fiori_secondarytimestamp_component"
 }
 
 public extension SecondaryTimestamp {
@@ -29,6 +38,7 @@ public extension SecondaryTimestamp {
     internal init(_ configuration: SecondaryTimestampConfiguration, shouldApplyDefaultStyle: Bool) {
         self.secondaryTimestamp = configuration.secondaryTimestamp
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension SecondaryTimestamp: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(secondaryTimestamp: .init(self.secondaryTimestamp))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, secondaryTimestamp: .init(self.secondaryTimestamp))).typeErased
                 .transformEnvironment(\.secondaryTimestampStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension SecondaryTimestamp {
     }
 
     func defaultStyle() -> some View {
-        SecondaryTimestamp(.init(secondaryTimestamp: .init(self.secondaryTimestamp)))
+        SecondaryTimestamp(.init(componentIdentifier: self.componentIdentifier, secondaryTimestamp: .init(self.secondaryTimestamp)))
             .shouldApplyDefaultStyle(false)
             .secondaryTimestampStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/SecondaryTimestamp/SecondaryTimestampStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/SecondaryTimestamp/SecondaryTimestampStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnySecondaryTimestampStyle: SecondaryTimestampStyle {
 }
 
 public struct SecondaryTimestampConfiguration {
+    public var componentIdentifier: String = "fiori_secondarytimestamp_component"
     public let secondaryTimestamp: SecondaryTimestamp
 
     public typealias SecondaryTimestamp = ConfigurationViewWrapper
+}
+
+extension SecondaryTimestampConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/SegmentedControlPicker/SegmentedControlPicker.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/SegmentedControlPicker/SegmentedControlPicker.generated.swift
@@ -18,14 +18,22 @@ public struct SegmentedControlPicker {
 
     @Environment(\.segmentedControlPickerStyle) var style
 
+    var componentIdentifier: String = SegmentedControlPicker.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(options: [AttributedString] = [],
-                selectedIndex: Binding<Int>)
+                selectedIndex: Binding<Int>,
+                componentIdentifier: String? = SegmentedControlPicker.identifier)
     {
         self.options = options
         self._selectedIndex = selectedIndex
+        self.componentIdentifier = componentIdentifier ?? SegmentedControlPicker.identifier
     }
+}
+
+public extension SegmentedControlPicker {
+    static let identifier = "fiori_segmentedcontrolpicker_component"
 }
 
 public extension SegmentedControlPicker {
@@ -37,6 +45,7 @@ public extension SegmentedControlPicker {
         self.options = configuration.options
         self._selectedIndex = configuration.$selectedIndex
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -45,7 +54,7 @@ extension SegmentedControlPicker: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(options: self.options, selectedIndex: self.$selectedIndex)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, options: self.options, selectedIndex: self.$selectedIndex)).typeErased
                 .transformEnvironment(\.segmentedControlPickerStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -63,7 +72,7 @@ private extension SegmentedControlPicker {
     }
 
     func defaultStyle() -> some View {
-        SegmentedControlPicker(.init(options: self.options, selectedIndex: self.$selectedIndex))
+        SegmentedControlPicker(.init(componentIdentifier: self.componentIdentifier, options: self.options, selectedIndex: self.$selectedIndex))
             .shouldApplyDefaultStyle(false)
             .segmentedControlPickerStyle(SegmentedControlPickerFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/SegmentedControlPicker/SegmentedControlPickerStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/SegmentedControlPicker/SegmentedControlPickerStyle.generated.swift
@@ -22,8 +22,15 @@ struct AnySegmentedControlPickerStyle: SegmentedControlPickerStyle {
 }
 
 public struct SegmentedControlPickerConfiguration {
+    public var componentIdentifier: String = "fiori_segmentedcontrolpicker_component"
     public let options: [AttributedString]
     @Binding public var selectedIndex: Int
+}
+
+extension SegmentedControlPickerConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct SegmentedControlPickerFioriStyle: SegmentedControlPickerStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/SelectAllAction/SelectAllAction.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/SelectAllAction/SelectAllAction.generated.swift
@@ -8,11 +8,20 @@ public struct SelectAllAction {
 
     @Environment(\.selectAllActionStyle) var style
 
+    var componentIdentifier: String = SelectAllAction.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder selectAllAction: () -> any View = { FioriButton { _ in Text("Select All".localizedFioriString()) } }) {
+    public init(@ViewBuilder selectAllAction: () -> any View = { FioriButton { _ in Text("Select All".localizedFioriString()) } },
+                componentIdentifier: String? = SelectAllAction.identifier)
+    {
         self.selectAllAction = selectAllAction()
+        self.componentIdentifier = componentIdentifier ?? SelectAllAction.identifier
     }
+}
+
+public extension SelectAllAction {
+    static let identifier = "fiori_selectallaction_component"
 }
 
 public extension SelectAllAction {
@@ -29,6 +38,7 @@ public extension SelectAllAction {
     internal init(_ configuration: SelectAllActionConfiguration, shouldApplyDefaultStyle: Bool) {
         self.selectAllAction = configuration.selectAllAction
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension SelectAllAction: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(selectAllAction: .init(self.selectAllAction))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, selectAllAction: .init(self.selectAllAction))).typeErased
                 .transformEnvironment(\.selectAllActionStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension SelectAllAction {
     }
 
     func defaultStyle() -> some View {
-        SelectAllAction(.init(selectAllAction: .init(self.selectAllAction)))
+        SelectAllAction(.init(componentIdentifier: self.componentIdentifier, selectAllAction: .init(self.selectAllAction)))
             .shouldApplyDefaultStyle(false)
             .selectAllActionStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/SelectAllAction/SelectAllActionStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/SelectAllAction/SelectAllActionStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnySelectAllActionStyle: SelectAllActionStyle {
 }
 
 public struct SelectAllActionConfiguration {
+    public var componentIdentifier: String = "fiori_selectallaction_component"
     public let selectAllAction: SelectAllAction
 
     public typealias SelectAllAction = ConfigurationViewWrapper
+}
+
+extension SelectAllActionConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/SelectedEntriesSectionTitle/SelectedEntriesSectionTitle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/SelectedEntriesSectionTitle/SelectedEntriesSectionTitle.generated.swift
@@ -8,11 +8,20 @@ public struct SelectedEntriesSectionTitle {
 
     @Environment(\.selectedEntriesSectionTitleStyle) var style
 
+    var componentIdentifier: String = SelectedEntriesSectionTitle.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder selectedEntriesSectionTitle: () -> any View = { Text("Selected".localizedFioriString()) }) {
+    public init(@ViewBuilder selectedEntriesSectionTitle: () -> any View = { Text("Selected".localizedFioriString()) },
+                componentIdentifier: String? = SelectedEntriesSectionTitle.identifier)
+    {
         self.selectedEntriesSectionTitle = selectedEntriesSectionTitle()
+        self.componentIdentifier = componentIdentifier ?? SelectedEntriesSectionTitle.identifier
     }
+}
+
+public extension SelectedEntriesSectionTitle {
+    static let identifier = "fiori_selectedentriessectiontitle_component"
 }
 
 public extension SelectedEntriesSectionTitle {
@@ -29,6 +38,7 @@ public extension SelectedEntriesSectionTitle {
     internal init(_ configuration: SelectedEntriesSectionTitleConfiguration, shouldApplyDefaultStyle: Bool) {
         self.selectedEntriesSectionTitle = configuration.selectedEntriesSectionTitle
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension SelectedEntriesSectionTitle: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(selectedEntriesSectionTitle: .init(self.selectedEntriesSectionTitle))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, selectedEntriesSectionTitle: .init(self.selectedEntriesSectionTitle))).typeErased
                 .transformEnvironment(\.selectedEntriesSectionTitleStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension SelectedEntriesSectionTitle {
     }
 
     func defaultStyle() -> some View {
-        SelectedEntriesSectionTitle(.init(selectedEntriesSectionTitle: .init(self.selectedEntriesSectionTitle)))
+        SelectedEntriesSectionTitle(.init(componentIdentifier: self.componentIdentifier, selectedEntriesSectionTitle: .init(self.selectedEntriesSectionTitle)))
             .shouldApplyDefaultStyle(false)
             .selectedEntriesSectionTitleStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/SelectedEntriesSectionTitle/SelectedEntriesSectionTitleStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/SelectedEntriesSectionTitle/SelectedEntriesSectionTitleStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnySelectedEntriesSectionTitleStyle: SelectedEntriesSectionTitleStyle {
 }
 
 public struct SelectedEntriesSectionTitleConfiguration {
+    public var componentIdentifier: String = "fiori_selectedentriessectiontitle_component"
     public let selectedEntriesSectionTitle: SelectedEntriesSectionTitle
 
     public typealias SelectedEntriesSectionTitle = ConfigurationViewWrapper
+}
+
+extension SelectedEntriesSectionTitleConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/SideBar/SideBar.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/SideBar/SideBar.generated.swift
@@ -110,6 +110,8 @@ public struct SideBar {
 
     @Environment(\.sideBarStyle) var style
 
+    var componentIdentifier: String = SideBar.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(isEditing: Binding<Bool>,
@@ -122,7 +124,8 @@ public struct SideBar {
                 destination: @escaping (SideBarItemModel) -> any View,
                 item: @escaping (Binding<SideBarItemModel>) -> any View,
                 onDataChange: (([SideBarItemModel]) -> Void)? = nil,
-                isUsedInSplitView: Bool = true)
+                isUsedInSplitView: Bool = true,
+                componentIdentifier: String? = SideBar.identifier)
     {
         self._isEditing = isEditing
         self._queryString = queryString
@@ -135,7 +138,12 @@ public struct SideBar {
         self.item = item
         self.onDataChange = onDataChange
         self.isUsedInSplitView = isUsedInSplitView
+        self.componentIdentifier = componentIdentifier ?? SideBar.identifier
     }
+}
+
+public extension SideBar {
+    static let identifier = "fiori_sidebar_component"
 }
 
 public extension SideBar {
@@ -156,6 +164,7 @@ public extension SideBar {
         self.onDataChange = configuration.onDataChange
         self.isUsedInSplitView = configuration.isUsedInSplitView
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -164,7 +173,7 @@ extension SideBar: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(isEditing: self.$isEditing, queryString: self.$queryString, data: self.$data, selection: self.$selection, title: self.title, footer: .init(self.footer), editButton: .init(self.editButton), destination: self.destination, item: self.item, onDataChange: self.onDataChange, isUsedInSplitView: self.isUsedInSplitView)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, isEditing: self.$isEditing, queryString: self.$queryString, data: self.$data, selection: self.$selection, title: self.title, footer: .init(self.footer), editButton: .init(self.editButton), destination: self.destination, item: self.item, onDataChange: self.onDataChange, isUsedInSplitView: self.isUsedInSplitView)).typeErased
                 .transformEnvironment(\.sideBarStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -182,7 +191,7 @@ private extension SideBar {
     }
 
     func defaultStyle() -> some View {
-        SideBar(.init(isEditing: self.$isEditing, queryString: self.$queryString, data: self.$data, selection: self.$selection, title: self.title, footer: .init(self.footer), editButton: .init(self.editButton), destination: self.destination, item: self.item, onDataChange: self.onDataChange, isUsedInSplitView: self.isUsedInSplitView))
+        SideBar(.init(componentIdentifier: self.componentIdentifier, isEditing: self.$isEditing, queryString: self.$queryString, data: self.$data, selection: self.$selection, title: self.title, footer: .init(self.footer), editButton: .init(self.editButton), destination: self.destination, item: self.item, onDataChange: self.onDataChange, isUsedInSplitView: self.isUsedInSplitView))
             .shouldApplyDefaultStyle(false)
             .sideBarStyle(SideBarFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/SideBar/SideBarStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/SideBar/SideBarStyle.generated.swift
@@ -22,6 +22,7 @@ struct AnySideBarStyle: SideBarStyle {
 }
 
 public struct SideBarConfiguration {
+    public var componentIdentifier: String = "fiori_sidebar_component"
     @Binding public var isEditing: Bool
     @Binding public var queryString: String?
     @Binding public var data: [SideBarItemModel]
@@ -36,6 +37,12 @@ public struct SideBarConfiguration {
 
     public typealias Footer = ConfigurationViewWrapper
     public typealias EditButton = ConfigurationViewWrapper
+}
+
+extension SideBarConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct SideBarFioriStyle: SideBarStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/SideBarListItem/SideBarListItem.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/SideBarListItem/SideBarListItem.generated.swift
@@ -22,6 +22,8 @@ public struct SideBarListItem {
 
     @Environment(\.sideBarListItemStyle) var style
 
+    var componentIdentifier: String = SideBarListItem.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder icon: () -> any View = { EmptyView() },
@@ -31,17 +33,23 @@ public struct SideBarListItem {
                 @ViewBuilder accessoryIcon: () -> any View = { EmptyView() },
                 isOn: Binding<Bool>,
                 data: SideBarItemModel,
-                isSelected: Binding<Bool>)
+                isSelected: Binding<Bool>,
+                componentIdentifier: String? = SideBarListItem.identifier)
     {
-        self.icon = Icon(icon: icon)
-        self.filledIcon = FilledIcon(filledIcon: filledIcon)
-        self.title = Title(title: title)
-        self.subtitle = Subtitle(subtitle: subtitle)
-        self.accessoryIcon = AccessoryIcon(accessoryIcon: accessoryIcon)
+        self.icon = Icon(icon: icon, componentIdentifier: componentIdentifier)
+        self.filledIcon = FilledIcon(filledIcon: filledIcon, componentIdentifier: componentIdentifier)
+        self.title = Title(title: title, componentIdentifier: componentIdentifier)
+        self.subtitle = Subtitle(subtitle: subtitle, componentIdentifier: componentIdentifier)
+        self.accessoryIcon = AccessoryIcon(accessoryIcon: accessoryIcon, componentIdentifier: componentIdentifier)
         self._isOn = isOn
         self.data = data
         self._isSelected = isSelected
+        self.componentIdentifier = componentIdentifier ?? SideBarListItem.identifier
     }
+}
+
+public extension SideBarListItem {
+    static let identifier = "fiori_sidebarlistitem_component"
 }
 
 public extension SideBarListItem {
@@ -73,6 +81,7 @@ public extension SideBarListItem {
         self.data = configuration.data
         self._isSelected = configuration.$isSelected
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -81,7 +90,7 @@ extension SideBarListItem: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(icon: .init(self.icon), filledIcon: .init(self.filledIcon), title: .init(self.title), subtitle: .init(self.subtitle), accessoryIcon: .init(self.accessoryIcon), isOn: self.$isOn, data: self.data, isSelected: self.$isSelected)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, icon: .init(self.icon), filledIcon: .init(self.filledIcon), title: .init(self.title), subtitle: .init(self.subtitle), accessoryIcon: .init(self.accessoryIcon), isOn: self.$isOn, data: self.data, isSelected: self.$isSelected)).typeErased
                 .transformEnvironment(\.sideBarListItemStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -99,7 +108,7 @@ private extension SideBarListItem {
     }
 
     func defaultStyle() -> some View {
-        SideBarListItem(.init(icon: .init(self.icon), filledIcon: .init(self.filledIcon), title: .init(self.title), subtitle: .init(self.subtitle), accessoryIcon: .init(self.accessoryIcon), isOn: self.$isOn, data: self.data, isSelected: self.$isSelected))
+        SideBarListItem(.init(componentIdentifier: self.componentIdentifier, icon: .init(self.icon), filledIcon: .init(self.filledIcon), title: .init(self.title), subtitle: .init(self.subtitle), accessoryIcon: .init(self.accessoryIcon), isOn: self.$isOn, data: self.data, isSelected: self.$isSelected))
             .shouldApplyDefaultStyle(false)
             .sideBarListItemStyle(SideBarListItemFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/SideBarListItem/SideBarListItemStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/SideBarListItem/SideBarListItemStyle.generated.swift
@@ -22,6 +22,7 @@ struct AnySideBarListItemStyle: SideBarListItemStyle {
 }
 
 public struct SideBarListItemConfiguration {
+    public var componentIdentifier: String = "fiori_sidebarlistitem_component"
     public let icon: Icon
     public let filledIcon: FilledIcon
     public let title: Title
@@ -36,6 +37,12 @@ public struct SideBarListItemConfiguration {
     public typealias Title = ConfigurationViewWrapper
     public typealias Subtitle = ConfigurationViewWrapper
     public typealias AccessoryIcon = ConfigurationViewWrapper
+}
+
+extension SideBarListItemConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct SideBarListItemFioriStyle: SideBarListItemStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/SingleStep/SingleStep.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/SingleStep/SingleStep.generated.swift
@@ -13,6 +13,8 @@ public struct SingleStep {
 
     @Environment(\.singleStepStyle) var style
 
+    var componentIdentifier: String = SingleStep.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder title: () -> any View,
@@ -20,15 +22,21 @@ public struct SingleStep {
                 @ViewBuilder line: () -> any View = { Rectangle() },
                 id: String = UUID().uuidString,
                 state: StepProgressIndicatorState = .normal,
-                @IndexedViewBuilder substeps: () -> any IndexedViewContainer = { EmptyView() })
+                @IndexedViewBuilder substeps: () -> any IndexedViewContainer = { EmptyView() },
+                componentIdentifier: String? = SingleStep.identifier)
     {
-        self.title = Title(title: title)
-        self.node = Node(node: node)
-        self.line = Line(line: line)
+        self.title = Title(title: title, componentIdentifier: componentIdentifier)
+        self.node = Node(node: node, componentIdentifier: componentIdentifier)
+        self.line = Line(line: line, componentIdentifier: componentIdentifier)
         self.id = id
         self.state = state
         self.substeps = substeps()
+        self.componentIdentifier = componentIdentifier ?? SingleStep.identifier
     }
+}
+
+public extension SingleStep {
+    static let identifier = "fiori_singlestep_component"
 }
 
 public extension SingleStep {
@@ -56,6 +64,7 @@ public extension SingleStep {
         self.state = configuration.state
         self.substeps = configuration.substeps
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -64,7 +73,7 @@ extension SingleStep: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(title: .init(self.title), node: .init(self.node), line: .init(self.line), id: self.id, state: self.state, substeps: self.substeps)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, title: .init(self.title), node: .init(self.node), line: .init(self.line), id: self.id, state: self.state, substeps: self.substeps)).typeErased
                 .transformEnvironment(\.singleStepStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -82,7 +91,7 @@ private extension SingleStep {
     }
 
     func defaultStyle() -> some View {
-        SingleStep(.init(title: .init(self.title), node: .init(self.node), line: .init(self.line), id: self.id, state: self.state, substeps: self.substeps))
+        SingleStep(.init(componentIdentifier: self.componentIdentifier, title: .init(self.title), node: .init(self.node), line: .init(self.line), id: self.id, state: self.state, substeps: self.substeps))
             .shouldApplyDefaultStyle(false)
             .singleStepStyle(SingleStepFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/SingleStep/SingleStepStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/SingleStep/SingleStepStyle.generated.swift
@@ -22,6 +22,7 @@ struct AnySingleStepStyle: SingleStepStyle {
 }
 
 public struct SingleStepConfiguration {
+    public var componentIdentifier: String = "fiori_singlestep_component"
     public let title: Title
     public let node: Node
     public let line: Line
@@ -33,6 +34,12 @@ public struct SingleStepConfiguration {
     public typealias Node = ConfigurationViewWrapper
     public typealias Line = ConfigurationViewWrapper
     public typealias Substeps = any IndexedViewContainer
+}
+
+extension SingleStepConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct SingleStepFioriStyle: SingleStepStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Status/Status.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Status/Status.generated.swift
@@ -8,11 +8,20 @@ public struct Status {
 
     @Environment(\.statusStyle) var style
 
+    var componentIdentifier: String = Status.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder status: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder status: () -> any View = { EmptyView() },
+                componentIdentifier: String? = Status.identifier)
+    {
         self.status = status()
+        self.componentIdentifier = componentIdentifier ?? Status.identifier
     }
+}
+
+public extension Status {
+    static let identifier = "fiori_status_component"
 }
 
 public extension Status {
@@ -29,6 +38,7 @@ public extension Status {
     internal init(_ configuration: StatusConfiguration, shouldApplyDefaultStyle: Bool) {
         self.status = configuration.status
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension Status: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(status: .init(self.status))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, status: .init(self.status))).typeErased
                 .transformEnvironment(\.statusStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension Status {
     }
 
     func defaultStyle() -> some View {
-        Status(.init(status: .init(self.status)))
+        Status(.init(componentIdentifier: self.componentIdentifier, status: .init(self.status)))
             .shouldApplyDefaultStyle(false)
             .statusStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Status/StatusStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Status/StatusStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyStatusStyle: StatusStyle {
 }
 
 public struct StatusConfiguration {
+    public var componentIdentifier: String = "fiori_status_component"
     public let status: Status
 
     public typealias Status = ConfigurationViewWrapper
+}
+
+extension StatusConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/StepProgressIndicator/StepProgressIndicator.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/StepProgressIndicator/StepProgressIndicator.generated.swift
@@ -24,20 +24,28 @@ public struct StepProgressIndicator {
 
     @Environment(\.stepProgressIndicatorStyle) var style
 
+    var componentIdentifier: String = StepProgressIndicator.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder title: () -> any View,
                 @ViewBuilder action: () -> any View = { EmptyView() },
                 @ViewBuilder cancelAction: () -> any View = { FioriButton { _ in Text("Cancel".localizedFioriString()) } },
                 selection: Binding<String>,
-                @IndexedViewBuilder steps: () -> any IndexedViewContainer = { EmptyView() })
+                @IndexedViewBuilder steps: () -> any IndexedViewContainer = { EmptyView() },
+                componentIdentifier: String? = StepProgressIndicator.identifier)
     {
-        self.title = Title(title: title)
-        self.action = Action(action: action)
-        self.cancelAction = CancelAction(cancelAction: cancelAction)
+        self.title = Title(title: title, componentIdentifier: componentIdentifier)
+        self.action = Action(action: action, componentIdentifier: componentIdentifier)
+        self.cancelAction = CancelAction(cancelAction: cancelAction, componentIdentifier: componentIdentifier)
         self._selection = selection
         self.steps = steps()
+        self.componentIdentifier = componentIdentifier ?? StepProgressIndicator.identifier
     }
+}
+
+public extension StepProgressIndicator {
+    static let identifier = "fiori_stepprogressindicator_component"
 }
 
 public extension StepProgressIndicator {
@@ -63,6 +71,7 @@ public extension StepProgressIndicator {
         self._selection = configuration.$selection
         self.steps = configuration.steps
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -71,7 +80,7 @@ extension StepProgressIndicator: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(title: .init(self.title), action: .init(self.action), cancelAction: .init(self.cancelAction), selection: self.$selection, steps: self.steps)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, title: .init(self.title), action: .init(self.action), cancelAction: .init(self.cancelAction), selection: self.$selection, steps: self.steps)).typeErased
                 .transformEnvironment(\.stepProgressIndicatorStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -89,7 +98,7 @@ private extension StepProgressIndicator {
     }
 
     func defaultStyle() -> some View {
-        StepProgressIndicator(.init(title: .init(self.title), action: .init(self.action), cancelAction: .init(self.cancelAction), selection: self.$selection, steps: self.steps))
+        StepProgressIndicator(.init(componentIdentifier: self.componentIdentifier, title: .init(self.title), action: .init(self.action), cancelAction: .init(self.cancelAction), selection: self.$selection, steps: self.steps))
             .shouldApplyDefaultStyle(false)
             .stepProgressIndicatorStyle(StepProgressIndicatorFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/StepProgressIndicator/StepProgressIndicatorStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/StepProgressIndicator/StepProgressIndicatorStyle.generated.swift
@@ -22,6 +22,7 @@ struct AnyStepProgressIndicatorStyle: StepProgressIndicatorStyle {
 }
 
 public struct StepProgressIndicatorConfiguration {
+    public var componentIdentifier: String = "fiori_stepprogressindicator_component"
     public let title: Title
     public let action: Action
     public let cancelAction: CancelAction
@@ -32,6 +33,12 @@ public struct StepProgressIndicatorConfiguration {
     public typealias Action = ConfigurationViewWrapper
     public typealias CancelAction = ConfigurationViewWrapper
     public typealias Steps = any IndexedViewContainer
+}
+
+extension StepProgressIndicatorConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct StepProgressIndicatorFioriStyle: StepProgressIndicatorStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/StepperField/StepperField.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/StepperField/StepperField.generated.swift
@@ -18,6 +18,8 @@ public struct StepperField {
 
     @Environment(\.stepperFieldStyle) var style
 
+    var componentIdentifier: String = StepperField.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder decrementAction: () -> any View = { FioriButton { _ in FioriIcon.actions.less } },
@@ -25,15 +27,21 @@ public struct StepperField {
                 @ViewBuilder incrementAction: () -> any View = { FioriButton { _ in FioriIcon.actions.add } },
                 step: Double = 1,
                 stepRange: ClosedRange<Double>,
-                isDecimalSupported: Bool = false)
+                isDecimalSupported: Bool = false,
+                componentIdentifier: String? = StepperField.identifier)
     {
-        self.decrementAction = DecrementAction(decrementAction: decrementAction)
+        self.decrementAction = DecrementAction(decrementAction: decrementAction, componentIdentifier: componentIdentifier)
         self._text = text
-        self.incrementAction = IncrementAction(incrementAction: incrementAction)
+        self.incrementAction = IncrementAction(incrementAction: incrementAction, componentIdentifier: componentIdentifier)
         self.step = step
         self.stepRange = stepRange
         self.isDecimalSupported = isDecimalSupported
+        self.componentIdentifier = componentIdentifier ?? StepperField.identifier
     }
+}
+
+public extension StepperField {
+    static let identifier = "fiori_stepperfield_component"
 }
 
 public extension StepperField {
@@ -61,6 +69,7 @@ public extension StepperField {
         self.stepRange = configuration.stepRange
         self.isDecimalSupported = configuration.isDecimalSupported
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -69,7 +78,7 @@ extension StepperField: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(decrementAction: .init(self.decrementAction), text: self.$text, incrementAction: .init(self.incrementAction), step: self.step, stepRange: self.stepRange, isDecimalSupported: self.isDecimalSupported)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, decrementAction: .init(self.decrementAction), text: self.$text, incrementAction: .init(self.incrementAction), step: self.step, stepRange: self.stepRange, isDecimalSupported: self.isDecimalSupported)).typeErased
                 .transformEnvironment(\.stepperFieldStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -87,7 +96,7 @@ private extension StepperField {
     }
 
     func defaultStyle() -> some View {
-        StepperField(.init(decrementAction: .init(self.decrementAction), text: self.$text, incrementAction: .init(self.incrementAction), step: self.step, stepRange: self.stepRange, isDecimalSupported: self.isDecimalSupported))
+        StepperField(.init(componentIdentifier: self.componentIdentifier, decrementAction: .init(self.decrementAction), text: self.$text, incrementAction: .init(self.incrementAction), step: self.step, stepRange: self.stepRange, isDecimalSupported: self.isDecimalSupported))
             .shouldApplyDefaultStyle(false)
             .stepperFieldStyle(StepperFieldFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/StepperField/StepperFieldStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/StepperField/StepperFieldStyle.generated.swift
@@ -22,6 +22,7 @@ struct AnyStepperFieldStyle: StepperFieldStyle {
 }
 
 public struct StepperFieldConfiguration {
+    public var componentIdentifier: String = "fiori_stepperfield_component"
     public let decrementAction: DecrementAction
     @Binding public var text: String
     public let incrementAction: IncrementAction
@@ -31,6 +32,12 @@ public struct StepperFieldConfiguration {
 
     public typealias DecrementAction = ConfigurationViewWrapper
     public typealias IncrementAction = ConfigurationViewWrapper
+}
+
+extension StepperFieldConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct StepperFieldFioriStyle: StepperFieldStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/StepperView/StepperView.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/StepperView/StepperView.generated.swift
@@ -21,6 +21,8 @@ public struct StepperView {
 
     @Environment(\.stepperViewStyle) var style
 
+    var componentIdentifier: String = StepperView.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder title: () -> any View,
@@ -31,18 +33,24 @@ public struct StepperView {
                 stepRange: ClosedRange<Double>,
                 isDecimalSupported: Bool = false,
                 @ViewBuilder icon: () -> any View = { EmptyView() },
-                @ViewBuilder description: () -> any View = { EmptyView() })
+                @ViewBuilder description: () -> any View = { EmptyView() },
+                componentIdentifier: String? = StepperView.identifier)
     {
-        self.title = Title(title: title)
-        self.decrementAction = DecrementAction(decrementAction: decrementAction)
+        self.title = Title(title: title, componentIdentifier: componentIdentifier)
+        self.decrementAction = DecrementAction(decrementAction: decrementAction, componentIdentifier: componentIdentifier)
         self._text = text
-        self.incrementAction = IncrementAction(incrementAction: incrementAction)
+        self.incrementAction = IncrementAction(incrementAction: incrementAction, componentIdentifier: componentIdentifier)
         self.step = step
         self.stepRange = stepRange
         self.isDecimalSupported = isDecimalSupported
-        self.icon = Icon(icon: icon)
-        self.description = Description(description: description)
+        self.icon = Icon(icon: icon, componentIdentifier: componentIdentifier)
+        self.description = Description(description: description, componentIdentifier: componentIdentifier)
+        self.componentIdentifier = componentIdentifier ?? StepperView.identifier
     }
+}
+
+public extension StepperView {
+    static let identifier = "fiori_stepperview_component"
 }
 
 public extension StepperView {
@@ -76,6 +84,7 @@ public extension StepperView {
         self.icon = configuration.icon
         self.description = configuration.description
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -84,7 +93,7 @@ extension StepperView: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(title: .init(self.title), decrementAction: .init(self.decrementAction), text: self.$text, incrementAction: .init(self.incrementAction), step: self.step, stepRange: self.stepRange, isDecimalSupported: self.isDecimalSupported, icon: .init(self.icon), description: .init(self.description))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, title: .init(self.title), decrementAction: .init(self.decrementAction), text: self.$text, incrementAction: .init(self.incrementAction), step: self.step, stepRange: self.stepRange, isDecimalSupported: self.isDecimalSupported, icon: .init(self.icon), description: .init(self.description))).typeErased
                 .transformEnvironment(\.stepperViewStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -102,7 +111,7 @@ private extension StepperView {
     }
 
     func defaultStyle() -> some View {
-        StepperView(.init(title: .init(self.title), decrementAction: .init(self.decrementAction), text: self.$text, incrementAction: .init(self.incrementAction), step: self.step, stepRange: self.stepRange, isDecimalSupported: self.isDecimalSupported, icon: .init(self.icon), description: .init(self.description)))
+        StepperView(.init(componentIdentifier: self.componentIdentifier, title: .init(self.title), decrementAction: .init(self.decrementAction), text: self.$text, incrementAction: .init(self.incrementAction), step: self.step, stepRange: self.stepRange, isDecimalSupported: self.isDecimalSupported, icon: .init(self.icon), description: .init(self.description)))
             .shouldApplyDefaultStyle(false)
             .stepperViewStyle(StepperViewFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/StepperView/StepperViewStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/StepperView/StepperViewStyle.generated.swift
@@ -22,6 +22,7 @@ struct AnyStepperViewStyle: StepperViewStyle {
 }
 
 public struct StepperViewConfiguration {
+    public var componentIdentifier: String = "fiori_stepperview_component"
     public let title: Title
     public let decrementAction: DecrementAction
     @Binding public var text: String
@@ -37,6 +38,12 @@ public struct StepperViewConfiguration {
     public typealias IncrementAction = ConfigurationViewWrapper
     public typealias Icon = ConfigurationViewWrapper
     public typealias Description = ConfigurationViewWrapper
+}
+
+extension StepperViewConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct StepperViewFioriStyle: StepperViewStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/SubAttribute/SubAttribute.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/SubAttribute/SubAttribute.generated.swift
@@ -8,11 +8,20 @@ public struct SubAttribute {
 
     @Environment(\.subAttributeStyle) var style
 
+    var componentIdentifier: String = SubAttribute.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder subAttribute: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder subAttribute: () -> any View = { EmptyView() },
+                componentIdentifier: String? = SubAttribute.identifier)
+    {
         self.subAttribute = subAttribute()
+        self.componentIdentifier = componentIdentifier ?? SubAttribute.identifier
     }
+}
+
+public extension SubAttribute {
+    static let identifier = "fiori_subattribute_component"
 }
 
 public extension SubAttribute {
@@ -29,6 +38,7 @@ public extension SubAttribute {
     internal init(_ configuration: SubAttributeConfiguration, shouldApplyDefaultStyle: Bool) {
         self.subAttribute = configuration.subAttribute
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension SubAttribute: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(subAttribute: .init(self.subAttribute))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, subAttribute: .init(self.subAttribute))).typeErased
                 .transformEnvironment(\.subAttributeStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension SubAttribute {
     }
 
     func defaultStyle() -> some View {
-        SubAttribute(.init(subAttribute: .init(self.subAttribute)))
+        SubAttribute(.init(componentIdentifier: self.componentIdentifier, subAttribute: .init(self.subAttribute)))
             .shouldApplyDefaultStyle(false)
             .subAttributeStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/SubAttribute/SubAttributeStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/SubAttribute/SubAttributeStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnySubAttributeStyle: SubAttributeStyle {
 }
 
 public struct SubAttributeConfiguration {
+    public var componentIdentifier: String = "fiori_subattribute_component"
     public let subAttribute: SubAttribute
 
     public typealias SubAttribute = ConfigurationViewWrapper
+}
+
+extension SubAttributeConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Substatus/Substatus.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Substatus/Substatus.generated.swift
@@ -8,11 +8,20 @@ public struct Substatus {
 
     @Environment(\.substatusStyle) var style
 
+    var componentIdentifier: String = Substatus.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder substatus: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder substatus: () -> any View = { EmptyView() },
+                componentIdentifier: String? = Substatus.identifier)
+    {
         self.substatus = substatus()
+        self.componentIdentifier = componentIdentifier ?? Substatus.identifier
     }
+}
+
+public extension Substatus {
+    static let identifier = "fiori_substatus_component"
 }
 
 public extension Substatus {
@@ -29,6 +38,7 @@ public extension Substatus {
     internal init(_ configuration: SubstatusConfiguration, shouldApplyDefaultStyle: Bool) {
         self.substatus = configuration.substatus
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension Substatus: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(substatus: .init(self.substatus))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, substatus: .init(self.substatus))).typeErased
                 .transformEnvironment(\.substatusStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension Substatus {
     }
 
     func defaultStyle() -> some View {
-        Substatus(.init(substatus: .init(self.substatus)))
+        Substatus(.init(componentIdentifier: self.componentIdentifier, substatus: .init(self.substatus)))
             .shouldApplyDefaultStyle(false)
             .substatusStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Substatus/SubstatusStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Substatus/SubstatusStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnySubstatusStyle: SubstatusStyle {
 }
 
 public struct SubstatusConfiguration {
+    public var componentIdentifier: String = "fiori_substatus_component"
     public let substatus: Substatus
 
     public typealias Substatus = ConfigurationViewWrapper
+}
+
+extension SubstatusConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Subtitle/Subtitle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Subtitle/Subtitle.generated.swift
@@ -8,11 +8,20 @@ public struct Subtitle {
 
     @Environment(\.subtitleStyle) var style
 
+    var componentIdentifier: String = Subtitle.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder subtitle: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder subtitle: () -> any View = { EmptyView() },
+                componentIdentifier: String? = Subtitle.identifier)
+    {
         self.subtitle = subtitle()
+        self.componentIdentifier = componentIdentifier ?? Subtitle.identifier
     }
+}
+
+public extension Subtitle {
+    static let identifier = "fiori_subtitle_component"
 }
 
 public extension Subtitle {
@@ -29,6 +38,7 @@ public extension Subtitle {
     internal init(_ configuration: SubtitleConfiguration, shouldApplyDefaultStyle: Bool) {
         self.subtitle = configuration.subtitle
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension Subtitle: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(subtitle: .init(self.subtitle))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, subtitle: .init(self.subtitle))).typeErased
                 .transformEnvironment(\.subtitleStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension Subtitle {
     }
 
     func defaultStyle() -> some View {
-        Subtitle(.init(subtitle: .init(self.subtitle)))
+        Subtitle(.init(componentIdentifier: self.componentIdentifier, subtitle: .init(self.subtitle)))
             .shouldApplyDefaultStyle(false)
             .subtitleStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Subtitle/SubtitleStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Subtitle/SubtitleStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnySubtitleStyle: SubtitleStyle {
 }
 
 public struct SubtitleConfiguration {
+    public var componentIdentifier: String = "fiori_subtitle_component"
     public let subtitle: Subtitle
 
     public typealias Subtitle = ConfigurationViewWrapper
+}
+
+extension SubtitleConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Switch/Switch.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Switch/Switch.generated.swift
@@ -8,11 +8,20 @@ public struct Switch {
 
     @Environment(\.switchStyle) var style
 
+    var componentIdentifier: String = Switch.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(isOn: Binding<Bool>) {
+    public init(isOn: Binding<Bool>,
+                componentIdentifier: String? = Switch.identifier)
+    {
         self._isOn = isOn
+        self.componentIdentifier = componentIdentifier ?? Switch.identifier
     }
+}
+
+public extension Switch {
+    static let identifier = "fiori_switch_component"
 }
 
 public extension Switch {
@@ -23,6 +32,7 @@ public extension Switch {
     internal init(_ configuration: SwitchConfiguration, shouldApplyDefaultStyle: Bool) {
         self._isOn = configuration.$isOn
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -31,7 +41,7 @@ extension Switch: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(isOn: self.$isOn)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, isOn: self.$isOn)).typeErased
                 .transformEnvironment(\.switchStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -49,7 +59,7 @@ private extension Switch {
     }
 
     func defaultStyle() -> some View {
-        Switch(.init(isOn: self.$isOn))
+        Switch(.init(componentIdentifier: self.componentIdentifier, isOn: self.$isOn))
             .shouldApplyDefaultStyle(false)
             .switchStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Switch/SwitchStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Switch/SwitchStyle.generated.swift
@@ -22,5 +22,12 @@ struct AnySwitchStyle: SwitchStyle {
 }
 
 public struct SwitchConfiguration {
+    public var componentIdentifier: String = "fiori_switch_component"
     @Binding public var isOn: Bool
+}
+
+extension SwitchConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/SwitchView/SwitchView.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/SwitchView/SwitchView.generated.swift
@@ -17,14 +17,22 @@ public struct SwitchView {
 
     @Environment(\.switchViewStyle) var style
 
+    var componentIdentifier: String = SwitchView.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder title: () -> any View,
-                isOn: Binding<Bool>)
+                isOn: Binding<Bool>,
+                componentIdentifier: String? = SwitchView.identifier)
     {
-        self.title = Title(title: title)
+        self.title = Title(title: title, componentIdentifier: componentIdentifier)
         self._isOn = isOn
+        self.componentIdentifier = componentIdentifier ?? SwitchView.identifier
     }
+}
+
+public extension SwitchView {
+    static let identifier = "fiori_switchview_component"
 }
 
 public extension SwitchView {
@@ -44,6 +52,7 @@ public extension SwitchView {
         self.title = configuration.title
         self._isOn = configuration.$isOn
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -52,7 +61,7 @@ extension SwitchView: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(title: .init(self.title), isOn: self.$isOn)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, title: .init(self.title), isOn: self.$isOn)).typeErased
                 .transformEnvironment(\.switchViewStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -70,7 +79,7 @@ private extension SwitchView {
     }
 
     func defaultStyle() -> some View {
-        SwitchView(.init(title: .init(self.title), isOn: self.$isOn))
+        SwitchView(.init(componentIdentifier: self.componentIdentifier, title: .init(self.title), isOn: self.$isOn))
             .shouldApplyDefaultStyle(false)
             .switchViewStyle(SwitchViewFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/SwitchView/SwitchViewStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/SwitchView/SwitchViewStyle.generated.swift
@@ -22,10 +22,17 @@ struct AnySwitchViewStyle: SwitchViewStyle {
 }
 
 public struct SwitchViewConfiguration {
+    public var componentIdentifier: String = "fiori_switchview_component"
     public let title: Title
     @Binding public var isOn: Bool
 
     public typealias Title = ConfigurationViewWrapper
+}
+
+extension SwitchViewConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct SwitchViewFioriStyle: SwitchViewStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Tag/Tag.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Tag/Tag.generated.swift
@@ -8,11 +8,20 @@ public struct Tag {
 
     @Environment(\.tagStyle) var style
 
+    var componentIdentifier: String = Tag.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder tag: () -> any View) {
+    public init(@ViewBuilder tag: () -> any View,
+                componentIdentifier: String? = Tag.identifier)
+    {
         self.tag = tag()
+        self.componentIdentifier = componentIdentifier ?? Tag.identifier
     }
+}
+
+public extension Tag {
+    static let identifier = "fiori_tag_component"
 }
 
 public extension Tag {
@@ -29,6 +38,7 @@ public extension Tag {
     internal init(_ configuration: TagConfiguration, shouldApplyDefaultStyle: Bool) {
         self.tag = configuration.tag
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension Tag: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(tag: .init(self.tag))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, tag: .init(self.tag))).typeErased
                 .transformEnvironment(\.tagStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension Tag {
     }
 
     func defaultStyle() -> some View {
-        Tag(.init(tag: .init(self.tag)))
+        Tag(.init(componentIdentifier: self.componentIdentifier, tag: .init(self.tag)))
             .shouldApplyDefaultStyle(false)
             .tagStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Tag/TagStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Tag/TagStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyTagStyle: TagStyle {
 }
 
 public struct TagConfiguration {
+    public var componentIdentifier: String = "fiori_tag_component"
     public let tag: Tag
 
     public typealias Tag = ConfigurationViewWrapper
+}
+
+extension TagConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Tags/Tags.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Tags/Tags.generated.swift
@@ -8,11 +8,20 @@ public struct Tags {
 
     @Environment(\.tagsStyle) var style
 
+    var componentIdentifier: String = Tags.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@TagBuilder tags: () -> any View = { EmptyView() }) {
+    public init(@TagBuilder tags: () -> any View = { EmptyView() },
+                componentIdentifier: String? = Tags.identifier)
+    {
         self.tags = tags()
+        self.componentIdentifier = componentIdentifier ?? Tags.identifier
     }
+}
+
+public extension Tags {
+    static let identifier = "fiori_tags_component"
 }
 
 public extension Tags {
@@ -29,6 +38,7 @@ public extension Tags {
     internal init(_ configuration: TagsConfiguration, shouldApplyDefaultStyle: Bool) {
         self.tags = configuration.tags
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension Tags: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(tags: .init(self.tags))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, tags: .init(self.tags))).typeErased
                 .transformEnvironment(\.tagsStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension Tags {
     }
 
     func defaultStyle() -> some View {
-        Tags(.init(tags: .init(self.tags)))
+        Tags(.init(componentIdentifier: self.componentIdentifier, tags: .init(self.tags)))
             .shouldApplyDefaultStyle(false)
             .tagsStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Tags/TagsStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Tags/TagsStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyTagsStyle: TagsStyle {
 }
 
 public struct TagsConfiguration {
+    public var componentIdentifier: String = "fiori_tags_component"
     public let tags: Tags
 
     public typealias Tags = ConfigurationViewWrapper
+}
+
+extension TagsConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/TertiaryAction/TertiaryAction.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/TertiaryAction/TertiaryAction.generated.swift
@@ -8,11 +8,20 @@ public struct TertiaryAction {
 
     @Environment(\.tertiaryActionStyle) var style
 
+    var componentIdentifier: String = TertiaryAction.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder tertiaryAction: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder tertiaryAction: () -> any View = { EmptyView() },
+                componentIdentifier: String? = TertiaryAction.identifier)
+    {
         self.tertiaryAction = tertiaryAction()
+        self.componentIdentifier = componentIdentifier ?? TertiaryAction.identifier
     }
+}
+
+public extension TertiaryAction {
+    static let identifier = "fiori_tertiaryaction_component"
 }
 
 public extension TertiaryAction {
@@ -29,6 +38,7 @@ public extension TertiaryAction {
     internal init(_ configuration: TertiaryActionConfiguration, shouldApplyDefaultStyle: Bool) {
         self.tertiaryAction = configuration.tertiaryAction
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension TertiaryAction: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(tertiaryAction: .init(self.tertiaryAction))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, tertiaryAction: .init(self.tertiaryAction))).typeErased
                 .transformEnvironment(\.tertiaryActionStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension TertiaryAction {
     }
 
     func defaultStyle() -> some View {
-        TertiaryAction(.init(tertiaryAction: .init(self.tertiaryAction)))
+        TertiaryAction(.init(componentIdentifier: self.componentIdentifier, tertiaryAction: .init(self.tertiaryAction)))
             .shouldApplyDefaultStyle(false)
             .tertiaryActionStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/TertiaryAction/TertiaryActionStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/TertiaryAction/TertiaryActionStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyTertiaryActionStyle: TertiaryActionStyle {
 }
 
 public struct TertiaryActionConfiguration {
+    public var componentIdentifier: String = "fiori_tertiaryaction_component"
     public let tertiaryAction: TertiaryAction
 
     public typealias TertiaryAction = ConfigurationViewWrapper
+}
+
+extension TertiaryActionConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/TextFieldFormView/TextFieldFormView.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/TextFieldFormView/TextFieldFormView.generated.swift
@@ -36,6 +36,8 @@ public struct TextFieldFormView {
 
     @Environment(\.textFieldFormViewStyle) var style
 
+    var componentIdentifier: String = TextFieldFormView.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder title: () -> any View,
@@ -54,11 +56,12 @@ public struct TextFieldFormView {
                 isRequired: Bool = false,
                 actionIcon: Image? = nil,
                 action: (() -> Void)? = nil,
-                actionIconAccessibilityLabel: String? = nil)
+                actionIconAccessibilityLabel: String? = nil,
+                componentIdentifier: String? = TextFieldFormView.identifier)
     {
-        self.title = Title(title: title)
+        self.title = Title(title: title, componentIdentifier: componentIdentifier)
         self._text = text
-        self.placeholder = Placeholder(placeholder: placeholder)
+        self.placeholder = Placeholder(placeholder: placeholder, componentIdentifier: componentIdentifier)
         self.controlState = controlState
         self.errorMessage = errorMessage
         self.maxTextLength = maxTextLength
@@ -68,12 +71,17 @@ public struct TextFieldFormView {
         self.allowsBeyondLimit = allowsBeyondLimit
         self.charCountReachLimitMessage = charCountReachLimitMessage
         self.charCountBeyondLimitMsg = charCountBeyondLimitMsg
-        self.mandatoryFieldIndicator = MandatoryFieldIndicator(mandatoryFieldIndicator: mandatoryFieldIndicator)
+        self.mandatoryFieldIndicator = MandatoryFieldIndicator(mandatoryFieldIndicator: mandatoryFieldIndicator, componentIdentifier: componentIdentifier)
         self.isRequired = isRequired
         self.actionIcon = actionIcon
         self.action = action
         self.actionIconAccessibilityLabel = actionIconAccessibilityLabel
+        self.componentIdentifier = componentIdentifier ?? TextFieldFormView.identifier
     }
+}
+
+public extension TextFieldFormView {
+    static let identifier = "fiori_textfieldformview_component"
 }
 
 public extension TextFieldFormView {
@@ -123,6 +131,7 @@ public extension TextFieldFormView {
         self.action = configuration.action
         self.actionIconAccessibilityLabel = configuration.actionIconAccessibilityLabel
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -131,7 +140,7 @@ extension TextFieldFormView: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(title: .init(self.title), text: self.$text, placeholder: .init(self.placeholder), controlState: self.controlState, errorMessage: self.errorMessage, maxTextLength: self.maxTextLength, hintText: self.hintText, hidesReadOnlyHint: self.hidesReadOnlyHint, isCharCountEnabled: self.isCharCountEnabled, allowsBeyondLimit: self.allowsBeyondLimit, charCountReachLimitMessage: self.charCountReachLimitMessage, charCountBeyondLimitMsg: self.charCountBeyondLimitMsg, mandatoryFieldIndicator: .init(self.mandatoryFieldIndicator), isRequired: self.isRequired, actionIcon: self.actionIcon, action: self.action, actionIconAccessibilityLabel: self.actionIconAccessibilityLabel)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, title: .init(self.title), text: self.$text, placeholder: .init(self.placeholder), controlState: self.controlState, errorMessage: self.errorMessage, maxTextLength: self.maxTextLength, hintText: self.hintText, hidesReadOnlyHint: self.hidesReadOnlyHint, isCharCountEnabled: self.isCharCountEnabled, allowsBeyondLimit: self.allowsBeyondLimit, charCountReachLimitMessage: self.charCountReachLimitMessage, charCountBeyondLimitMsg: self.charCountBeyondLimitMsg, mandatoryFieldIndicator: .init(self.mandatoryFieldIndicator), isRequired: self.isRequired, actionIcon: self.actionIcon, action: self.action, actionIconAccessibilityLabel: self.actionIconAccessibilityLabel)).typeErased
                 .transformEnvironment(\.textFieldFormViewStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -149,7 +158,7 @@ private extension TextFieldFormView {
     }
 
     func defaultStyle() -> some View {
-        TextFieldFormView(.init(title: .init(self.title), text: self.$text, placeholder: .init(self.placeholder), controlState: self.controlState, errorMessage: self.errorMessage, maxTextLength: self.maxTextLength, hintText: self.hintText, hidesReadOnlyHint: self.hidesReadOnlyHint, isCharCountEnabled: self.isCharCountEnabled, allowsBeyondLimit: self.allowsBeyondLimit, charCountReachLimitMessage: self.charCountReachLimitMessage, charCountBeyondLimitMsg: self.charCountBeyondLimitMsg, mandatoryFieldIndicator: .init(self.mandatoryFieldIndicator), isRequired: self.isRequired, actionIcon: self.actionIcon, action: self.action, actionIconAccessibilityLabel: self.actionIconAccessibilityLabel))
+        TextFieldFormView(.init(componentIdentifier: self.componentIdentifier, title: .init(self.title), text: self.$text, placeholder: .init(self.placeholder), controlState: self.controlState, errorMessage: self.errorMessage, maxTextLength: self.maxTextLength, hintText: self.hintText, hidesReadOnlyHint: self.hidesReadOnlyHint, isCharCountEnabled: self.isCharCountEnabled, allowsBeyondLimit: self.allowsBeyondLimit, charCountReachLimitMessage: self.charCountReachLimitMessage, charCountBeyondLimitMsg: self.charCountBeyondLimitMsg, mandatoryFieldIndicator: .init(self.mandatoryFieldIndicator), isRequired: self.isRequired, actionIcon: self.actionIcon, action: self.action, actionIconAccessibilityLabel: self.actionIconAccessibilityLabel))
             .shouldApplyDefaultStyle(false)
             .textFieldFormViewStyle(TextFieldFormViewFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/TextFieldFormView/TextFieldFormViewStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/TextFieldFormView/TextFieldFormViewStyle.generated.swift
@@ -22,6 +22,7 @@ struct AnyTextFieldFormViewStyle: TextFieldFormViewStyle {
 }
 
 public struct TextFieldFormViewConfiguration {
+    public var componentIdentifier: String = "fiori_textfieldformview_component"
     public let title: Title
     @Binding public var text: String
     public let placeholder: Placeholder
@@ -43,6 +44,12 @@ public struct TextFieldFormViewConfiguration {
     public typealias Title = ConfigurationViewWrapper
     public typealias Placeholder = ConfigurationViewWrapper
     public typealias MandatoryFieldIndicator = ConfigurationViewWrapper
+}
+
+extension TextFieldFormViewConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct TextFieldFormViewFioriStyle: TextFieldFormViewStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/TextInputField/TextInputField.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/TextInputField/TextInputField.generated.swift
@@ -8,11 +8,20 @@ public struct TextInputField {
 
     @Environment(\.textInputFieldStyle) var style
 
+    var componentIdentifier: String = TextInputField.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(text: Binding<String>) {
+    public init(text: Binding<String>,
+                componentIdentifier: String? = TextInputField.identifier)
+    {
         self._text = text
+        self.componentIdentifier = componentIdentifier ?? TextInputField.identifier
     }
+}
+
+public extension TextInputField {
+    static let identifier = "fiori_textinputfield_component"
 }
 
 public extension TextInputField {
@@ -23,6 +32,7 @@ public extension TextInputField {
     internal init(_ configuration: TextInputFieldConfiguration, shouldApplyDefaultStyle: Bool) {
         self._text = configuration.$text
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -31,7 +41,7 @@ extension TextInputField: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(text: self.$text)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, text: self.$text)).typeErased
                 .transformEnvironment(\.textInputFieldStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -49,7 +59,7 @@ private extension TextInputField {
     }
 
     func defaultStyle() -> some View {
-        TextInputField(.init(text: self.$text))
+        TextInputField(.init(componentIdentifier: self.componentIdentifier, text: self.$text))
             .shouldApplyDefaultStyle(false)
             .textInputFieldStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/TextInputField/TextInputFieldStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/TextInputField/TextInputFieldStyle.generated.swift
@@ -22,5 +22,12 @@ struct AnyTextInputFieldStyle: TextInputFieldStyle {
 }
 
 public struct TextInputFieldConfiguration {
+    public var componentIdentifier: String = "fiori_textinputfield_component"
     @Binding public var text: String
+}
+
+extension TextInputFieldConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/TextInputInfoView/TextInputInfoView.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/TextInputInfoView/TextInputInfoView.generated.swift
@@ -10,16 +10,24 @@ struct TextInputInfoView {
 
     @Environment(\.textInputInfoViewStyle) var style
 
+    var componentIdentifier: String = TextInputInfoView.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder icon: () -> any View = { EmptyView() },
                 @ViewBuilder description: () -> any View = { EmptyView() },
-                @ViewBuilder counter: () -> any View = { EmptyView() })
+                @ViewBuilder counter: () -> any View = { EmptyView() },
+                componentIdentifier: String? = TextInputInfoView.identifier)
     {
-        self.icon = Icon(icon: icon)
-        self.description = Description(description: description)
-        self.counter = Counter(counter: counter)
+        self.icon = Icon(icon: icon, componentIdentifier: componentIdentifier)
+        self.description = Description(description: description, componentIdentifier: componentIdentifier)
+        self.counter = Counter(counter: counter, componentIdentifier: componentIdentifier)
+        self.componentIdentifier = componentIdentifier ?? TextInputInfoView.identifier
     }
+}
+
+extension TextInputInfoView {
+    public static let identifier = "fiori_textinputinfoview_component"
 }
 
 extension TextInputInfoView {
@@ -41,6 +49,7 @@ extension TextInputInfoView {
         self.description = configuration.description
         self.counter = configuration.counter
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -49,7 +58,7 @@ extension TextInputInfoView: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(icon: .init(self.icon), description: .init(self.description), counter: .init(self.counter))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, icon: .init(self.icon), description: .init(self.description), counter: .init(self.counter))).typeErased
                 .transformEnvironment(\.textInputInfoViewStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -67,7 +76,7 @@ private extension TextInputInfoView {
     }
 
     func defaultStyle() -> some View {
-        TextInputInfoView(.init(icon: .init(self.icon), description: .init(self.description), counter: .init(self.counter)))
+        TextInputInfoView(.init(componentIdentifier: self.componentIdentifier, icon: .init(self.icon), description: .init(self.description), counter: .init(self.counter)))
             .shouldApplyDefaultStyle(false)
             .textInputInfoViewStyle(TextInputInfoViewFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/TextInputInfoView/TextInputInfoViewStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/TextInputInfoView/TextInputInfoViewStyle.generated.swift
@@ -22,6 +22,7 @@ struct AnyTextInputInfoViewStyle: TextInputInfoViewStyle {
 }
 
 struct TextInputInfoViewConfiguration {
+    public var componentIdentifier: String = "fiori_textinputinfoview_component"
     public let icon: Icon
     public let description: Description
     public let counter: Counter
@@ -29,6 +30,12 @@ struct TextInputInfoViewConfiguration {
     public typealias Icon = ConfigurationViewWrapper
     public typealias Description = ConfigurationViewWrapper
     public typealias Counter = ConfigurationViewWrapper
+}
+
+extension TextInputInfoViewConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 struct TextInputInfoViewFioriStyle: TextInputInfoViewStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/TextView/TextView.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/TextView/TextView.generated.swift
@@ -8,11 +8,20 @@ public struct TextView {
 
     @Environment(\.textViewStyle) var style
 
+    var componentIdentifier: String = TextView.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(text: Binding<String>) {
+    public init(text: Binding<String>,
+                componentIdentifier: String? = TextView.identifier)
+    {
         self._text = text
+        self.componentIdentifier = componentIdentifier ?? TextView.identifier
     }
+}
+
+public extension TextView {
+    static let identifier = "fiori_textview_component"
 }
 
 public extension TextView {
@@ -23,6 +32,7 @@ public extension TextView {
     internal init(_ configuration: TextViewConfiguration, shouldApplyDefaultStyle: Bool) {
         self._text = configuration.$text
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -31,7 +41,7 @@ extension TextView: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(text: self.$text)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, text: self.$text)).typeErased
                 .transformEnvironment(\.textViewStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -49,7 +59,7 @@ private extension TextView {
     }
 
     func defaultStyle() -> some View {
-        TextView(.init(text: self.$text))
+        TextView(.init(componentIdentifier: self.componentIdentifier, text: self.$text))
             .shouldApplyDefaultStyle(false)
             .textViewStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/TextView/TextViewStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/TextView/TextViewStyle.generated.swift
@@ -22,5 +22,12 @@ struct AnyTextViewStyle: TextViewStyle {
 }
 
 public struct TextViewConfiguration {
+    public var componentIdentifier: String = "fiori_textview_component"
     @Binding public var text: String
+}
+
+extension TextViewConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Timeline/Timeline.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Timeline/Timeline.generated.swift
@@ -33,6 +33,8 @@ public struct Timeline {
 
     @Environment(\.timelineStyle) var style
 
+    var componentIdentifier: String = Timeline.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder timestamp: () -> any View = { EmptyView() },
@@ -46,21 +48,27 @@ public struct Timeline {
                 @ViewBuilder substatus: () -> any View = { EmptyView() },
                 @ViewBuilder subAttribute: () -> any View = { EmptyView() },
                 isPast: Bool = false,
-                isPresent: Bool = false)
+                isPresent: Bool = false,
+                componentIdentifier: String? = Timeline.identifier)
     {
-        self.timestamp = Timestamp(timestamp: timestamp)
-        self.secondaryTimestamp = SecondaryTimestamp(secondaryTimestamp: secondaryTimestamp)
-        self.timelineNode = TimelineNode(timelineNode: timelineNode)
-        self.icon = Icon(icon: icon)
-        self.title = Title(title: title)
-        self.subtitle = Subtitle(subtitle: subtitle)
-        self.attribute = Attribute(attribute: attribute)
-        self.status = Status(status: status)
-        self.substatus = Substatus(substatus: substatus)
-        self.subAttribute = SubAttribute(subAttribute: subAttribute)
+        self.timestamp = Timestamp(timestamp: timestamp, componentIdentifier: componentIdentifier)
+        self.secondaryTimestamp = SecondaryTimestamp(secondaryTimestamp: secondaryTimestamp, componentIdentifier: componentIdentifier)
+        self.timelineNode = TimelineNode(timelineNode: timelineNode, componentIdentifier: componentIdentifier)
+        self.icon = Icon(icon: icon, componentIdentifier: componentIdentifier)
+        self.title = Title(title: title, componentIdentifier: componentIdentifier)
+        self.subtitle = Subtitle(subtitle: subtitle, componentIdentifier: componentIdentifier)
+        self.attribute = Attribute(attribute: attribute, componentIdentifier: componentIdentifier)
+        self.status = Status(status: status, componentIdentifier: componentIdentifier)
+        self.substatus = Substatus(substatus: substatus, componentIdentifier: componentIdentifier)
+        self.subAttribute = SubAttribute(subAttribute: subAttribute, componentIdentifier: componentIdentifier)
         self.isPast = isPast
         self.isPresent = isPresent
+        self.componentIdentifier = componentIdentifier ?? Timeline.identifier
     }
+}
+
+public extension Timeline {
+    static let identifier = "fiori_timeline_component"
 }
 
 public extension Timeline {
@@ -100,6 +108,7 @@ public extension Timeline {
         self.isPast = configuration.isPast
         self.isPresent = configuration.isPresent
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -108,7 +117,7 @@ extension Timeline: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(timestamp: .init(self.timestamp), secondaryTimestamp: .init(self.secondaryTimestamp), timelineNode: .init(self.timelineNode), icon: .init(self.icon), title: .init(self.title), subtitle: .init(self.subtitle), attribute: .init(self.attribute), status: .init(self.status), substatus: .init(self.substatus), subAttribute: .init(self.subAttribute), isPast: self.isPast, isPresent: self.isPresent)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, timestamp: .init(self.timestamp), secondaryTimestamp: .init(self.secondaryTimestamp), timelineNode: .init(self.timelineNode), icon: .init(self.icon), title: .init(self.title), subtitle: .init(self.subtitle), attribute: .init(self.attribute), status: .init(self.status), substatus: .init(self.substatus), subAttribute: .init(self.subAttribute), isPast: self.isPast, isPresent: self.isPresent)).typeErased
                 .transformEnvironment(\.timelineStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -126,7 +135,7 @@ private extension Timeline {
     }
 
     func defaultStyle() -> some View {
-        Timeline(.init(timestamp: .init(self.timestamp), secondaryTimestamp: .init(self.secondaryTimestamp), timelineNode: .init(self.timelineNode), icon: .init(self.icon), title: .init(self.title), subtitle: .init(self.subtitle), attribute: .init(self.attribute), status: .init(self.status), substatus: .init(self.substatus), subAttribute: .init(self.subAttribute), isPast: self.isPast, isPresent: self.isPresent))
+        Timeline(.init(componentIdentifier: self.componentIdentifier, timestamp: .init(self.timestamp), secondaryTimestamp: .init(self.secondaryTimestamp), timelineNode: .init(self.timelineNode), icon: .init(self.icon), title: .init(self.title), subtitle: .init(self.subtitle), attribute: .init(self.attribute), status: .init(self.status), substatus: .init(self.substatus), subAttribute: .init(self.subAttribute), isPast: self.isPast, isPresent: self.isPresent))
             .shouldApplyDefaultStyle(false)
             .timelineStyle(TimelineFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Timeline/TimelineStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Timeline/TimelineStyle.generated.swift
@@ -22,6 +22,7 @@ struct AnyTimelineStyle: TimelineStyle {
 }
 
 public struct TimelineConfiguration {
+    public var componentIdentifier: String = "fiori_timeline_component"
     public let timestamp: Timestamp
     public let secondaryTimestamp: SecondaryTimestamp
     public let timelineNode: TimelineNode
@@ -45,6 +46,12 @@ public struct TimelineConfiguration {
     public typealias Status = ConfigurationViewWrapper
     public typealias Substatus = ConfigurationViewWrapper
     public typealias SubAttribute = ConfigurationViewWrapper
+}
+
+extension TimelineConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct TimelineFioriStyle: TimelineStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/TimelineMarker/TimelineMarker.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/TimelineMarker/TimelineMarker.generated.swift
@@ -32,6 +32,8 @@ public struct TimelineMarker {
 
     @Environment(\.timelineMarkerStyle) var style
 
+    var componentIdentifier: String = TimelineMarker.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder timestamp: () -> any View = { EmptyView() },
@@ -42,18 +44,24 @@ public struct TimelineMarker {
                 isPast: Bool = false,
                 isPresent: Bool = false,
                 showUpperVerticalLine: Bool = true,
-                showLowerVerticalLine: Bool = true)
+                showLowerVerticalLine: Bool = true,
+                componentIdentifier: String? = TimelineMarker.identifier)
     {
-        self.timestamp = Timestamp(timestamp: timestamp)
-        self.secondaryTimestamp = SecondaryTimestamp(secondaryTimestamp: secondaryTimestamp)
-        self.timelineNode = TimelineNode(timelineNode: timelineNode)
-        self.icon = Icon(icon: icon)
-        self.title = Title(title: title)
+        self.timestamp = Timestamp(timestamp: timestamp, componentIdentifier: componentIdentifier)
+        self.secondaryTimestamp = SecondaryTimestamp(secondaryTimestamp: secondaryTimestamp, componentIdentifier: componentIdentifier)
+        self.timelineNode = TimelineNode(timelineNode: timelineNode, componentIdentifier: componentIdentifier)
+        self.icon = Icon(icon: icon, componentIdentifier: componentIdentifier)
+        self.title = Title(title: title, componentIdentifier: componentIdentifier)
         self.isPast = isPast
         self.isPresent = isPresent
         self.showUpperVerticalLine = showUpperVerticalLine
         self.showLowerVerticalLine = showLowerVerticalLine
+        self.componentIdentifier = componentIdentifier ?? TimelineMarker.identifier
     }
+}
+
+public extension TimelineMarker {
+    static let identifier = "fiori_timelinemarker_component"
 }
 
 public extension TimelineMarker {
@@ -87,6 +95,7 @@ public extension TimelineMarker {
         self.showUpperVerticalLine = configuration.showUpperVerticalLine
         self.showLowerVerticalLine = configuration.showLowerVerticalLine
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -95,7 +104,7 @@ extension TimelineMarker: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(timestamp: .init(self.timestamp), secondaryTimestamp: .init(self.secondaryTimestamp), timelineNode: .init(self.timelineNode), icon: .init(self.icon), title: .init(self.title), isPast: self.isPast, isPresent: self.isPresent, showUpperVerticalLine: self.showUpperVerticalLine, showLowerVerticalLine: self.showLowerVerticalLine)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, timestamp: .init(self.timestamp), secondaryTimestamp: .init(self.secondaryTimestamp), timelineNode: .init(self.timelineNode), icon: .init(self.icon), title: .init(self.title), isPast: self.isPast, isPresent: self.isPresent, showUpperVerticalLine: self.showUpperVerticalLine, showLowerVerticalLine: self.showLowerVerticalLine)).typeErased
                 .transformEnvironment(\.timelineMarkerStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -113,7 +122,7 @@ private extension TimelineMarker {
     }
 
     func defaultStyle() -> some View {
-        TimelineMarker(.init(timestamp: .init(self.timestamp), secondaryTimestamp: .init(self.secondaryTimestamp), timelineNode: .init(self.timelineNode), icon: .init(self.icon), title: .init(self.title), isPast: self.isPast, isPresent: self.isPresent, showUpperVerticalLine: self.showUpperVerticalLine, showLowerVerticalLine: self.showLowerVerticalLine))
+        TimelineMarker(.init(componentIdentifier: self.componentIdentifier, timestamp: .init(self.timestamp), secondaryTimestamp: .init(self.secondaryTimestamp), timelineNode: .init(self.timelineNode), icon: .init(self.icon), title: .init(self.title), isPast: self.isPast, isPresent: self.isPresent, showUpperVerticalLine: self.showUpperVerticalLine, showLowerVerticalLine: self.showLowerVerticalLine))
             .shouldApplyDefaultStyle(false)
             .timelineMarkerStyle(TimelineMarkerFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/TimelineMarker/TimelineMarkerStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/TimelineMarker/TimelineMarkerStyle.generated.swift
@@ -22,6 +22,7 @@ struct AnyTimelineMarkerStyle: TimelineMarkerStyle {
 }
 
 public struct TimelineMarkerConfiguration {
+    public var componentIdentifier: String = "fiori_timelinemarker_component"
     public let timestamp: Timestamp
     public let secondaryTimestamp: SecondaryTimestamp
     public let timelineNode: TimelineNode
@@ -37,6 +38,12 @@ public struct TimelineMarkerConfiguration {
     public typealias TimelineNode = ConfigurationViewWrapper
     public typealias Icon = ConfigurationViewWrapper
     public typealias Title = ConfigurationViewWrapper
+}
+
+extension TimelineMarkerConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct TimelineMarkerFioriStyle: TimelineMarkerStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/TimelineNode/TimelineNode.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/TimelineNode/TimelineNode.generated.swift
@@ -8,11 +8,20 @@ public struct TimelineNode {
 
     @Environment(\.timelineNodeStyle) var style
 
+    var componentIdentifier: String = TimelineNode.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder timelineNode: () -> any View) {
+    public init(@ViewBuilder timelineNode: () -> any View,
+                componentIdentifier: String? = TimelineNode.identifier)
+    {
         self.timelineNode = timelineNode()
+        self.componentIdentifier = componentIdentifier ?? TimelineNode.identifier
     }
+}
+
+public extension TimelineNode {
+    static let identifier = "fiori_timelinenode_component"
 }
 
 public extension TimelineNode {
@@ -29,6 +38,7 @@ public extension TimelineNode {
     internal init(_ configuration: TimelineNodeConfiguration, shouldApplyDefaultStyle: Bool) {
         self.timelineNode = configuration.timelineNode
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension TimelineNode: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(timelineNode: .init(self.timelineNode))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, timelineNode: .init(self.timelineNode))).typeErased
                 .transformEnvironment(\.timelineNodeStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension TimelineNode {
     }
 
     func defaultStyle() -> some View {
-        TimelineNode(.init(timelineNode: .init(self.timelineNode)))
+        TimelineNode(.init(componentIdentifier: self.componentIdentifier, timelineNode: .init(self.timelineNode)))
             .shouldApplyDefaultStyle(false)
             .timelineNodeStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/TimelineNode/TimelineNodeStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/TimelineNode/TimelineNodeStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyTimelineNodeStyle: TimelineNodeStyle {
 }
 
 public struct TimelineNodeConfiguration {
+    public var componentIdentifier: String = "fiori_timelinenode_component"
     public let timelineNode: TimelineNode
 
     public typealias TimelineNode = ConfigurationViewWrapper
+}
+
+extension TimelineNodeConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/TimelineNowIndicator/TimelineNowIndicator.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/TimelineNowIndicator/TimelineNowIndicator.generated.swift
@@ -14,11 +14,20 @@ public struct TimelineNowIndicator {
 
     @Environment(\.timelineNowIndicatorStyle) var style
 
+    var componentIdentifier: String = TimelineNowIndicator.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder nowIndicatorNode: () -> any View = { Image(systemName: "circle.fill") }) {
-        self.nowIndicatorNode = NowIndicatorNode(nowIndicatorNode: nowIndicatorNode)
+    public init(@ViewBuilder nowIndicatorNode: () -> any View = { Image(systemName: "circle.fill") },
+                componentIdentifier: String? = TimelineNowIndicator.identifier)
+    {
+        self.nowIndicatorNode = NowIndicatorNode(nowIndicatorNode: nowIndicatorNode, componentIdentifier: componentIdentifier)
+        self.componentIdentifier = componentIdentifier ?? TimelineNowIndicator.identifier
     }
+}
+
+public extension TimelineNowIndicator {
+    static let identifier = "fiori_timelinenowindicator_component"
 }
 
 public extension TimelineNowIndicator {
@@ -29,6 +38,7 @@ public extension TimelineNowIndicator {
     internal init(_ configuration: TimelineNowIndicatorConfiguration, shouldApplyDefaultStyle: Bool) {
         self.nowIndicatorNode = configuration.nowIndicatorNode
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension TimelineNowIndicator: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(nowIndicatorNode: .init(self.nowIndicatorNode))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, nowIndicatorNode: .init(self.nowIndicatorNode))).typeErased
                 .transformEnvironment(\.timelineNowIndicatorStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension TimelineNowIndicator {
     }
 
     func defaultStyle() -> some View {
-        TimelineNowIndicator(.init(nowIndicatorNode: .init(self.nowIndicatorNode)))
+        TimelineNowIndicator(.init(componentIdentifier: self.componentIdentifier, nowIndicatorNode: .init(self.nowIndicatorNode)))
             .shouldApplyDefaultStyle(false)
             .timelineNowIndicatorStyle(TimelineNowIndicatorFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/TimelineNowIndicator/TimelineNowIndicatorStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/TimelineNowIndicator/TimelineNowIndicatorStyle.generated.swift
@@ -22,9 +22,16 @@ struct AnyTimelineNowIndicatorStyle: TimelineNowIndicatorStyle {
 }
 
 public struct TimelineNowIndicatorConfiguration {
+    public var componentIdentifier: String = "fiori_timelinenowindicator_component"
     public let nowIndicatorNode: NowIndicatorNode
 
     public typealias NowIndicatorNode = ConfigurationViewWrapper
+}
+
+extension TimelineNowIndicatorConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct TimelineNowIndicatorFioriStyle: TimelineNowIndicatorStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/TimelinePreview/TimelinePreview.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/TimelinePreview/TimelinePreview.generated.swift
@@ -49,16 +49,24 @@ public struct TimelinePreview {
 
     @Environment(\.timelinePreviewStyle) var style
 
+    var componentIdentifier: String = TimelinePreview.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder optionalTitle: () -> any View = { EmptyView() },
                 @ViewBuilder action: () -> any View = { EmptyView() },
-                items: Binding<[any TimelinePreviewItemModel]>)
+                items: Binding<[any TimelinePreviewItemModel]>,
+                componentIdentifier: String? = TimelinePreview.identifier)
     {
-        self.optionalTitle = OptionalTitle(optionalTitle: optionalTitle)
-        self.action = Action(action: action)
+        self.optionalTitle = OptionalTitle(optionalTitle: optionalTitle, componentIdentifier: componentIdentifier)
+        self.action = Action(action: action, componentIdentifier: componentIdentifier)
         self._items = items
+        self.componentIdentifier = componentIdentifier ?? TimelinePreview.identifier
     }
+}
+
+public extension TimelinePreview {
+    static let identifier = "fiori_timelinepreview_component"
 }
 
 public extension TimelinePreview {
@@ -80,6 +88,7 @@ public extension TimelinePreview {
         self.action = configuration.action
         self._items = configuration.$items
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -88,7 +97,7 @@ extension TimelinePreview: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(optionalTitle: .init(self.optionalTitle), action: .init(self.action), items: self.$items)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, optionalTitle: .init(self.optionalTitle), action: .init(self.action), items: self.$items)).typeErased
                 .transformEnvironment(\.timelinePreviewStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -106,7 +115,7 @@ private extension TimelinePreview {
     }
 
     func defaultStyle() -> some View {
-        TimelinePreview(.init(optionalTitle: .init(self.optionalTitle), action: .init(self.action), items: self.$items))
+        TimelinePreview(.init(componentIdentifier: self.componentIdentifier, optionalTitle: .init(self.optionalTitle), action: .init(self.action), items: self.$items))
             .shouldApplyDefaultStyle(false)
             .timelinePreviewStyle(TimelinePreviewFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/TimelinePreview/TimelinePreviewStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/TimelinePreview/TimelinePreviewStyle.generated.swift
@@ -22,12 +22,19 @@ struct AnyTimelinePreviewStyle: TimelinePreviewStyle {
 }
 
 public struct TimelinePreviewConfiguration {
+    public var componentIdentifier: String = "fiori_timelinepreview_component"
     public let optionalTitle: OptionalTitle
     public let action: Action
     @Binding public var items: [any TimelinePreviewItemModel]
 
     public typealias OptionalTitle = ConfigurationViewWrapper
     public typealias Action = ConfigurationViewWrapper
+}
+
+extension TimelinePreviewConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct TimelinePreviewFioriStyle: TimelinePreviewStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/TimelinePreviewItem/TimelinePreviewItem.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/TimelinePreviewItem/TimelinePreviewItem.generated.swift
@@ -16,6 +16,8 @@ public struct TimelinePreviewItem {
 
     @Environment(\.timelinePreviewItemStyle) var style
 
+    var componentIdentifier: String = TimelinePreviewItem.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder title: () -> any View,
@@ -23,15 +25,21 @@ public struct TimelinePreviewItem {
                 @ViewBuilder timelineNode: () -> any View,
                 @ViewBuilder timestamp: () -> any View = { EmptyView() },
                 isFuture: Bool = false,
-                nodeType: TimelineNodeType)
+                nodeType: TimelineNodeType,
+                componentIdentifier: String? = TimelinePreviewItem.identifier)
     {
-        self.title = Title(title: title)
-        self.icon = Icon(icon: icon)
-        self.timelineNode = TimelineNode(timelineNode: timelineNode)
-        self.timestamp = Timestamp(timestamp: timestamp)
+        self.title = Title(title: title, componentIdentifier: componentIdentifier)
+        self.icon = Icon(icon: icon, componentIdentifier: componentIdentifier)
+        self.timelineNode = TimelineNode(timelineNode: timelineNode, componentIdentifier: componentIdentifier)
+        self.timestamp = Timestamp(timestamp: timestamp, componentIdentifier: componentIdentifier)
         self.isFuture = isFuture
         self.nodeType = nodeType
+        self.componentIdentifier = componentIdentifier ?? TimelinePreviewItem.identifier
     }
+}
+
+public extension TimelinePreviewItem {
+    static let identifier = "fiori_timelinepreviewitem_component"
 }
 
 public extension TimelinePreviewItem {
@@ -59,6 +67,7 @@ public extension TimelinePreviewItem {
         self.isFuture = configuration.isFuture
         self.nodeType = configuration.nodeType
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -67,7 +76,7 @@ extension TimelinePreviewItem: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(title: .init(self.title), icon: .init(self.icon), timelineNode: .init(self.timelineNode), timestamp: .init(self.timestamp), isFuture: self.isFuture, nodeType: self.nodeType)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, title: .init(self.title), icon: .init(self.icon), timelineNode: .init(self.timelineNode), timestamp: .init(self.timestamp), isFuture: self.isFuture, nodeType: self.nodeType)).typeErased
                 .transformEnvironment(\.timelinePreviewItemStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -85,7 +94,7 @@ private extension TimelinePreviewItem {
     }
 
     func defaultStyle() -> some View {
-        TimelinePreviewItem(.init(title: .init(self.title), icon: .init(self.icon), timelineNode: .init(self.timelineNode), timestamp: .init(self.timestamp), isFuture: self.isFuture, nodeType: self.nodeType))
+        TimelinePreviewItem(.init(componentIdentifier: self.componentIdentifier, title: .init(self.title), icon: .init(self.icon), timelineNode: .init(self.timelineNode), timestamp: .init(self.timestamp), isFuture: self.isFuture, nodeType: self.nodeType))
             .shouldApplyDefaultStyle(false)
             .timelinePreviewItemStyle(TimelinePreviewItemFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/TimelinePreviewItem/TimelinePreviewItemStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/TimelinePreviewItem/TimelinePreviewItemStyle.generated.swift
@@ -22,6 +22,7 @@ struct AnyTimelinePreviewItemStyle: TimelinePreviewItemStyle {
 }
 
 public struct TimelinePreviewItemConfiguration {
+    public var componentIdentifier: String = "fiori_timelinepreviewitem_component"
     public let title: Title
     public let icon: Icon
     public let timelineNode: TimelineNode
@@ -33,6 +34,12 @@ public struct TimelinePreviewItemConfiguration {
     public typealias Icon = ConfigurationViewWrapper
     public typealias TimelineNode = ConfigurationViewWrapper
     public typealias Timestamp = ConfigurationViewWrapper
+}
+
+extension TimelinePreviewItemConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct TimelinePreviewItemFioriStyle: TimelinePreviewItemStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Timestamp/Timestamp.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Timestamp/Timestamp.generated.swift
@@ -8,11 +8,20 @@ public struct Timestamp {
 
     @Environment(\.timestampStyle) var style
 
+    var componentIdentifier: String = Timestamp.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder timestamp: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder timestamp: () -> any View = { EmptyView() },
+                componentIdentifier: String? = Timestamp.identifier)
+    {
         self.timestamp = timestamp()
+        self.componentIdentifier = componentIdentifier ?? Timestamp.identifier
     }
+}
+
+public extension Timestamp {
+    static let identifier = "fiori_timestamp_component"
 }
 
 public extension Timestamp {
@@ -29,6 +38,7 @@ public extension Timestamp {
     internal init(_ configuration: TimestampConfiguration, shouldApplyDefaultStyle: Bool) {
         self.timestamp = configuration.timestamp
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension Timestamp: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(timestamp: .init(self.timestamp))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, timestamp: .init(self.timestamp))).typeErased
                 .transformEnvironment(\.timestampStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension Timestamp {
     }
 
     func defaultStyle() -> some View {
-        Timestamp(.init(timestamp: .init(self.timestamp)))
+        Timestamp(.init(componentIdentifier: self.componentIdentifier, timestamp: .init(self.timestamp)))
             .shouldApplyDefaultStyle(false)
             .timestampStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Timestamp/TimestampStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Timestamp/TimestampStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyTimestampStyle: TimestampStyle {
 }
 
 public struct TimestampConfiguration {
+    public var componentIdentifier: String = "fiori_timestamp_component"
     public let timestamp: Timestamp
 
     public typealias Timestamp = ConfigurationViewWrapper
+}
+
+extension TimestampConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Title/Title.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Title/Title.generated.swift
@@ -8,11 +8,20 @@ public struct Title {
 
     @Environment(\.titleStyle) var style
 
+    var componentIdentifier: String = Title.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder title: () -> any View) {
+    public init(@ViewBuilder title: () -> any View,
+                componentIdentifier: String? = Title.identifier)
+    {
         self.title = title()
+        self.componentIdentifier = componentIdentifier ?? Title.identifier
     }
+}
+
+public extension Title {
+    static let identifier = "fiori_title_component"
 }
 
 public extension Title {
@@ -29,6 +38,7 @@ public extension Title {
     internal init(_ configuration: TitleConfiguration, shouldApplyDefaultStyle: Bool) {
         self.title = configuration.title
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension Title: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(title: .init(self.title))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, title: .init(self.title))).typeErased
                 .transformEnvironment(\.titleStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension Title {
     }
 
     func defaultStyle() -> some View {
-        Title(.init(title: .init(self.title)))
+        Title(.init(componentIdentifier: self.componentIdentifier, title: .init(self.title)))
             .shouldApplyDefaultStyle(false)
             .titleStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Title/TitleStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Title/TitleStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyTitleStyle: TitleStyle {
 }
 
 public struct TitleConfiguration {
+    public var componentIdentifier: String = "fiori_title_component"
     public let title: Title
 
     public typealias Title = ConfigurationViewWrapper
+}
+
+extension TitleConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/TitleFormView/TitleFormView.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/TitleFormView/TitleFormView.generated.swift
@@ -27,6 +27,8 @@ public struct TitleFormView {
 
     @Environment(\.titleFormViewStyle) var style
 
+    var componentIdentifier: String = TitleFormView.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(text: Binding<String>,
@@ -39,10 +41,11 @@ public struct TitleFormView {
                 isCharCountEnabled: Bool = false,
                 allowsBeyondLimit: Bool = false,
                 charCountReachLimitMessage: String? = nil,
-                charCountBeyondLimitMsg: String? = nil)
+                charCountBeyondLimitMsg: String? = nil,
+                componentIdentifier: String? = TitleFormView.identifier)
     {
         self._text = text
-        self.placeholder = Placeholder(placeholder: placeholder)
+        self.placeholder = Placeholder(placeholder: placeholder, componentIdentifier: componentIdentifier)
         self.controlState = controlState
         self.errorMessage = errorMessage
         self.maxTextLength = maxTextLength
@@ -52,7 +55,12 @@ public struct TitleFormView {
         self.allowsBeyondLimit = allowsBeyondLimit
         self.charCountReachLimitMessage = charCountReachLimitMessage
         self.charCountBeyondLimitMsg = charCountBeyondLimitMsg
+        self.componentIdentifier = componentIdentifier ?? TitleFormView.identifier
     }
+}
+
+public extension TitleFormView {
+    static let identifier = "fiori_titleformview_component"
 }
 
 public extension TitleFormView {
@@ -90,6 +98,7 @@ public extension TitleFormView {
         self.charCountReachLimitMessage = configuration.charCountReachLimitMessage
         self.charCountBeyondLimitMsg = configuration.charCountBeyondLimitMsg
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -98,7 +107,7 @@ extension TitleFormView: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(text: self.$text, placeholder: .init(self.placeholder), controlState: self.controlState, errorMessage: self.errorMessage, maxTextLength: self.maxTextLength, hintText: self.hintText, hidesReadOnlyHint: self.hidesReadOnlyHint, isCharCountEnabled: self.isCharCountEnabled, allowsBeyondLimit: self.allowsBeyondLimit, charCountReachLimitMessage: self.charCountReachLimitMessage, charCountBeyondLimitMsg: self.charCountBeyondLimitMsg)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, text: self.$text, placeholder: .init(self.placeholder), controlState: self.controlState, errorMessage: self.errorMessage, maxTextLength: self.maxTextLength, hintText: self.hintText, hidesReadOnlyHint: self.hidesReadOnlyHint, isCharCountEnabled: self.isCharCountEnabled, allowsBeyondLimit: self.allowsBeyondLimit, charCountReachLimitMessage: self.charCountReachLimitMessage, charCountBeyondLimitMsg: self.charCountBeyondLimitMsg)).typeErased
                 .transformEnvironment(\.titleFormViewStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -116,7 +125,7 @@ private extension TitleFormView {
     }
 
     func defaultStyle() -> some View {
-        TitleFormView(.init(text: self.$text, placeholder: .init(self.placeholder), controlState: self.controlState, errorMessage: self.errorMessage, maxTextLength: self.maxTextLength, hintText: self.hintText, hidesReadOnlyHint: self.hidesReadOnlyHint, isCharCountEnabled: self.isCharCountEnabled, allowsBeyondLimit: self.allowsBeyondLimit, charCountReachLimitMessage: self.charCountReachLimitMessage, charCountBeyondLimitMsg: self.charCountBeyondLimitMsg))
+        TitleFormView(.init(componentIdentifier: self.componentIdentifier, text: self.$text, placeholder: .init(self.placeholder), controlState: self.controlState, errorMessage: self.errorMessage, maxTextLength: self.maxTextLength, hintText: self.hintText, hidesReadOnlyHint: self.hidesReadOnlyHint, isCharCountEnabled: self.isCharCountEnabled, allowsBeyondLimit: self.allowsBeyondLimit, charCountReachLimitMessage: self.charCountReachLimitMessage, charCountBeyondLimitMsg: self.charCountBeyondLimitMsg))
             .shouldApplyDefaultStyle(false)
             .titleFormViewStyle(TitleFormViewFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/TitleFormView/TitleFormViewStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/TitleFormView/TitleFormViewStyle.generated.swift
@@ -22,6 +22,7 @@ struct AnyTitleFormViewStyle: TitleFormViewStyle {
 }
 
 public struct TitleFormViewConfiguration {
+    public var componentIdentifier: String = "fiori_titleformview_component"
     @Binding public var text: String
     public let placeholder: Placeholder
     public let controlState: ControlState
@@ -35,6 +36,12 @@ public struct TitleFormViewConfiguration {
     public let charCountBeyondLimitMsg: String?
 
     public typealias Placeholder = ConfigurationViewWrapper
+}
+
+extension TitleFormViewConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct TitleFormViewFioriStyle: TitleFormViewStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/ToastMessage/ToastMessage.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/ToastMessage/ToastMessage.generated.swift
@@ -11,16 +11,24 @@ public struct ToastMessage {
 
     @Environment(\.toastMessageStyle) var style
 
+    var componentIdentifier: String = ToastMessage.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder icon: () -> any View = { EmptyView() },
                 @ViewBuilder title: () -> any View,
-                duration: Double = 1)
+                duration: Double = 1,
+                componentIdentifier: String? = ToastMessage.identifier)
     {
-        self.icon = Icon(icon: icon)
-        self.title = Title(title: title)
+        self.icon = Icon(icon: icon, componentIdentifier: componentIdentifier)
+        self.title = Title(title: title, componentIdentifier: componentIdentifier)
         self.duration = duration
+        self.componentIdentifier = componentIdentifier ?? ToastMessage.identifier
     }
+}
+
+public extension ToastMessage {
+    static let identifier = "fiori_toastmessage_component"
 }
 
 public extension ToastMessage {
@@ -42,6 +50,7 @@ public extension ToastMessage {
         self.title = configuration.title
         self.duration = configuration.duration
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -50,7 +59,7 @@ extension ToastMessage: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(icon: .init(self.icon), title: .init(self.title), duration: self.duration)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, icon: .init(self.icon), title: .init(self.title), duration: self.duration)).typeErased
                 .transformEnvironment(\.toastMessageStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -68,7 +77,7 @@ private extension ToastMessage {
     }
 
     func defaultStyle() -> some View {
-        ToastMessage(.init(icon: .init(self.icon), title: .init(self.title), duration: self.duration))
+        ToastMessage(.init(componentIdentifier: self.componentIdentifier, icon: .init(self.icon), title: .init(self.title), duration: self.duration))
             .shouldApplyDefaultStyle(false)
             .toastMessageStyle(ToastMessageFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/ToastMessage/ToastMessageStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/ToastMessage/ToastMessageStyle.generated.swift
@@ -22,12 +22,19 @@ struct AnyToastMessageStyle: ToastMessageStyle {
 }
 
 public struct ToastMessageConfiguration {
+    public var componentIdentifier: String = "fiori_toastmessage_component"
     public let icon: Icon
     public let title: Title
     public let duration: Double
 
     public typealias Icon = ConfigurationViewWrapper
     public typealias Title = ConfigurationViewWrapper
+}
+
+extension ToastMessageConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct ToastMessageFioriStyle: ToastMessageStyle {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/TopDivider/TopDivider.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/TopDivider/TopDivider.generated.swift
@@ -8,11 +8,20 @@ public struct TopDivider {
 
     @Environment(\.topDividerStyle) var style
 
+    var componentIdentifier: String = TopDivider.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder topDivider: () -> any View = { Rectangle().fill(Color.clear) }) {
+    public init(@ViewBuilder topDivider: () -> any View = { Rectangle().fill(Color.clear) },
+                componentIdentifier: String? = TopDivider.identifier)
+    {
         self.topDivider = topDivider()
+        self.componentIdentifier = componentIdentifier ?? TopDivider.identifier
     }
+}
+
+public extension TopDivider {
+    static let identifier = "fiori_topdivider_component"
 }
 
 public extension TopDivider {
@@ -23,6 +32,7 @@ public extension TopDivider {
     internal init(_ configuration: TopDividerConfiguration, shouldApplyDefaultStyle: Bool) {
         self.topDivider = configuration.topDivider
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -31,7 +41,7 @@ extension TopDivider: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(topDivider: .init(self.topDivider))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, topDivider: .init(self.topDivider))).typeErased
                 .transformEnvironment(\.topDividerStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -49,7 +59,7 @@ private extension TopDivider {
     }
 
     func defaultStyle() -> some View {
-        TopDivider(.init(topDivider: .init(self.topDivider)))
+        TopDivider(.init(componentIdentifier: self.componentIdentifier, topDivider: .init(self.topDivider)))
             .shouldApplyDefaultStyle(false)
             .topDividerStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/TopDivider/TopDividerStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/TopDivider/TopDividerStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyTopDividerStyle: TopDividerStyle {
 }
 
 public struct TopDividerConfiguration {
+    public var componentIdentifier: String = "fiori_topdivider_component"
     public let topDivider: TopDivider
 
     public typealias TopDivider = ConfigurationViewWrapper
+}
+
+extension TopDividerConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/TrailingAccessory/TrailingAccessory.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/TrailingAccessory/TrailingAccessory.generated.swift
@@ -8,11 +8,20 @@ public struct TrailingAccessory {
 
     @Environment(\.trailingAccessoryStyle) var style
 
+    var componentIdentifier: String = TrailingAccessory.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder trailingAccessory: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder trailingAccessory: () -> any View = { EmptyView() },
+                componentIdentifier: String? = TrailingAccessory.identifier)
+    {
         self.trailingAccessory = trailingAccessory()
+        self.componentIdentifier = componentIdentifier ?? TrailingAccessory.identifier
     }
+}
+
+public extension TrailingAccessory {
+    static let identifier = "fiori_trailingaccessory_component"
 }
 
 public extension TrailingAccessory {
@@ -23,6 +32,7 @@ public extension TrailingAccessory {
     internal init(_ configuration: TrailingAccessoryConfiguration, shouldApplyDefaultStyle: Bool) {
         self.trailingAccessory = configuration.trailingAccessory
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -31,7 +41,7 @@ extension TrailingAccessory: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(trailingAccessory: .init(self.trailingAccessory))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, trailingAccessory: .init(self.trailingAccessory))).typeErased
                 .transformEnvironment(\.trailingAccessoryStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -49,7 +59,7 @@ private extension TrailingAccessory {
     }
 
     func defaultStyle() -> some View {
-        TrailingAccessory(.init(trailingAccessory: .init(self.trailingAccessory)))
+        TrailingAccessory(.init(componentIdentifier: self.componentIdentifier, trailingAccessory: .init(self.trailingAccessory)))
             .shouldApplyDefaultStyle(false)
             .trailingAccessoryStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/TrailingAccessory/TrailingAccessoryStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/TrailingAccessory/TrailingAccessoryStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyTrailingAccessoryStyle: TrailingAccessoryStyle {
 }
 
 public struct TrailingAccessoryConfiguration {
+    public var componentIdentifier: String = "fiori_trailingaccessory_component"
     public let trailingAccessory: TrailingAccessory
 
     public typealias TrailingAccessory = ConfigurationViewWrapper
+}
+
+extension TrailingAccessoryConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/UpperThumb/UpperThumb.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/UpperThumb/UpperThumb.generated.swift
@@ -8,11 +8,20 @@ public struct UpperThumb {
 
     @Environment(\.upperThumbStyle) var style
 
+    var componentIdentifier: String = UpperThumb.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder upperThumb: () -> any View) {
+    public init(@ViewBuilder upperThumb: () -> any View,
+                componentIdentifier: String? = UpperThumb.identifier)
+    {
         self.upperThumb = upperThumb()
+        self.componentIdentifier = componentIdentifier ?? UpperThumb.identifier
     }
+}
+
+public extension UpperThumb {
+    static let identifier = "fiori_upperthumb_component"
 }
 
 public extension UpperThumb {
@@ -29,6 +38,7 @@ public extension UpperThumb {
     internal init(_ configuration: UpperThumbConfiguration, shouldApplyDefaultStyle: Bool) {
         self.upperThumb = configuration.upperThumb
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension UpperThumb: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(upperThumb: .init(self.upperThumb))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, upperThumb: .init(self.upperThumb))).typeErased
                 .transformEnvironment(\.upperThumbStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension UpperThumb {
     }
 
     func defaultStyle() -> some View {
-        UpperThumb(.init(upperThumb: .init(self.upperThumb)))
+        UpperThumb(.init(componentIdentifier: self.componentIdentifier, upperThumb: .init(self.upperThumb)))
             .shouldApplyDefaultStyle(false)
             .upperThumbStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/UpperThumb/UpperThumbStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/UpperThumb/UpperThumbStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyUpperThumbStyle: UpperThumbStyle {
 }
 
 public struct UpperThumbConfiguration {
+    public var componentIdentifier: String = "fiori_upperthumb_component"
     public let upperThumb: UpperThumb
 
     public typealias UpperThumb = ConfigurationViewWrapper
+}
+
+extension UpperThumbConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Value/Value.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Value/Value.generated.swift
@@ -8,11 +8,20 @@ public struct Value {
 
     @Environment(\.valueStyle) var style
 
+    var componentIdentifier: String = Value.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder value: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder value: () -> any View = { EmptyView() },
+                componentIdentifier: String? = Value.identifier)
+    {
         self.value = value()
+        self.componentIdentifier = componentIdentifier ?? Value.identifier
     }
+}
+
+public extension Value {
+    static let identifier = "fiori_value_component"
 }
 
 public extension Value {
@@ -29,6 +38,7 @@ public extension Value {
     internal init(_ configuration: ValueConfiguration, shouldApplyDefaultStyle: Bool) {
         self.value = configuration.value
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension Value: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(value: .init(self.value))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, value: .init(self.value))).typeErased
                 .transformEnvironment(\.valueStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension Value {
     }
 
     func defaultStyle() -> some View {
-        Value(.init(value: .init(self.value)))
+        Value(.init(componentIdentifier: self.componentIdentifier, value: .init(self.value)))
             .shouldApplyDefaultStyle(false)
             .valueStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Value/ValueStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Value/ValueStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyValueStyle: ValueStyle {
 }
 
 public struct ValueConfiguration {
+    public var componentIdentifier: String = "fiori_value_component"
     public let value: Value
 
     public typealias Value = ConfigurationViewWrapper
+}
+
+extension ValueConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/ValueLabel/ValueLabel.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/ValueLabel/ValueLabel.generated.swift
@@ -8,11 +8,20 @@ public struct ValueLabel {
 
     @Environment(\.valueLabelStyle) var style
 
+    var componentIdentifier: String = ValueLabel.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
-    public init(@ViewBuilder valueLabel: () -> any View = { EmptyView() }) {
+    public init(@ViewBuilder valueLabel: () -> any View = { EmptyView() },
+                componentIdentifier: String? = ValueLabel.identifier)
+    {
         self.valueLabel = valueLabel()
+        self.componentIdentifier = componentIdentifier ?? ValueLabel.identifier
     }
+}
+
+public extension ValueLabel {
+    static let identifier = "fiori_valuelabel_component"
 }
 
 public extension ValueLabel {
@@ -29,6 +38,7 @@ public extension ValueLabel {
     internal init(_ configuration: ValueLabelConfiguration, shouldApplyDefaultStyle: Bool) {
         self.valueLabel = configuration.valueLabel
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -37,7 +47,7 @@ extension ValueLabel: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(valueLabel: .init(self.valueLabel))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, valueLabel: .init(self.valueLabel))).typeErased
                 .transformEnvironment(\.valueLabelStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -55,7 +65,7 @@ private extension ValueLabel {
     }
 
     func defaultStyle() -> some View {
-        ValueLabel(.init(valueLabel: .init(self.valueLabel)))
+        ValueLabel(.init(componentIdentifier: self.componentIdentifier, valueLabel: .init(self.valueLabel)))
             .shouldApplyDefaultStyle(false)
             .valueLabelStyle(.fiori)
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/ValueLabel/ValueLabelStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/ValueLabel/ValueLabelStyle.generated.swift
@@ -22,7 +22,14 @@ struct AnyValueLabelStyle: ValueLabelStyle {
 }
 
 public struct ValueLabelConfiguration {
+    public var componentIdentifier: String = "fiori_valuelabel_component"
     public let valueLabel: ValueLabel
 
     public typealias ValueLabel = ConfigurationViewWrapper
+}
+
+extension ValueLabelConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/ValuePicker/ValuePicker.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/ValuePicker/ValuePicker.generated.swift
@@ -30,6 +30,8 @@ public struct ValuePicker {
 
     @Environment(\.valuePickerStyle) var style
 
+    var componentIdentifier: String = ValuePicker.identifier
+
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder title: () -> any View,
@@ -40,18 +42,24 @@ public struct ValuePicker {
                 selectedIndex: Binding<Int>,
                 isTrackingLiveChanges: Bool = true,
                 alwaysShowPicker: Bool = false,
-                controlState: ControlState = .normal)
+                controlState: ControlState = .normal,
+                componentIdentifier: String? = ValuePicker.identifier)
     {
-        self.title = Title(title: title)
-        self.valueLabel = ValueLabel(valueLabel: valueLabel)
-        self.mandatoryFieldIndicator = MandatoryFieldIndicator(mandatoryFieldIndicator: mandatoryFieldIndicator)
+        self.title = Title(title: title, componentIdentifier: componentIdentifier)
+        self.valueLabel = ValueLabel(valueLabel: valueLabel, componentIdentifier: componentIdentifier)
+        self.mandatoryFieldIndicator = MandatoryFieldIndicator(mandatoryFieldIndicator: mandatoryFieldIndicator, componentIdentifier: componentIdentifier)
         self.isRequired = isRequired
         self.options = options
         self._selectedIndex = selectedIndex
         self.isTrackingLiveChanges = isTrackingLiveChanges
         self.alwaysShowPicker = alwaysShowPicker
         self.controlState = controlState
+        self.componentIdentifier = componentIdentifier ?? ValuePicker.identifier
     }
+}
+
+public extension ValuePicker {
+    static let identifier = "fiori_valuepicker_component"
 }
 
 public extension ValuePicker {
@@ -85,6 +93,7 @@ public extension ValuePicker {
         self.alwaysShowPicker = configuration.alwaysShowPicker
         self.controlState = configuration.controlState
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
+        self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
@@ -93,7 +102,7 @@ extension ValuePicker: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(title: .init(self.title), valueLabel: .init(self.valueLabel), mandatoryFieldIndicator: .init(self.mandatoryFieldIndicator), isRequired: self.isRequired, options: self.options, selectedIndex: self.$selectedIndex, isTrackingLiveChanges: self.isTrackingLiveChanges, alwaysShowPicker: self.alwaysShowPicker, controlState: self.controlState)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, title: .init(self.title), valueLabel: .init(self.valueLabel), mandatoryFieldIndicator: .init(self.mandatoryFieldIndicator), isRequired: self.isRequired, options: self.options, selectedIndex: self.$selectedIndex, isTrackingLiveChanges: self.isTrackingLiveChanges, alwaysShowPicker: self.alwaysShowPicker, controlState: self.controlState)).typeErased
                 .transformEnvironment(\.valuePickerStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -111,7 +120,7 @@ private extension ValuePicker {
     }
 
     func defaultStyle() -> some View {
-        ValuePicker(.init(title: .init(self.title), valueLabel: .init(self.valueLabel), mandatoryFieldIndicator: .init(self.mandatoryFieldIndicator), isRequired: self.isRequired, options: self.options, selectedIndex: self.$selectedIndex, isTrackingLiveChanges: self.isTrackingLiveChanges, alwaysShowPicker: self.alwaysShowPicker, controlState: self.controlState))
+        ValuePicker(.init(componentIdentifier: self.componentIdentifier, title: .init(self.title), valueLabel: .init(self.valueLabel), mandatoryFieldIndicator: .init(self.mandatoryFieldIndicator), isRequired: self.isRequired, options: self.options, selectedIndex: self.$selectedIndex, isTrackingLiveChanges: self.isTrackingLiveChanges, alwaysShowPicker: self.alwaysShowPicker, controlState: self.controlState))
             .shouldApplyDefaultStyle(false)
             .valuePickerStyle(ValuePickerFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/ValuePicker/ValuePickerStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/ValuePicker/ValuePickerStyle.generated.swift
@@ -22,6 +22,7 @@ struct AnyValuePickerStyle: ValuePickerStyle {
 }
 
 public struct ValuePickerConfiguration {
+    public var componentIdentifier: String = "fiori_valuepicker_component"
     public let title: Title
     public let valueLabel: ValueLabel
     public let mandatoryFieldIndicator: MandatoryFieldIndicator
@@ -35,6 +36,12 @@ public struct ValuePickerConfiguration {
     public typealias Title = ConfigurationViewWrapper
     public typealias ValueLabel = ConfigurationViewWrapper
     public typealias MandatoryFieldIndicator = ConfigurationViewWrapper
+}
+
+extension ValuePickerConfiguration {
+    func isDirectChild(_ componentIdentifier: String) -> Bool {
+        componentIdentifier == self.componentIdentifier
+    }
 }
 
 public struct ValuePickerFioriStyle: ValuePickerStyle {

--- a/sourcery/.lib/Sources/utils/ForStyleableComponent/Array<Variable>+Extension.swift
+++ b/sourcery/.lib/Sources/utils/ForStyleableComponent/Array<Variable>+Extension.swift
@@ -64,7 +64,7 @@ extension [Variable] {
                 if !variable.closureParameters.isEmpty {
                     return "self.\(name) = \(name)"
                 } else {
-                    let assignment = isBaseComponent || !variable.isStyleable ? "\(name)()" : "\(name.capitalizingFirst())(\(name): \(name))"
+                    let assignment = isBaseComponent || !variable.isStyleable ? "\(name)()" : "\(name.capitalizingFirst())(\(name): \(name), componentIdentifier: componentIdentifier)"
                     return "self.\(name) = \(assignment)"
                 }
             } else if variable.isBinding {


### PR DESCRIPTION
Tag the subcomponents in a composite component, giving each component a unique identity.

1.Can be used to solve the problem of styles of other components in closures being overwritten.
2.Provide different IDs for components to match different style sheets.