### PR TITLE
test: 💍 restore default UISegmentedControl appearance

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/Picker/SegmentedControlExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/Picker/SegmentedControlExample.swift
@@ -6,7 +6,7 @@ struct SegmentedControlExample: View {
     var segments: [AttributedString] = ["Segment 1", "Segment 2", "Segment 3"]
     @State var selectedIndex: Int = 0
     @State private var _isCustomStyle = false
-
+    
     struct CustomStyle: SegmentedControlPickerStyle {
         func makeBody(_ configuration: SegmentedControlPickerConfiguration) -> some View {
             let appearance = UISegmentedControl.appearance()
@@ -29,13 +29,21 @@ struct SegmentedControlExample: View {
             
             if self._isCustomStyle {
                 SegmentedControlPicker(options: self.segments, selectedIndex: self.$selectedIndex).segmentedControlPickerStyle(CustomStyle())
+                    .onDisappear {
+                        // Reset the appearance when it disappears. Otherwise, the style will affect other views using UISegmentedControl
+                        let appearance = UISegmentedControl.appearance()
+                        appearance.selectedSegmentTintColor = nil
+                        appearance.backgroundColor = .systemBackground
+                        UISegmentedControl.appearance().setTitleTextAttributes(nil, for: .normal)
+                        UISegmentedControl.appearance().setTitleTextAttributes(nil, for: .selected)
+                    }
             } else {
                 SegmentedControlPicker(options: self.segments, selectedIndex: self.$selectedIndex)
             }
         }
     }
 }
-    
+
 struct SegmentedControlExample_Previews: PreviewProvider {
     static var previews: some View {
         SegmentedControlExample()


### PR DESCRIPTION
After using the "Custom Style" test case in SegmentedControlExample, the customized style will be applied to other test cases as well. See screenshot for Checkout Indicator. Fix this by resetting UISegmentedControl appearance when SegmentedControlExample view disappears.

Before Fix:
![Simulator Screenshot - iPhone 16 Pro Max Example - 2025-04-30 at 11 03 21](https://github.com/user-attachments/assets/89009a49-86c0-479a-925e-0bb9f3fbc11d)

After Fix:
![Simulator Screenshot - iPhone 16 Pro Max Example - 2025-04-30 at 11 12 22](https://github.com/user-attachments/assets/319c3615-cff4-4c4d-a90d-7c2cc5febd4d)

