### PR TITLE
fix: 🐛 extra top spacing for description in object item

### DIFF
--- a/Sources/FioriSwiftUICore/_FioriStyles/ObjectItemStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/ObjectItemStyle.fiori.swift
@@ -43,13 +43,12 @@ public struct ObjectItemBaseStyle: ObjectItemStyle {
         }
         
         var isCenterAligned: Bool {
-            configuration.subtitle.isEmpty && configuration.footnote.isEmpty && configuration.tags.isEmpty && (configuration.description.isEmpty || !isCompact)
+            configuration.subtitle.isEmpty && configuration.footnote.isEmpty && configuration.tags.isEmpty && (configuration.description.isEmpty || !isCompact || !configuration.showsDescriptionInCompact)
         }
         
         let context = Context(configuration: configuration, shouldShowAvatar: shouldShowAvatar, avatarView: avatarView)
         
-        // FIXME: check if VStack causes any problem.
-        return VStack {
+        return Group {
             if !configuration.action.isEmpty {
                 // When only the headline label is used, everything in the cell is center aligned. Only 1 status can be used.
                 if isCenterAligned {
@@ -318,12 +317,15 @@ extension ObjectItemBaseStyle {
                     Spacer().frame(width: 12)
                 }
                 
-                VStack(alignment: .leading, spacing: 3) {
-                    context.configuration.title.lineLimit(2)
-                    context.configuration.subtitle
-                    context.configuration.footnote
-                    context.configuration.tags
-                    self.footnoteIconsView(context)
+                VStack(alignment: .leading, spacing: 8) {
+                    VStack(alignment: .leading, spacing: 3) {
+                        context.configuration.title.lineLimit(2)
+                        context.configuration.subtitle
+                        context.configuration.footnote
+                        context.configuration.tags
+                        self.footnoteIconsView(context)
+                    }
+                    
                     if context.configuration.showsDescriptionInCompact {
                         context.configuration.description
                     }


### PR DESCRIPTION
Ref: #1111