### PR TITLE
feat: 🎸 [jira: 1975] status and substatus should support both icon and text

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/ObjectHeader/ObjectHeaderViewScenarios.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/ObjectHeader/ObjectHeaderViewScenarios.swift
@@ -158,8 +158,9 @@ struct ObjectHeaderViewScenarios: ListDataProtocol {
                                   footnote: "Due on 12/31/16",
                                   descriptionText: "Temperature sensor predicts overheating failure in 4 days Urgent and needs attention sensor predicts overheating failure in 4 days Urgent and need attention.",
                                   status: TextOrIcon.text("Very High Priority"),
-                                  substatus: TextOrIcon.text("Scheduled"),
-                                  detailContent: {})
+                                  substatus: TextOrIcon.both("Time", Image(systemName: "clock")),
+                                  detailContent: {}).environment(\.iconHorizontalAlignment, .trailing)
+                .substatusStyle(.negativeLabel)
             
             return AnyView(oh)
         

--- a/Apps/Examples/Examples/FioriSwiftUICore/ObjectItem/ObjectCell_Spec_Jan2018.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/ObjectItem/ObjectCell_Spec_Jan2018.swift
@@ -64,12 +64,13 @@ struct ObjectCell_Spec_Jan2018: ObjectItemListDataProtocol {
                 oi = ObjectItem(title: "Lorem ipseum dolor",
                                 footnote: "Words\nSeparated\nNewLineChars and this is Just some really long text that is here dont worry about it too much",
                                 description: "Some description",
-                                status: TextOrIcon.text("Some status"),
+                                status: .both("Some status", Image(systemName: "paperplane")),
                                 substatus: TextOrIcon.text("some substatus"))
                     .footnoteStyle {
                         Footnote($0)
                             .lineLimit(4)
                     }
+                    .statusStyle(.positiveLabel)
             } else {
                 oi = _ObjectItem(title: "Lorem ipseum dolor",
                                  footnote: "Words\nSeparated\nNewLineChars and this is Just some really long text that is here dont worry about it too much",

--- a/Apps/Examples/Examples/FioriSwiftUICore/Timeline/TimelineItemsExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/Timeline/TimelineItemsExample.swift
@@ -21,14 +21,12 @@ struct TimelineItemsExample: View {
                     })
             }
             Section(header: Text("Timeline")) {
-                Timeline(timestamp: "06/21/24", secondaryTimestamp: .icon(Image(systemName: "sun.max")), timelineNode: .complete, title: "Complete", subtitle: "abc", attribute: "attr", status: .text("Info"), substatus: .icon(Image(systemName: "exclamationmark.circle")), subAttribute: "subAttr", isPast: true)
+                Timeline(timestamp: "06/21/24", secondaryTimestamp: .icon(Image(systemName: "sun.max")), timelineNode: .complete, title: "Complete", subtitle: "abc", attribute: "attr", status: .text("Info"), substatus: .both("substatus", Image(systemName: "exclamationmark.circle")), subAttribute: "subAttr", isPast: true)
                     .modifier(CustomListRowModifier())
                     .secondaryTimestampStyle(content: { config in
                         config.secondaryTimestamp.foregroundColor(.yellow)
                     })
-                    .substatusStyle(content: { config in
-                        config.substatus.foregroundColor(.yellow)
-                    })
+                    .substatusStyle(.positiveLabel)
                 Timeline(timestamp: "06/21/24", secondaryTimestamp: .icon(Image(systemName: "sun.max")), timelineNode: .complete, title: "Complete(Disabled)", subtitle: "abc", attribute: "attr", status: .text("Info"), substatus: .icon(Image(systemName: "exclamationmark.circle")), subAttribute: "subAttr", isPast: true)
                     .modifier(CustomListRowModifier())
                     .disabled(/*@START_MENU_TOKEN@*/true/*@END_MENU_TOKEN@*/)

--- a/Sources/FioriSwiftUICore/Components/TextOrIcon.swift
+++ b/Sources/FioriSwiftUICore/Components/TextOrIcon.swift
@@ -3,10 +3,10 @@ import SwiftUI
 
 /// It is either a String or Image
 public enum TextOrIcon {
-    // Contains a text only
+    /// Contains a text only
     case text(AttributedString)
-    // Contains an icon only
+    /// Contains an icon only
     case icon(Image)
-    // Contains both a text and an icon
+    /// Contains both a text and an icon
     case both(AttributedString, Image)
 }

--- a/Sources/FioriSwiftUICore/Components/TextOrIcon.swift
+++ b/Sources/FioriSwiftUICore/Components/TextOrIcon.swift
@@ -3,6 +3,10 @@ import SwiftUI
 
 /// It is either a String or Image
 public enum TextOrIcon {
-    case text(String)
+    // Contains a text only
+    case text(AttributedString)
+    // Contains an icon only
     case icon(Image)
+    // Contains both a text and an icon
+    case both(AttributedString, Image)
 }

--- a/Sources/FioriSwiftUICore/Views/CustomBuilder/FootnoteIconsBuilder.swift
+++ b/Sources/FioriSwiftUICore/Views/CustomBuilder/FootnoteIconsBuilder.swift
@@ -242,6 +242,8 @@ extension FootnoteIconStack: FootnoteIconList {
                 Text(txt)
             case .icon(let icon):
                 icon
+            case .both(let txt, let icon):
+                Text(txt)
             }
         }
     }

