### PR TITLE
fix: 🐛 [HCPSDKFIORIUIKIT-2931] Fix Toast Message text styling

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/ToastMessage/ToastMessageExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/ToastMessage/ToastMessageExample.swift
@@ -44,19 +44,20 @@ struct ToastMessageBasicExample: View {
 struct ToastMessagePositionExample: View {
     @State var selectedPosition: ToastMessagePosition = .above
     @State var spacing: CGFloat = 0
+    @State var parentViewHeight: CGFloat = 100
     @State var showIcon = false
 
     var body: some View {
         VStack {
             HStack {}
-                .frame(maxWidth: 300, maxHeight: 300)
+                .frame(maxWidth: 300, maxHeight: self.parentViewHeight)
                 .border(.blue, width: 1)
                 .toastMessage(isPresented: .constant(true),
                               icon: {
                                   self.showIcon ? Image(systemName: "info.circle") : nil
                               },
                               title: {
-                                  Text("Toast Message Title")
+                                  Text("Unable to submit request. Please try again later.")
                               },
                               duration: .infinity,
                               position: self.selectedPosition,
@@ -65,12 +66,13 @@ struct ToastMessagePositionExample: View {
             VStack {
                 Picker("Position", selection: self.$selectedPosition) {
                     ForEach(ToastMessagePosition.allCases) { position in
-
                         Text(position.rawValue)
                     }
                 }
                 Text("Spacing: \(self.spacing)")
                 Slider(value: self.$spacing, in: -50.0 ... 50.0, step: 5)
+                Text("Parent View Height: \(self.parentViewHeight)")
+                Slider(value: self.$parentViewHeight, in: 5 ... 300.0, step: 5)
                 Toggle("Show Icon", isOn: self.$showIcon)
             }
             .frame(maxWidth: 300)
@@ -170,12 +172,5 @@ struct ToastMessageCustomStyleExample: View {
                 .padding(30)
         }
         .navigationTitle("Toast Message")
-    }
-}
-
-struct DetailView_Previews1: PreviewProvider {
-    static var previews: some View {
-        ToastMessagePositionExample()
-            .environment(\.locale, .init(identifier: "ar"))
     }
 }

--- a/Sources/FioriSwiftUICore/_FioriStyles/ToastMessageStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/ToastMessageStyle.fiori.swift
@@ -35,8 +35,8 @@ public struct ToastMessageBaseStyle: ToastMessageStyle {
             configuration.icon
                 .foregroundColor(Color.preferredColor(.primaryLabel))
             configuration.title
-                .font(Font.fiori(forTextStyle: .subheadline))
                 .foregroundColor(Color.preferredColor(.primaryLabel))
+                .fixedSize(horizontal: false, vertical: true)
         }
         .padding(20)
         .frame(width: size.width * (self.horizontalSizeClass == .compact ? 0.8 : 0.6))
@@ -103,9 +103,7 @@ extension ToastMessageFioriStyle {
 
         func makeBody(_ configuration: TitleConfiguration) -> some View {
             Title(configuration)
-            // Add default style for Title
-            // .foregroundStyle(Color.preferredColor(<#fiori color#>))
-            // .font(.fiori(forTextStyle: <#fiori font#>))
+                .font(Font.fiori(forTextStyle: .subheadline))
         }
     }
 }


### PR DESCRIPTION
This PR prevents truncation of the title when the parent view has a small height and sets the font size to subhead/15pt.

Before             |  After
:-------------------------:|:-------------------------:
![Simulator Screenshot - iPhone 16 Pro #2 - 2025-05-09 at 12 59 30](https://github.com/user-attachments/assets/81b7073e-4d57-45ca-a981-04ba7debfb0d)  |  ![Simulator Screenshot - iPhone 16 Pro #2 - 2025-05-09 at 13 01 09](https://github.com/user-attachments/assets/9e54f1e5-4179-4490-a915-95d4a303f363)