### PR TITLE
fix: 🐛 object item title style to primary label

### DIFF
--- a/Sources/FioriSwiftUICore/_FioriStyles/ObjectItemStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/ObjectItemStyle.fiori.swift
@@ -552,7 +552,6 @@ extension ObjectItemFioriStyle {
         func makeBody(_ configuration: TitleConfiguration) -> some View {
             Title(configuration)
                 .font(.fiori(forTextStyle: .headline, weight: .semibold))
-                .foregroundStyle(Color.preferredColor(.baseBlack))
         }
     }
 


### PR DESCRIPTION
Title foreground color should be primary label, no need extra setting.
https://github.com/SAP/cloud-sdk-ios-fiori/issues/1103
<img width="50%" alt="Screenshot 2025-06-16 at 10 00 47" src="https://github.com/user-attachments/assets/74f98e99-35c5-4148-9dee-66a928b4f7fe" />
