### PR TITLE
fix: 🐛 MandatoryAttachmentExample file path error

### DIFF
--- a/Apps/Examples/Examples.xcodeproj/project.pbxproj
+++ b/Apps/Examples/Examples.xcodeproj/project.pbxproj
@@ -195,7 +195,6 @@
 		C106AD482B33940600FE8B35 /* SearchWithBookmark.swift in Sources */ = {isa = PBXBuildFile; fileRef = C106AD472B33940600FE8B35 /* SearchWithBookmark.swift */; };
 		C106AD4A2B33970500FE8B35 /* SearchPromptFontAndColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C106AD492B33970500FE8B35 /* SearchPromptFontAndColor.swift */; };
 		C12EDF6B2D5EB98F006CF674 /* Square Image.jpeg in Resources */ = {isa = PBXBuildFile; fileRef = C12EDF6A2D5EB98F006CF674 /* Square Image.jpeg */; };
-		C15005182DA44C3600BB0EA8 /* MandatoryAttachmentExample.swift in Sources */ = {isa = PBXBuildFile; fileRef = C15005172DA44C3600BB0EA8 /* MandatoryAttachmentExample.swift */; };
 		C150CCCC2B86B78E00118DF7 /* ChromeEffect.swift in Sources */ = {isa = PBXBuildFile; fileRef = C150CCCB2B86B78E00118DF7 /* ChromeEffect.swift */; };
 		C167183C2B477A81005E2629 /* SearchDemos.swift in Sources */ = {isa = PBXBuildFile; fileRef = C167183B2B477A81005E2629 /* SearchDemos.swift */; };
 		C18868D12B32535100F865F7 /* SearchFontAndColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C18868D02B32535100F865F7 /* SearchFontAndColor.swift */; };
@@ -714,6 +713,7 @@
 				1F60179529A8439A00DBDCDE /* WatchExamples Watch App */,
 				8A55795424C1286E0098003A /* Products */,
 				8A557A1224C129900098003A /* Frameworks */,
+				A6DFDEBB2DA6750900666A51 /* Recovered References */,
 			);
 			sourceTree = "<group>";
 		};
@@ -929,6 +929,14 @@
 			path = Views;
 			sourceTree = "<group>";
 		};
+		A6DFDEBB2DA6750900666A51 /* Recovered References */ = {
+			isa = PBXGroup;
+			children = (
+				C15005172DA44C3600BB0EA8 /* MandatoryAttachmentExample.swift */,
+			);
+			name = "Recovered References";
+			sourceTree = "<group>";
+		};
 		AB988B11263128C400483D87 /* DataTable */ = {
 			isa = PBXGroup;
 			children = (
@@ -1114,24 +1122,6 @@
 			path = SortFilter;
 			sourceTree = "<group>";
 		};
-		C1ECE3272D2C8F27003ACD24 /* Attachment */ = {
-			isa = PBXGroup;
-			children = (
-				C15005172DA44C3600BB0EA8 /* MandatoryAttachmentExample.swift */,
-				C180F30C2D820E4200991974 /* AttachmentExamples.swift */,
-				C180F3082D7A3F3200991974 /* AttachmentDelegateExample.swift */,
-				C1865DA02D6D322600C42A98 /* FilterCFG.swift */,
-				C1865D9E2D6D31C400C42A98 /* PhotoFilter.swift */,
-				C1865D9C2D6D31B600C42A98 /* FileFilter.swift */,
-				C12EDF682D5EB2BA006CF674 /* AttachmentPreviewExample.swift */,
-				C12EDC552D5A8CF5006CF674 /* Sandbox.swift */,
-				C19CAF842D41B6C90052FF2D /* AttachmentGroupExample.swift */,
-				C1ECE3242D2C8F27003ACD24 /* AttachmentGroupCustomExample.swift */,
-			);
-			path = Attachment;
-			sourceTree = "<group>";
-		};
-
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -1347,7 +1337,6 @@
 				1F55FEF32AC941FF00D7A1BE /* View+Extensions.swift in Sources */,
 				6DEC31F42C463ED50084DD20 /* FioriButtonTestsExample.swift in Sources */,
 				8A6DE30B28DD27F9003222E3 /* Colors.swift in Sources */,
-				C15005182DA44C3600BB0EA8 /* MandatoryAttachmentExample.swift in Sources */,
 				876964222D6B7D0C005AB5B2 /* KPIViewExample.swift in Sources */,
 				8AD9DFB225D49967007448EC /* StylingModifierExample.swift in Sources */,
 				9D0B260A2B9BA5C0004278A5 /* NoteFormViewExample.swift in Sources */,


### PR DESCRIPTION
project build fail: Build input file cannot be found: '/Users/***/***/Fiori/SwiftUI_SDK/cloud-sdk-ios-fiori/Apps/Examples/MandatoryAttachmentExample.swift'. Did you forget to declare this file as an output of a script phase or custom build rule which produces it?
