### PR TITLE
fix: 🐛 [IOSSDKBUG-530]Range Slider the slider overlay the text

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/Slider/SliderExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/Slider/SliderExample.swift
@@ -230,7 +230,7 @@ struct SingleSliderExample: View {
 }
 
 struct RangeSliderExample: View {
-    @State var intLowerValue: Double = 10
+    @State var intLowerValue: Double = 30
     @State var intUpperValue: Double = 60
     
     @State var lowerValue: Double = 30.0
@@ -277,15 +277,16 @@ struct RangeSliderExample: View {
             .informationViewStyle(getInfoStyle(lowerValue: singleEditableRange.lowerBound, upperValue: self.singleEditUpperValue, range: singleEditableRange)).typeErased
             
             FioriSlider(
-                title: "Range Slider (0 - 100)",
+                title: "Range Slider (20 - 100)",
                 lowerValue: self.$intLowerValue,
                 upperValue: self.$intUpperValue,
-                description: getInfoDescription(lowerValue: self.intLowerValue, upperValue: self.intUpperValue, range: 0 ... 100, decimalPlace: 0, defaultDesc: "A range slider that allows users to input integers for the lower and upper values provides flexibility in defining numeric ranges through both sliding handles and direct text input."),
+                range: 20 ... 100,
+                description: getInfoDescription(lowerValue: self.intLowerValue, upperValue: self.intUpperValue, range: 20 ... 100, decimalPlace: 0, defaultDesc: "A range slider that allows users to input integers for the lower and upper values provides flexibility in defining numeric ranges through both sliding handles and direct text input."),
                 onRangeValueChange: { isEditing, lowerValue, upperValue in
                     self.onRangeValueChange(isEditing, lowerValue, upperValue, 0)
                 }
             )
-            .informationViewStyle(getInfoStyle(lowerValue: self.intLowerValue, upperValue: self.intUpperValue, range: 0 ... 100)).typeErased
+            .informationViewStyle(getInfoStyle(lowerValue: self.intLowerValue, upperValue: self.intUpperValue, range: 20 ... 100)).typeErased
             
             let oneDecimalRange = 10.5 ... 400.5
             FioriSlider(

--- a/Sources/FioriSwiftUICore/_FioriStyles/RangeSliderControlStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/RangeSliderControlStyle.fiori.swift
@@ -45,9 +45,10 @@ public struct RangeSliderControlBaseStyle: RangeSliderControlStyle {
                     accessibilityColorHStack
                 }
                 
-                let effectiveLowerValue = min(configuration.lowerValue, configuration.upperValue)
-                let effectiveUpperValue = max(configuration.lowerValue, configuration.upperValue)
-                
+                // Fix the issue IOSSDKBUG-530, the effective lower and upper values should not exceed the specified lower and upper bounds of the range to avoid the track display incorrectly.
+                let effectiveLowerValue = min(max(min(configuration.lowerValue, configuration.upperValue), configuration.range.lowerBound), configuration.range.upperBound)
+                let effectiveUpperValue = min(max(max(configuration.lowerValue, configuration.upperValue), configuration.range.lowerBound), configuration.range.upperBound)
+                                
                 let upperValueWidth = self.xOffsetFor(min(effectiveUpperValue, configuration.range.upperBound), in: geometry.size.width, configuration: configuration)
                 let lowerValueWidth = self.xOffsetFor(max(effectiveLowerValue, configuration.range.lowerBound), in: geometry.size.width, configuration: configuration)
                 


### PR DESCRIPTION
[IOSSDKBUG-530](https://jira.tools.sap/browse/IOSSDKBUG-530): Range Slider the slider overlay the text

This PR addresses the issue where the start and end x-coordinates of the slider's active track are incorrect when the lower or upper value falls below the range's lower bound. Actually, the effective lower and upper values should not exceed the specified lower and upper bounds of the range to ensure that the track displays correctly.

To update the demo case to allow for testing of this scenario.