### PR TITLE
refactor: 💡 [HCPSDKFIORIUIKIT-2893] SliderPickerItemModel

### DIFF
--- a/Sources/FioriSwiftUICore/Models/ModelDefinitions.swift
+++ b/Sources/FioriSwiftUICore/Models/ModelDefinitions.swift
@@ -655,4 +655,8 @@ public protocol SwitchPickerItemModel {}
 
 // sourcery: add_env_props = "_filterFeedbackBarStyle"
 // sourcery: generated_component_not_configurable
-public protocol SliderPickerItemModel: SliderPickerComponent {}
+public protocol _SliderPickerItemModel: SliderPickerComponent {}
+
+/// Deprecated SliderPickerItemModel
+@available(*, unavailable, renamed: "_SliderPickerItemModel", message: "Will be removed in the future release. Please create FioriSlider with other initializers instead.")
+public protocol SliderPickerItemModel {}

--- a/Sources/FioriSwiftUICore/Models/ModelDefinitions.swift
+++ b/Sources/FioriSwiftUICore/Models/ModelDefinitions.swift
@@ -658,5 +658,5 @@ public protocol SwitchPickerItemModel {}
 public protocol _SliderPickerItemModel: SliderPickerComponent {}
 
 /// Deprecated SliderPickerItemModel
-@available(*, unavailable, renamed: "_SliderPickerItemModel", message: "Will be removed in the future release. Please create FioriSlider with other initializers instead.")
+@available(*, deprecated, renamed: "_SliderPickerItemModel", message: "Will be removed in the future release. Please create FioriSlider with other initializers instead.")
 public protocol SliderPickerItemModel {}

--- a/Sources/FioriSwiftUICore/Views/_SliderPickerItem+View.swift
+++ b/Sources/FioriSwiftUICore/Views/_SliderPickerItem+View.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-extension SliderPickerItem: View {
+extension _SliderPickerItem: View {
     public var body: some View {
         VStack {
             HStack {
@@ -40,7 +40,7 @@ extension SliderPickerItem: View {
     }
 }
 
-private extension SliderPickerItem {
+private extension _SliderPickerItem {
     func calcWidth(font: Font) -> CGFloat {
         var width: CGFloat = 0
         for i in 0 ... 9 {
@@ -145,7 +145,7 @@ private struct SliderPickeTestView: View {
                     .foregroundColor(self.value1 != nil ? .blue : .gray)
                 Spacer()
             }
-            SliderPickerItem(value: Binding<Int?>(
+            _SliderPickerItem(value: Binding<Int?>(
                 get: {
                     self.value1
                 },
@@ -162,7 +162,7 @@ private struct SliderPickeTestView: View {
                 Spacer()
             }
 
-            SliderPickerItem(value: Binding<Int?>(
+            _SliderPickerItem(value: Binding<Int?>(
                 get: {
                     self.value2
                 },
@@ -178,7 +178,7 @@ private struct SliderPickeTestView: View {
 
                 Spacer()
             }
-            SliderPickerItem(value: Binding<Int?>(
+            _SliderPickerItem(value: Binding<Int?>(
                 get: {
                     self.value3
                 },

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/API/_SliderPickerItem+API.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/API/_SliderPickerItem+API.generated.swift
@@ -2,7 +2,7 @@
 // DO NOT EDIT
 import SwiftUI
 
-public struct SliderPickerItem {
+public struct _SliderPickerItem {
     @Environment(\._filterFeedbackBarStyle) var _filterFeedbackBarStyle
 
     var _value: Binding<Int?>
@@ -11,7 +11,7 @@ public struct SliderPickerItem {
 	var _maximumValue: Int
 	var _hint: String? = nil
 	
-    public init(model: SliderPickerItemModel) {
+    public init(model: _SliderPickerItemModel) {
         self.init(value: Binding<Int?>(get: { model.value }, set: { model.value = $0 }), formatter: model.formatter, minimumValue: model.minimumValue, maximumValue: model.maximumValue, hint: model.hint)
     }
 

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/Boilerplate/_SliderPickerItem+View.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/Boilerplate/_SliderPickerItem+View.generated.swift
@@ -1,7 +1,7 @@
 // Generated using Sourcery 2.1.7 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
-//TODO: Copy commented code to new file: `FioriSwiftUICore/Views/SliderPickerItem+View.swift`
-//TODO: Implement SliderPickerItem `View` body
+//TODO: Copy commented code to new file: `FioriSwiftUICore/Views/_SliderPickerItem+View.swift`
+//TODO: Implement _SliderPickerItem `View` body
 
 /// - Important: to make `@Environment` properties (e.g. `horizontalSizeClass`), internally accessible
 /// to extensions, add as sourcery annotation in `FioriSwiftUICore/Models/ModelDefinitions.swift`
@@ -13,21 +13,21 @@ import SwiftUI
 
 // FIXME: - Implement Fiori style definitions
 
-// FIXME: - Implement SliderPickerItem View body
+// FIXME: - Implement _SliderPickerItem View body
 
-extension SliderPickerItem: View {
+extension _SliderPickerItem: View {
     public var body: some View {
         <# View body #>
     }
 }
 
-// FIXME: - Implement SliderPickerItem specific LibraryContentProvider
+// FIXME: - Implement _SliderPickerItem specific LibraryContentProvider
 
 @available(iOS 14.0, macOS 11.0, *)
-struct SliderPickerItemLibraryContent: LibraryContentProvider {
+struct _SliderPickerItemLibraryContent: LibraryContentProvider {
     @LibraryContentBuilder
     var views: [LibraryItem] {
-        LibraryItem(SliderPickerItem(model: LibraryPreviewData.Person.laurelosborn),
+        LibraryItem(_SliderPickerItem(model: LibraryPreviewData.Person.laurelosborn),
                     category: .control)
     }
 }

--- a/sourcery/.lib/Sources/utils/Type+Extensions.swift
+++ b/sourcery/.lib/Sources/utils/Type+Extensions.swift
@@ -95,7 +95,8 @@ public extension Type {
                                     "_SortFilterViewModel",
                                     "_SignatureCaptureViewModel",
                                     "_EmptyStateViewModel",
-                                    "_KPIItemModel"]
+                                    "_KPIItemModel",
+                                    "_SliderPickerItemModel"]
         
         if deprecatedComponents.contains(name) {
             return name.replacingOccurrences(of: "Model", with: "")


### PR DESCRIPTION
[HCPSDKFIORIUIKIT-2893](https://jira.tools.sap/browse/HCPSDKFIORIUIKIT-2893): SwiftUI code refactoring with component style: SliderPickerItemModel

This PR address the code refactoring for SliderPickerItemModel deprecation. Currently, the styled component FioriSlider was available. The FilterFeedbackBar already use new styled component FioriSlider. The original SliderPickerItemModel can be deprecated.