--- a/Sources/FioriSwiftUICore/Views/IconStack/IconStack+View.swift
+++ b/Sources/FioriSwiftUICore/Views/IconStack/IconStack+View.swift
@@ -26,6 +26,8 @@ extension IconStack: ViewList {
                 Text(txt)
             case .icon(let icon):
                 icon
+            case .both(let txt, let icon):
+                Text(txt)
             }
         }
     }
@@ -41,6 +43,8 @@ extension IconStack: ViewList {
             return true
         case .icon:
             return false
+        case .both:
+            return true
         }
     }
     

--- a/Sources/FioriSwiftUICore/Views/TextOrIconView.swift
+++ b/Sources/FioriSwiftUICore/Views/TextOrIconView.swift
@@ -1,7 +1,24 @@
 import SwiftUI
 
+struct IconHorizontalAlignment: EnvironmentKey {
+    // The default is `.leading`. `.center` and `.trailing` means `.trailing`.
+    public static let defaultValue: HorizontalAlignment = .leading
+}
+
+public extension EnvironmentValues {
+    // Determine the relative positioning of an icon within the `TextOrIcon` when both a text and an icon are present. . The default is `.leading`. `.center` and `.trailing` means `.trailing`.
+    var iconHorizontalAlignment: HorizontalAlignment {
+        get {
+            self[IconHorizontalAlignment.self]
+        } set {
+            self[IconHorizontalAlignment.self] = newValue
+        }
+    }
+}
+
 /// TextOrIconView to display TextOrIcon
 public struct TextOrIconView: View {
+    @Environment(\.iconHorizontalAlignment) var iconHorizontalAlignment
     var content: TextOrIcon?
     
     /// init with TextOrIcon
@@ -30,6 +47,17 @@ public struct TextOrIconView: View {
                 
             case .icon(let icon):
                 icon
+            
+            case .both(let text, let icon):
+                HStack(alignment: .center, spacing: 2) {
+                    if self.iconHorizontalAlignment == .leading {
+                        icon
+                        Text(text)
+                    } else {
+                        Text(text)
+                        icon
+                    }
+                }
             }
         } else {
             EmptyView()

--- a/Sources/FioriSwiftUICore/Views/TextOrIconView.swift
+++ b/Sources/FioriSwiftUICore/Views/TextOrIconView.swift
@@ -1,12 +1,12 @@
 import SwiftUI
 
 struct IconHorizontalAlignment: EnvironmentKey {
-    // The default is `.leading`. `.center` and `.trailing` means `.trailing`.
+    /// The default is `.leading`. `.center` and `.trailing` means `.trailing`.
     public static let defaultValue: HorizontalAlignment = .leading
 }
 
 public extension EnvironmentValues {
-    // Determine the relative positioning of an icon within the `TextOrIcon` when both a text and an icon are present. . The default is `.leading`. `.center` and `.trailing` means `.trailing`.
+    /// Determine the relative positioning of an icon within the `TextOrIcon` when both a text and an icon are present. . The default is `.leading`. `.center` and `.trailing` means `.trailing`.
     var iconHorizontalAlignment: HorizontalAlignment {
         get {
             self[IconHorizontalAlignment.self]

--- a/Sources/FioriSwiftUICore/_FioriStyles/StatusStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/StatusStyle.fiori.swift
@@ -26,3 +26,35 @@ public struct StatusFioriStyle: StatusStyle {
             .font(.fiori(forTextStyle: .subheadline))
     }
 }
+
+// A convenient `StatusStyle` to set a foreground color for `Status`
+public struct StatusColorStyleStyle: StatusStyle {
+    let style: ColorStyle
+    public func makeBody(_ configuration: StatusConfiguration) -> some View {
+        Status(configuration)
+            .foregroundStyle(Color.preferredColor(self.style))
+            .font(.fiori(forTextStyle: .subheadline))
+    }
+}
+
+public extension StatusStyle where Self == StatusColorStyleStyle {
+    // `.negativeLabel` color style for `Status`
+    static var negativeLabel: Self {
+        StatusColorStyleStyle(style: .negativeLabel)
+    }
+    
+    // `.positiveLabel` color style for `Status`
+    static var positiveLabel: Self {
+        StatusColorStyleStyle(style: .positiveLabel)
+    }
+    
+    // `.criticalLabel` color style for `Status`
+    static var criticalLabel: Self {
+        StatusColorStyleStyle(style: .criticalLabel)
+    }
+    
+    // `.informativeLabel` color style for `Status`
+    static var informativeLabel: Self {
+        StatusColorStyleStyle(style: .informativeLabel)
+    }
+}

--- a/Sources/FioriSwiftUICore/_FioriStyles/StatusStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/StatusStyle.fiori.swift
@@ -27,7 +27,7 @@ public struct StatusFioriStyle: StatusStyle {
     }
 }
 
-// A convenient `StatusStyle` to set a foreground color for `Status`
+/// A convenient `StatusStyle` to set a foreground color for `Status`
 public struct StatusColorStyleStyle: StatusStyle {
     let style: ColorStyle
     public func makeBody(_ configuration: StatusConfiguration) -> some View {
@@ -38,22 +38,22 @@ public struct StatusColorStyleStyle: StatusStyle {
 }
 
 public extension StatusStyle where Self == StatusColorStyleStyle {
-    // `.negativeLabel` color style for `Status`
+    /// `.negativeLabel` color style for `Status`
     static var negativeLabel: Self {
         StatusColorStyleStyle(style: .negativeLabel)
     }
     
-    // `.positiveLabel` color style for `Status`
+    /// `.positiveLabel` color style for `Status`
     static var positiveLabel: Self {
         StatusColorStyleStyle(style: .positiveLabel)
     }
     
-    // `.criticalLabel` color style for `Status`
+    /// `.criticalLabel` color style for `Status`
     static var criticalLabel: Self {
         StatusColorStyleStyle(style: .criticalLabel)
     }
     
-    // `.informativeLabel` color style for `Status`
+    /// `.informativeLabel` color style for `Status`
     static var informativeLabel: Self {
         StatusColorStyleStyle(style: .informativeLabel)
     }

--- a/Sources/FioriSwiftUICore/_FioriStyles/SubstatusStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/SubstatusStyle.fiori.swift
@@ -27,7 +27,7 @@ public struct SubstatusFioriStyle: SubstatusStyle {
     }
 }
 
-// A convenient `SubstatusStyle` to set a foreground color for `Substatus`
+/// A convenient `SubstatusStyle` to set a foreground color for `Substatus`
 public struct SubstatusColorStyle: SubstatusStyle {
     let style: ColorStyle
     public func makeBody(_ configuration: SubstatusConfiguration) -> some View {
@@ -38,22 +38,22 @@ public struct SubstatusColorStyle: SubstatusStyle {
 }
 
 public extension SubstatusStyle where Self == SubstatusColorStyle {
-    // `.negativeLabel` color style for `Substatus`
+    /// `.negativeLabel` color style for `Substatus`
     static var negativeLabel: Self {
         SubstatusColorStyle(style: .negativeLabel)
     }
     
-    // `.positiveLabel` color style for `Substatus`
+    /// `.positiveLabel` color style for `Substatus`
     static var positiveLabel: Self {
         SubstatusColorStyle(style: .positiveLabel)
     }
     
-    // `.criticalLabel` color style for `Substatus`
+    /// `.criticalLabel` color style for `Substatus`
     static var criticalLabel: Self {
         SubstatusColorStyle(style: .criticalLabel)
     }
     
-    // `.informativeLabel` color style for `Substatus`
+    /// `.informativeLabel` color style for `Substatus`
     static var informativeLabel: Self {
         SubstatusColorStyle(style: .informativeLabel)
     }

--- a/Sources/FioriSwiftUICore/_FioriStyles/SubstatusStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/SubstatusStyle.fiori.swift
@@ -26,3 +26,35 @@ public struct SubstatusFioriStyle: SubstatusStyle {
             .font(.fiori(forTextStyle: .subheadline))
     }
 }
+
+// A convenient `SubstatusStyle` to set a foreground color for `Substatus`
+public struct SubstatusColorStyle: SubstatusStyle {
+    let style: ColorStyle
+    public func makeBody(_ configuration: SubstatusConfiguration) -> some View {
+        Substatus(configuration)
+            .foregroundStyle(Color.preferredColor(self.style))
+            .font(.fiori(forTextStyle: .subheadline))
+    }
+}
+
+public extension SubstatusStyle where Self == SubstatusColorStyle {
+    // `.negativeLabel` color style for `Substatus`
+    static var negativeLabel: Self {
+        SubstatusColorStyle(style: .negativeLabel)
+    }
+    
+    // `.positiveLabel` color style for `Substatus`
+    static var positiveLabel: Self {
+        SubstatusColorStyle(style: .positiveLabel)
+    }
+    
+    // `.criticalLabel` color style for `Substatus`
+    static var criticalLabel: Self {
+        SubstatusColorStyle(style: .criticalLabel)
+    }
+    
+    // `.informativeLabel` color style for `Substatus`
+    static var informativeLabel: Self {
+        SubstatusColorStyle(style: .informativeLabel)
+    }
+}


### PR DESCRIPTION
jira: HCPSDKFIORIUIKIT-1975

A status contains a text and an icon in ObjectItem:
![Screenshot 2025-03-20 at 10 54 00 AM](https://github.com/user-attachments/assets/75f9ca40-45ba-409b-b9ba-11ab1dc13cbf)


A Substatus contains a text and an icon and the icon shows in .trailing position in ObjectHeader:
![Screenshot 2025-03-20 at 10 54 20 AM](https://github.com/user-attachments/assets/7ce9e84e-ad62-4a75-9951-5f000baa9297)

A Substatus contains a text and icon and the icon shows in .leading position in TimeLine:
![Screenshot 2025-03-20 at 10 54 45 AM](https://github.com/user-attachments/assets/50aa3731-720a-4b96-972b-6e8a8e1ea516)
