### PR TITLE
fix: 🐛 extra top spacing for description in object item

### DIFF
--- a/Sources/FioriSwiftUICore/_FioriStyles/ObjectItemStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/ObjectItemStyle.fiori.swift
@@ -43,13 +43,12 @@ public struct ObjectItemBaseStyle: ObjectItemStyle {
         }
         
         var isCenterAligned: Bool {
-            configuration.subtitle.isEmpty && configuration.footnote.isEmpty && configuration.tags.isEmpty && (configuration.description.isEmpty || !isCompact)
+            configuration.subtitle.isEmpty && configuration.footnote.isEmpty && configuration.tags.isEmpty && (configuration.description.isEmpty || !isCompact || !configuration.showsDescriptionInCompact)
         }
         
         let context = Context(configuration: configuration, shouldShowAvatar: shouldShowAvatar, avatarView: avatarView)
         
-        // FIXME: check if VStack causes any problem.
-        return VStack {
+        return Group {
             if !configuration.action.isEmpty {
                 // When only the headline label is used, everything in the cell is center aligned. Only 1 status can be used.
                 if isCenterAligned {
@@ -318,12 +317,15 @@ extension ObjectItemBaseStyle {
                     Spacer().frame(width: 12)
                 }
                 
-                VStack(alignment: .leading, spacing: 3) {
-                    context.configuration.title.lineLimit(2)
-                    context.configuration.subtitle
-                    context.configuration.footnote
-                    context.configuration.tags
-                    self.footnoteIconsView(context)
+                VStack(alignment: .leading, spacing: 8) {
+                    VStack(alignment: .leading, spacing: 3) {
+                        context.configuration.title.lineLimit(2)
+                        context.configuration.subtitle
+                        context.configuration.footnote
+                        context.configuration.tags
+                        self.footnoteIconsView(context)
+                    }
+                    
                     if context.configuration.showsDescriptionInCompact {
                         context.configuration.description
                     }


### PR DESCRIPTION
3 vertical spacing for title, subtitle..., which is right in code.
Just extra top spacing needed for description.
I can't find a latest spec for specific spacing between each elements. I'm not sure if this one is out of date.

|spec|app view|
|-|-|
|<img width="618" alt="Screenshot 2025-06-17 at 15 57 37" src="https://github.com/user-attachments/assets/20c262f0-dbc6-4a28-a589-d5f83ee3b14a" />|![Simulator Screenshot - iPhone 16 Pro Max - 2025-06-17 at 16 15 12](https://github.com/user-attachments/assets/34287589-350e-4e8e-8106-927fcec5d19b)|
