### PR TITLE
fix: 🐛 [JIRA:0] BannerMultiMessage enhancement

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/BannerMessage/BannerMultiMessageCustomInitExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/BannerMessage/BannerMultiMessageCustomInitExample.swift
@@ -65,7 +65,7 @@ struct BannerMultiMessageCustomInitExample: View {
                             Text("Check Result")
                             
                             // workaround for forcing list refresh when second layer array modified in bannerMultiMessage.
-                            Text("\(self.refreshFlag)")
+                            Text("\(self.refreshFlag ? "true" : "false")")
                                 .frame(height: 0.01)
                                 .opacity(0)
                         }

--- a/Apps/Examples/Examples/FioriSwiftUICore/BannerMessage/BannerMultiMessageCustomInitExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/BannerMessage/BannerMultiMessageCustomInitExample.swift
@@ -52,13 +52,23 @@ struct BannerMultiMessageCustomInitExample: View {
     @State private var lastNameErrorMessage = AttributedString()
     @State private var emailAddressErrorMessage = AttributedString()
     
+    // workaround for forcing list refresh when second layer array modified in bannerMultiMessage.
+    @State private var refreshFlag = false
+    
     var body: some View {
         ScrollViewReader { proxy in
             List {
                 Section {
                     HStack {
                         Spacer()
-                        Text("Check Result")
+                        ZStack {
+                            Text("Check Result")
+                            
+                            // workaround for forcing list refresh when second layer array modified in bannerMultiMessage.
+                            Text("\(self.refreshFlag)")
+                                .frame(height: 0.01)
+                                .opacity(0)
+                        }
                         Spacer()
                     }
                     .popover(isPresented: self.$showingMessageDetail) {
@@ -75,6 +85,7 @@ struct BannerMultiMessageCustomInitExample: View {
                             self.showingMessageDetail = false
                         }, removeAction: { category, _ in
                             self.removeCategory(category: category)
+                            self.refreshFlag.toggle()
                         }, turnOnSectionHeader: self.turnOnSectionHeader, messageItemView: { id in
                             if let (message, category) = getItemData(with: id) {
                                 BannerMessage(icon: {
@@ -252,14 +263,14 @@ struct BannerMultiMessageCustomInitExample: View {
             let item = self.bannerMultiMessages[i]
             if item.category == category {
                 if let id {
-                    var messages = self.bannerMultiMessages[i].items
+                    let messages = item.items
                     for index in 0 ..< messages.count where messages[index].id == id {
-                        messages.remove(at: index)
+                        self.bannerMultiMessages[i].items.remove(at: index)
+                        refreshFlag.toggle()
                         break
                     }
-                    self.bannerMultiMessages[i].items = messages
                     
-                    if messages.isEmpty {
+                    if self.bannerMultiMessages[i].items.isEmpty {
                         self.removeCategory(category: category)
                     }
                 } else {

--- a/Apps/Examples/Examples/FioriSwiftUICore/BannerMessage/BannerMultiMessageExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/BannerMessage/BannerMultiMessageExample.swift
@@ -225,9 +225,9 @@ struct BannerMultiMessageExample: View {
             let tips = "First name correct."
             self.firstNameErrorMessage = AttributedString()
             informationMessages.append(BannerMessageItemModel(id: self.firstNameId, icon: EmptyView(), title: tips + " Developer custom icon.", messageType: .positive, showDetailLink: false, showCloseAction: false))
-            informationMessages.append(BannerMessageItemModel(id: self.firstNameId, icon: Image(fioriName: "fiori.home"), title: tips + " Developer custom icon.", messageType: .positive, showDetailLink: false, showCloseAction: false))
-            informationMessages.append(BannerMessageItemModel(id: self.firstNameId, icon: Image(fioriName: "fiori.home"), title: tips + " Developer custom icon.", messageType: .positive, showDetailLink: false))
-            informationMessages.append(BannerMessageItemModel(id: self.firstNameId, icon: Image(fioriName: "fiori.home"), title: tips + " Developer custom icon.", messageType: .positive))
+            informationMessages.append(BannerMessageItemModel(id: UUID(), icon: Image(fioriName: "fiori.home"), title: tips + " Developer custom icon.", messageType: .positive, showDetailLink: false, showCloseAction: false))
+            informationMessages.append(BannerMessageItemModel(id: UUID(), icon: Image(fioriName: "fiori.home"), title: tips + " Developer custom icon.", messageType: .positive, showDetailLink: false))
+            informationMessages.append(BannerMessageItemModel(id: UUID(), icon: Image(fioriName: "fiori.home"), title: tips + " Developer custom icon.", messageType: .positive))
             informationMessages.append(BannerMessageItemModel(id: UUID(), icon: EmptyView(), title: tips + " Empty icon.", messageType: .positive))
             informationMessages.append(BannerMessageItemModel(id: UUID(), icon: nil, title: tips + " SDK default icon.", messageType: .positive))
         }

--- a/Sources/FioriSwiftUICore/_FioriStyles/BannerMultiMessageSheetStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/BannerMultiMessageSheetStyle.fiori.swift
@@ -162,11 +162,14 @@ public struct BannerMultiMessageSheetBaseStyle: BannerMultiMessageSheetStyle {
                     element.items.remove(at: index)
                     break
                 }
-                configuration.bannerMultiMessages.remove(at: i)
-                configuration.bannerMultiMessages.insert(element, at: i)
                 
                 if element.items.isEmpty {
                     self.handleRemoveCategory(configuration, category: category)
+                } else {
+                    configuration.bannerMultiMessages.remove(at: i)
+                    withAnimation {
+                        configuration.bannerMultiMessages.insert(element, at: i)
+                    }
                 }
                 break
             }
@@ -183,7 +186,9 @@ public struct BannerMultiMessageSheetBaseStyle: BannerMultiMessageSheetStyle {
         for i in 0 ..< configuration.bannerMultiMessages.count {
             let element = configuration.bannerMultiMessages[i]
             if element.category == category {
-                configuration.bannerMultiMessages.remove(at: i)
+                withAnimation {
+                    configuration.bannerMultiMessages.remove(at: i)
+                }
                 break
             }
         }

--- a/Sources/FioriSwiftUICore/_FioriStyles/BannerMultiMessageSheetStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/BannerMultiMessageSheetStyle.fiori.swift
@@ -59,7 +59,7 @@ class CategorySelect: ObservableObject {
     }
 }
 
-public struct BannerMessageListModel: Identifiable, Equatable {
+public class BannerMessageListModel: Identifiable, Equatable, ObservableObject {
     public static func == (lhs: BannerMessageListModel, rhs: BannerMessageListModel) -> Bool {
         lhs.id == rhs.id
     }
@@ -67,7 +67,7 @@ public struct BannerMessageListModel: Identifiable, Equatable {
     public var id: UUID
     // customized category, like "Errors", "Warnings", "Information", etc
     public let category: String
-    public var items: [BannerMessageItemModel]
+    @Published public var items: [BannerMessageItemModel]
     
     /// Public initializer for BannerMessageListModel
     /// - Parameters:
@@ -106,6 +106,9 @@ public struct BannerMultiMessageSheetBaseStyle: BannerMultiMessageSheetStyle {
     @State private var scrollContentHeight: CGFloat = 40
     @State private var dimensionSelectorHeight: CGFloat = 0
     @State private var messageCountHeight: CGFloat = 65
+    
+    // workaround for forcing list refresh when second layer array modified in bannerMultiMessage.
+    @State private var refreshFlag = false
     
     private let viewDetailOpenUrlStr = "MultiMessageViewDetail"
     
@@ -156,20 +159,16 @@ public struct BannerMultiMessageSheetBaseStyle: BannerMultiMessageSheetStyle {
     
     private func removeItem(_ configuration: BannerMultiMessageSheetConfiguration, category: String, at id: UUID) {
         for i in 0 ..< configuration.bannerMultiMessages.count {
-            var element = configuration.bannerMultiMessages[i]
+            let element = configuration.bannerMultiMessages[i]
             if element.category == category {
                 for index in 0 ..< element.items.count where element.items[index].id == id {
-                    element.items.remove(at: index)
+                    configuration.bannerMultiMessages[i].items.remove(at: index)
+                    refreshFlag.toggle()
                     break
                 }
                 
-                if element.items.isEmpty {
+                if configuration.bannerMultiMessages[i].items.isEmpty {
                     self.handleRemoveCategory(configuration, category: category)
-                } else {
-                    configuration.bannerMultiMessages.remove(at: i)
-                    withAnimation {
-                        configuration.bannerMultiMessages.insert(element, at: i)
-                    }
                 }
                 break
             }
@@ -186,9 +185,8 @@ public struct BannerMultiMessageSheetBaseStyle: BannerMultiMessageSheetStyle {
         for i in 0 ..< configuration.bannerMultiMessages.count {
             let element = configuration.bannerMultiMessages[i]
             if element.category == category {
-                withAnimation {
-                    configuration.bannerMultiMessages.remove(at: i)
-                }
+                configuration.bannerMultiMessages.remove(at: i)
+                self.refreshFlag.toggle()
                 break
             }
         }
@@ -297,8 +295,7 @@ public struct BannerMultiMessageSheetBaseStyle: BannerMultiMessageSheetStyle {
                             .padding(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
                         }
                         
-                        ForEach(0 ..< element.items.count, id: \.self) { index in
-                            let message = element.items[index]
+                        ForEach(element.items, id: \.id) { message in
                             
                             if !configuration.messageItemView(message.id).isEmpty {
                                 AnyView(configuration.messageItemView(message.id))
@@ -364,6 +361,11 @@ public struct BannerMultiMessageSheetBaseStyle: BannerMultiMessageSheetStyle {
                     }
                 }
             })
+            
+            // workaround for forcing list refresh when second layer array modified in bannerMultiMessage.
+            Text("\(self.refreshFlag)")
+                .frame(height: 0.01)
+                .opacity(0)
         })
         .background(Color.preferredColor(.chrome))
         .onDisappear(perform: {

--- a/Sources/FioriSwiftUICore/_FioriStyles/BannerMultiMessageSheetStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/BannerMultiMessageSheetStyle.fiori.swift
@@ -363,7 +363,7 @@ public struct BannerMultiMessageSheetBaseStyle: BannerMultiMessageSheetStyle {
             })
             
             // workaround for forcing list refresh when second layer array modified in bannerMultiMessage.
-            Text("\(self.refreshFlag)")
+            Text("\(self.refreshFlag ? "true" : "false")")
                 .frame(height: 0.01)
                 .opacity(0)
         })


### PR DESCRIPTION
Workaround for forcing list refresh when second layer array modified in bannerMultiMessage.