### PR TITLE
fix: 🐛 object item title style to primary label

### DIFF
--- a/Sources/FioriSwiftUICore/_FioriStyles/ObjectItemStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/ObjectItemStyle.fiori.swift
@@ -552,7 +552,6 @@ extension ObjectItemFioriStyle {
         func makeBody(_ configuration: TitleConfiguration) -> some View {
             Title(configuration)
                 .font(.fiori(forTextStyle: .headline, weight: .semibold))
-                .foregroundStyle(Color.preferredColor(.baseBlack))
         }
     }
 


### PR DESCRIPTION
Ref: #1106 