### PR TITLE
fix: 🐛 remove clipped() in Carousel [jira: IOSSDKBUG-701]

### DIFF
--- a/Sources/FioriSwiftUICore/Views/Carousel.swift
+++ b/Sources/FioriSwiftUICore/Views/Carousel.swift
@@ -289,7 +289,6 @@ public struct Carousel<Content>: View where Content: View {
                     }
             )
         }
-        .clipped()
         .modifier(CarouselSizeModifier())
         .onPreferenceChange(CarouselSizePreferenceKey.self) { size in
             DispatchQueue.main.async {


### PR DESCRIPTION
BREAKING CHANGE: 🧨 Carousel doesn't clip itself by default.

Before:
![Screenshot 2025-05-01 at 10 58 45 AM](https://github.com/user-attachments/assets/4ae96086-328c-4556-b59f-1e077530466b)

After:
![Screenshot 2025-05-01 at 10 57 43 AM](https://github.com/user-attachments/assets/147ead08-8e56-4f91-ae9a-b441535896f7)
