### PR TITLE
fix: 🐛 [IOSSDKBUG-547]FilterFeedbackBar list duplicated names

### DIFF
--- a/Sources/FioriSwiftUICore/Models/ModelDefinitions.swift
+++ b/Sources/FioriSwiftUICore/Models/ModelDefinitions.swift
@@ -596,6 +596,7 @@ public protocol OptionListPickerItemModel: OptionListPickerComponent {
 // sourcery: virtualPropDisableListEntriesSection = "var disableListEntriesSection: Bool = false"
 // sourcery: virtualPropAllowsDisplaySelectionCount = "var allowsDisplaySelectionCount: Bool = true"
 // sourcery: virtualPropBarItemFrame = "var barItemFrame: CGRect = .zero"
+// sourcery: virtualPropUUIDValueOptions = "var uuidValueOptions: [[String: String]] = []"
 public protocol SearchListPickerItemModel: OptionListPickerComponent {
     // sourcery: default.value = nil
     // sourcery: no_view

--- a/Sources/FioriSwiftUICore/Views/SortFilter/FilterFeedbackBarItemSubview.swift
+++ b/Sources/FioriSwiftUICore/Views/SortFilter/FilterFeedbackBarItemSubview.swift
@@ -411,7 +411,7 @@ struct PickerMenuItem: View {
                     .buttonStyle(ApplyButtonStyle())
                 } components: {
                     SearchListPickerItem(value: self.$item.workingValue, valueOptions: self.item.valueOptions, hint: nil, allowsMultipleSelection: self.item.allowsMultipleSelection, allowsEmptySelection: self.item.allowsEmptySelection, isSearchBarHidden: self.item.isSearchBarHidden, disableListEntriesSection: self.item.disableListEntriesSection, allowsDisplaySelectionCount: self.item.allowsDisplaySelectionCount, barItemFrame: self.barItemFrame) { index in
-                        self.item.onTap(option: self.item.valueOptions[index])
+                        self.item.optionOnTap(index)
                     } selectAll: { isAll in
                         self.item.selectAll(isAll)
                     } updateSearchListPickerHeight: { height in
@@ -485,7 +485,7 @@ struct PickerMenuItem: View {
                     .buttonStyle(ApplyButtonStyle())
                 } components: {
                     SearchListPickerItem(value: self.$item.workingValue, valueOptions: self.item.valueOptions, hint: nil, allowsMultipleSelection: self.item.allowsMultipleSelection, allowsEmptySelection: self.item.allowsEmptySelection, isSearchBarHidden: self.item.isSearchBarHidden, disableListEntriesSection: self.item.disableListEntriesSection, allowsDisplaySelectionCount: self.item.allowsDisplaySelectionCount, barItemFrame: self.barItemFrame) { index in
-                        self.item.onTap(option: self.item.valueOptions[index])
+                        self.item.optionOnTap(index)
                     } selectAll: { isAll in
                         self.item.selectAll(isAll)
                     } updateSearchListPickerHeight: { height in

--- a/Sources/FioriSwiftUICore/Views/SortFilter/_FilterFeedbackBarItem+View.swift
+++ b/Sources/FioriSwiftUICore/Views/SortFilter/_FilterFeedbackBarItem+View.swift
@@ -469,7 +469,7 @@ struct _PickerMenuItem: View {
                     .buttonStyle(ApplyButtonStyle())
                 } components: {
                     SearchListPickerItem(value: self.$item.workingValue, valueOptions: self.item.valueOptions, hint: nil, allowsMultipleSelection: self.item.allowsMultipleSelection, allowsEmptySelection: self.item.allowsEmptySelection, isSearchBarHidden: self.item.isSearchBarHidden, disableListEntriesSection: self.item.disableListEntriesSection, allowsDisplaySelectionCount: self.item.allowsDisplaySelectionCount, barItemFrame: self.barItemFrame) { index in
-                        self.item.onTap(option: self.item.valueOptions[index])
+                        self.item.optionOnTap(index)
                     } selectAll: { isAll in
                         self.item.selectAll(isAll)
                     } updateSearchListPickerHeight: { height in
@@ -543,7 +543,7 @@ struct _PickerMenuItem: View {
                     .buttonStyle(ApplyButtonStyle())
                 } components: {
                     SearchListPickerItem(value: self.$item.workingValue, valueOptions: self.item.valueOptions, hint: nil, allowsMultipleSelection: self.item.allowsMultipleSelection, allowsEmptySelection: self.item.allowsEmptySelection, isSearchBarHidden: self.item.isSearchBarHidden, disableListEntriesSection: self.item.disableListEntriesSection, allowsDisplaySelectionCount: self.item.allowsDisplaySelectionCount, barItemFrame: self.barItemFrame) { index in
-                        self.item.onTap(option: self.item.valueOptions[index])
+                        self.item.optionOnTap(index)
                     } selectAll: { isAll in
                         self.item.selectAll(isAll)
                     } updateSearchListPickerHeight: { height in

--- a/Sources/FioriSwiftUICore/Views/SortFilter/_SortFilterCFGItemContainer.swift
+++ b/Sources/FioriSwiftUICore/Views/SortFilter/_SortFilterCFGItemContainer.swift
@@ -258,7 +258,7 @@ extension _SortFilterCFGItemContainer: View {
                 disableListEntriesSection: self._items[r][c].picker.disableListEntriesSection,
                 allowsDisplaySelectionCount: self._items[r][c].picker.allowsDisplaySelectionCount
             ) { index in
-                self._items[r][c].picker.onTap(option: self._items[r][c].picker.valueOptions[index])
+                self._items[r][c].picker.optionOnTap(index)
             } selectAll: { isAll in
                 self._items[r][c].picker.selectAll(isAll)
             }

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/API/SearchListPickerItem+API.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/API/SearchListPickerItem+API.generated.swift
@@ -9,19 +9,20 @@ public struct SearchListPickerItem {
 	var _valueOptions: [String]
 	var _hint: String? = nil
 	var _onTap: ((_ index: Int) -> Void)? = nil
-	var allowsEmptySelection: Bool = false
-	var disableListEntriesSection: Bool = false
-	var selectAll: ((Bool) -> ())? = nil
-	var allowsMultipleSelection: Bool = false
-	@State var _searchViewCornerRadius: CGFloat = 18
-	var barItemFrame: CGRect = .zero
 	var updateSearchListPickerHeight: ((CGFloat) -> ())? = nil
-	@State var _searchText: String = ""
-	let popoverWidth = 393.0
-	@State var _keyboardHeight: CGFloat = 0.0
-	var allowsDisplaySelectionCount: Bool = true
 	@State var _height: CGFloat = 44
+	var allowsMultipleSelection: Bool = false
+	var uuidValueOptions: [[String: String]] = []
 	var isSearchBarHidden: Bool = false
+	var allowsDisplaySelectionCount: Bool = true
+	var selectAll: ((Bool) -> ())? = nil
+	var allowsEmptySelection: Bool = false
+	@State var _searchText: String = ""
+	var barItemFrame: CGRect = .zero
+	var disableListEntriesSection: Bool = false
+	@State var _keyboardHeight: CGFloat = 0.0
+	let popoverWidth = 393.0
+	@State var _searchViewCornerRadius: CGFloat = 18
     public init(model: SearchListPickerItemModel) {
         self.init(value: Binding<[Int]>(get: { model.value }, set: { model.value = $0 }), valueOptions: model.valueOptions, hint: model.hint, onTap: model.onTap)
     }


### PR DESCRIPTION
When options for the list have duplicated names, distinguish selected name by adding UUID as key and name as value.