### PR TITLE
chore: 🤖 [HCPSDKFIORIUIKIT-2862]warning cleanup

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/BannerMessage/BannerMultiMessageCustomInitExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/BannerMessage/BannerMultiMessageCustomInitExample.swift
@@ -235,13 +235,13 @@ struct BannerMultiMessageCustomInitExample: View {
                     }
                 }
             }
-            .onChange(of: self.firstName) { _ in
+            .onChange(of: self.firstName) {
                 self.validateUploadData()
             }
-            .onChange(of: self.lastName) { _ in
+            .onChange(of: self.lastName) {
                 self.validateUploadData()
             }
-            .onChange(of: self.emailAddress) { _ in
+            .onChange(of: self.emailAddress) {
                 self.validateUploadData()
             }
         }

--- a/Apps/Examples/Examples/FioriSwiftUICore/BannerMessage/BannerMultiMessageExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/BannerMessage/BannerMultiMessageExample.swift
@@ -175,13 +175,13 @@ struct BannerMultiMessageExample: View {
                     }
                 }
             }
-            .onChange(of: self.firstName) { _ in
+            .onChange(of: self.firstName) {
                 self.validateUploadData()
             }
-            .onChange(of: self.lastName) { _ in
+            .onChange(of: self.lastName) {
                 self.validateUploadData()
             }
-            .onChange(of: self.emailAddress) { _ in
+            .onChange(of: self.emailAddress) {
                 self.validateUploadData()
             }
         }

--- a/Apps/Examples/Examples/FioriSwiftUICore/DocumentScannerView/DocumentScannerViewExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/DocumentScannerView/DocumentScannerViewExample.swift
@@ -14,7 +14,7 @@ struct DocumentScannerViewExample: View {
         VStack {
             Toggle("Save Results as PDF", isOn: self.$isPDFDocument)
                 .padding(EdgeInsets(top: 10, leading: 20, bottom: 10, trailing: 20))
-                .onChange(of: self.isPDFDocument) { _ in
+                .onChange(of: self.isPDFDocument) {
                     if self.isPDFDocument {
                         self.viewerTitle = "Results as PDF"
                     } else {

--- a/Apps/Examples/Examples/FioriSwiftUICore/FormCells/ListPickerItemExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/FormCells/ListPickerItemExample.swift
@@ -63,7 +63,7 @@ struct ListPickerItemExample: View {
                     })
                 }
             }
-            .onChange(of: self.dataType) { _ in
+            .onChange(of: self.dataType) {
                 self.selections.removeAll()
                 self.uuidSelections.removeAll()
                 self.selection = nil

--- a/Apps/Examples/Examples/FioriSwiftUICore/FormCells/StepperViewExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/FormCells/StepperViewExample.swift
@@ -64,14 +64,14 @@ struct StepperViewExample: View {
                 text: self.$negativeValue,
                 stepRange: 10 ... 100,
                 description: { Text(self.isInputValueValid ? "Hint Text" : "Validation failed.") }
-            ).onChange(of: self.negativeValue, perform: { value in
-                let cValue = Double(value) ?? 10
+            ).onChange(of: self.negativeValue) {
+                let cValue = Double(self.negativeValue) ?? 10
                 if cValue > 80 || cValue < 20 {
                     self.isInputValueValid = false
                 } else {
                     self.isInputValueValid = true
                 }
-            })
+            }
             .informationViewStyle(self.newStyle).typeErased
             .disabled(self.isDisabled)
             

--- a/Apps/Examples/Examples/FioriSwiftUICore/MenuSelection/MenuSelectionExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/MenuSelection/MenuSelectionExample.swift
@@ -27,7 +27,7 @@ struct MenuSelectionExample: View {
                         }
                     }
                 })
-                .onChange(of: self.isExpanded) { _ in
+                .onChange(of: self.isExpanded) {
                     withAnimation {
                         scrollView.scrollTo("MenuSelection", anchor: .bottom)
                     }

--- a/Apps/Examples/Examples/FioriSwiftUICore/StepProgressIndicator/SPIModelExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/StepProgressIndicator/SPIModelExample.swift
@@ -60,9 +60,9 @@ struct SPIModelExample: View {
             .padding(20)
         }
         .padding()
-        .onChange(of: self.model.selection, perform: { _ in
+        .onChange(of: self.model.selection) {
             self.updateCurrentStepName()
-        })
+        }
         .onAppear {
             self.updateCurrentStepName()
         }

--- a/Apps/Examples/Examples/FioriSwiftUICore/StepProgressIndicator/StepProgressIndicatorExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/StepProgressIndicator/StepProgressIndicatorExample.swift
@@ -137,9 +137,9 @@ struct SPIExampleWithIcon: View {
                 }
             }
             .padding()
-            .onChange(of: self.iconSelection, perform: { _ in
+            .onChange(of: self.iconSelection) {
                 self.updateCurrentStepName()
-            })
+            }
             .onAppear {
                 self.updateCurrentStepName()
             }
@@ -332,9 +332,9 @@ struct SPIExampleWithHeader: View {
             .padding(20)
         }
         .padding()
-        .onChange(of: self.selection, perform: { _ in
+        .onChange(of: self.selection) {
             self.updateCurrentStepName()
-        })
+        }
         .onAppear {
             self.updateCurrentStepName()
         }
@@ -569,8 +569,8 @@ struct SPIExampleByBuilder: View {
             }
             Spacer()
         }.padding()
-            .onChange(of: self.selection) { newValue in
-                print(newValue)
+            .onChange(of: self.selection) {
+                print(self.selection)
             }
     }
     
@@ -661,9 +661,9 @@ struct SPICustomStyleExample: View {
             .padding(20)
         }
         .padding()
-        .onChange(of: self.selection, perform: { _ in
+        .onChange(of: self.selection) {
             self.updateCurrentStepName()
-        })
+        }
         .onAppear {
             self.updateCurrentStepName()
         }

--- a/Sources/FioriSwiftUICore/Views/OptionListPickerItem+View.swift
+++ b/Sources/FioriSwiftUICore/Views/OptionListPickerItem+View.swift
@@ -106,7 +106,7 @@ extension OptionListPickerItem: View {
                         .onAppear {
                             self.updateSearchListPickerHeight?(self.calculateHeight(scrollViewContentHeight: geometry.size.height))
                         }
-                        .onChange(of: geometry.size) { _ in
+                        .onChange(of: geometry.size) {
                             self.updateSearchListPickerHeight?(self.calculateHeight(scrollViewContentHeight: geometry.size.height))
                         }
                 }

--- a/Sources/FioriSwiftUICore/Views/SortFilter/FilterFeedbackBarItemSubview.swift
+++ b/Sources/FioriSwiftUICore/Views/SortFilter/FilterFeedbackBarItemSubview.swift
@@ -80,12 +80,12 @@ struct SliderMenuItem: View {
                                     self.geometrySizeHeight = geometry.size.height
                                     self.calculateDetentHeight()
                                 }
-                                .onChange(of: geometry.size) { newSize in
-                                    self.geometrySizeHeight = newSize.height
+                                .onChange(of: geometry.size) {
+                                    self.geometrySizeHeight = geometry.size.height
                                     self.calculateDetentHeight()
                                 }
                         })
-                        .onChange(of: self.dynamicTypeSize) { _ in
+                        .onChange(of: self.dynamicTypeSize) {
                             self.calculateDetentHeight()
                         }
                 }
@@ -799,12 +799,12 @@ struct StepperMenuItem: View {
                                 self.geometrySizeHeight = geometry.size.height
                                 self.calculateDetentHeight()
                             }
-                            .onChange(of: geometry.size) { newSize in
-                                self.geometrySizeHeight = newSize.height
+                            .onChange(of: geometry.size) {
+                                self.geometrySizeHeight = geometry.size.height
                                 self.calculateDetentHeight()
                             }
                     })
-                    .onChange(of: self.dynamicTypeSize) { _ in
+                    .onChange(of: self.dynamicTypeSize) {
                         self.stepperViewHeight = 110 + self.dynamicTypeAddHeight()
                         self.calculateDetentHeight()
                     }

--- a/Sources/FioriSwiftUICore/Views/SortFilter/_FilterFeedbackBarItem+View.swift
+++ b/Sources/FioriSwiftUICore/Views/SortFilter/_FilterFeedbackBarItem+View.swift
@@ -123,12 +123,12 @@ struct _SliderMenuItem: View {
                                     self.geometrySizeHeight = geometry.size.height
                                     self.calculateDetentHeight()
                                 }
-                                .onChange(of: geometry.size) { newSize in
-                                    self.geometrySizeHeight = newSize.height
+                                .onChange(of: geometry.size) {
+                                    self.geometrySizeHeight = geometry.size.height
                                     self.calculateDetentHeight()
                                 }
                         })
-                        .onChange(of: self.dynamicTypeSize) { _ in
+                        .onChange(of: self.dynamicTypeSize) {
                             self.calculateDetentHeight()
                         }
                 }
@@ -892,12 +892,12 @@ struct _StepperMenuItem: View {
                                 self.geometrySizeHeight = geometry.size.height
                                 self.calculateDetentHeight()
                             }
-                            .onChange(of: geometry.size) { newSize in
-                                self.geometrySizeHeight = newSize.height
+                            .onChange(of: geometry.size) {
+                                self.geometrySizeHeight = geometry.size.height
                                 self.calculateDetentHeight()
                             }
                     })
-                    .onChange(of: self.dynamicTypeSize) { _ in
+                    .onChange(of: self.dynamicTypeSize) {
                         self.stepperViewHeight = 110 + self.dynamicTypeAddHeight()
                         self.calculateDetentHeight()
                     }


### PR DESCRIPTION
'onChange(of:perform:)' was deprecated in iOS 17.0: Use `onChange` with a two or zero parameter action closure instead.