### PR TITLE
fix: 🐛 [IOSSDKBUG-728] NoteFormView flashes

### DIFF
--- a/Sources/FioriSwiftUICore/_FioriStyles/NoteFormViewStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/NoteFormViewStyle.fiori.swift
@@ -61,7 +61,6 @@ extension NoteFormViewFioriStyle {
                             RoundedRectangle(cornerRadius: 8)
                                 .stroke(self.getBorderColor(configuration), lineWidth: self.getBorderWidth(configuration))
                         )
-                        .cornerRadius(8)
                         .setOnChange(of: configuration.text, action1: { s in
                             self.checkCharCount(configuration, textString: s)
                         }) { _, s in


### PR DESCRIPTION
Fixed [IOSSDKBUG-728] NoteFormView flashes when opening the screen.
The RoundedRectangle in the .overlay already has a corner radius of 8, so the additional .cornerRadius(8) is redundant and cause the flashes.