### PR TITLE
fix: 🐛 [IOSSDKBUG-749] Optimize the animation of Order Picker

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/Picker/OrderPickerExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/Picker/OrderPickerExample.swift
@@ -48,10 +48,6 @@ struct OrderPickerExample: View {
                     c.subtitle
                         .lineLimit(1)
                 }
-                .accessoryIconStyle { c in
-                    c.accessoryIcon
-                        .foregroundStyle(Color.preferredColor(.baseBlack))
-                }
         }
     }
     

--- a/Sources/FioriSwiftUICore/_ComponentProtocols/CompositeComponentProtocols.swift
+++ b/Sources/FioriSwiftUICore/_ComponentProtocols/CompositeComponentProtocols.swift
@@ -2172,7 +2172,7 @@ protocol _ActivationScreenComponent: _TitleComponent, _DescriptionTextComponent,
 }
 
 // sourcery: CompositeComponent
-protocol _SortCriterionComponent: _CheckmarkComponent, _TitleComponent, _SubtitleComponent, _AccessoryIconComponent {
+protocol _SortCriterionComponent: _CheckmarkComponent, _TitleComponent, _SubtitleComponent {
     // sourcery: @Binding
     /// The data of the Order Picker Item
     var data: OrderPickerItemModel { get }

--- a/Sources/FioriSwiftUICore/_FioriStyles/SortCriterionStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/SortCriterionStyle.fiori.swift
@@ -6,55 +6,43 @@ import SwiftUI
 public struct SortCriterionBaseStyle: SortCriterionStyle {
     @Environment(\.sizeCategory) private var sizeCategory
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
-    @Environment(\.verticalSizeClass) var verticalSizeClass
     @EnvironmentObject private var modelObject: OrderPickerModelObject
-    @State private var originalModelObject: [OrderPickerItemModel] = []
-        
+    
     public func makeBody(_ configuration: SortCriterionConfiguration) -> some View {
-        VStack(spacing: 0) {
-            HStack {
-                HStack(alignment: .top) {
-                    Checkmark(checkmark: configuration.data.selectedIcon ?? Image(systemName: "checkmark"))
-                        .frame(minHeight: 44)
-                        .padding(EdgeInsets(top: 0, leading: self.getWidth(compactWidth: 16), bottom: 0, trailing: self.getWidth(compactWidth: 8)))
-                        .setHidden(!configuration.data.isSelected)
-                                    
-                    if self.sizeCategory.isAccessibilityCategory {
-                        self.configureMainStack(configuration, isVertical: true)
-                    } else {
-                        ViewThatFits {
-                            self.configureMainStack(configuration, isVertical: false)
-                        }
+        HStack(spacing: 0) {
+            HStack(alignment: .top, spacing: 0) {
+                Checkmark(checkmark: configuration.data.selectedIcon ?? Image(systemName: "checkmark"))
+                    .padding(EdgeInsets(top: 8, leading: 0, bottom: 0, trailing: self.getWidth(compactWidth: 8)))
+                    .setHidden(!configuration.data.isSelected)
+
+                if self.sizeCategory.isAccessibilityCategory {
+                    self.configureMainStack(configuration, isVertical: true)
+                } else {
+                    ViewThatFits {
+                        self.configureMainStack(configuration, isVertical: false)
                     }
                 }
-                .accessibilityElement(children: .contain)
-                .accessibilityLabel(configuration.data.description)
-                .accessibilityAddTraits(.isButton)
-                .frame(minHeight: 44)
-                .contentShape(Rectangle())
-                .background(self.modelObject.highlightedItemID == configuration.data.id ? Color.preferredColor(.quaternaryFill) : Color.clear)
-                .gesture(
-                    LongPressGesture(minimumDuration: 0.2)
-                        .onEnded { _ in
-                            self.modelObject.highlightedItemID = configuration.data.id
-                        }
-                )
-                
-                DraggableImage(item: configuration.$data, modelObject: self.modelObject, sortCriterionBaseStyle: self)
-            }.accessibilityElement(children: .combine)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .contentShape(Rectangle())
-                .onTapGesture {
-                    let trueCount = self.modelObject.items.filter(\.isSelected).count
-                    if !configuration.data.isSelected || trueCount > (self.modelObject.configuration.isAtLeastOneSelected ? 1 : 0) {
-                        configuration.data.isSelected.toggle()
-                        if let index = self.modelObject.items.firstIndex(where: { $0.id == configuration.data.id }) {
-                            self.dataChangeHandler(OrderPickerItemModel.Change.selected(index: index, isSelected: configuration.data.isSelected))
-                        }
+            }
+            .contentShape(Rectangle())
+            .background(self.modelObject.highlightedItemID == configuration.data.id ? Color.preferredColor(.quaternaryFill) : Color.clear)
+            .gesture(
+                LongPressGesture(minimumDuration: 0.2)
+                    .onEnded { _ in
+                        self.modelObject.highlightedItemID = configuration.data.id
                     }
-                    self.modelObject.highlightedItemID = nil
+            )
+        }
+        .contentShape(Rectangle())
+        .onTapGesture {
+            let trueCount = self.modelObject.items.filter(\.isSelected).count
+            
+            if !configuration.data.isSelected || trueCount > (self.modelObject.configuration.isAtLeastOneSelected ? 1 : 0) {
+                configuration.data.isSelected.toggle()
+                if let index = self.modelObject.items.firstIndex(where: { $0.id == configuration.data.id }) {
+                    self.dataChangeHandler(OrderPickerItemModel.Change.selected(index: index, isSelected: configuration.data.isSelected))
                 }
-            Divider().padding(.leading, self.getWidth(compactWidth: 16))
+                self.modelObject.highlightedItemID = nil
+            }
         }
     }
     
@@ -62,42 +50,32 @@ public struct SortCriterionBaseStyle: SortCriterionStyle {
         @EnvironmentObject var modelObject: OrderPickerModelObject
         let mainStack = isVertical ? AnyLayout(VStackLayout(alignment: .leading, spacing: 0)) : AnyLayout(HStackLayout())
         return mainStack {
-            HStack {
-                Title(title: configuration.data.criterion)
-                    .padding(.trailing, self.getWidth(compactWidth: 16))
-                if isVertical {
-                    Spacer()
-                }
-            }
+            Title(title: configuration.data.criterion)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.trailing, self.getWidth(compactWidth: 16))
             
-            if !isVertical {
-                Spacer(minLength: 0)
-            }
-            
-            ZStack {
-                if configuration.data.isSelected {
-                    Subtitle(subtitle: configuration.data.isAscending ? configuration.data.ascendingText : configuration.data.descendingText)
-                        .ifApply(isVertical) {
-                            $0.frame(maxWidth: .infinity, alignment: .leading)
-                        }
+            if configuration.data.isSelected {
+                ZStack {
+                    if configuration.data.isSelected {
+                        Subtitle(subtitle: configuration.data.isAscending ? configuration.data.ascendingText : configuration.data.descendingText)
+                            .ifApply(isVertical) {
+                                $0.frame(maxWidth: .infinity, alignment: .leading)
+                            }
+                            .ifApply(!isVertical) {
+                                $0.frame(minWidth: 44, alignment: .trailing)
+                            }
+                    }
                 }
-            }
-            .frame(minWidth: 44, maxHeight: .infinity)
-            .padding(.trailing, self.getWidth(compactWidth: 6))
-            .contentShape(Rectangle())
-            .onTapGesture {
-                if configuration.data.isSelected {
+                .frame(maxHeight: .infinity)
+                .padding(.trailing, self.getWidth(compactWidth: 6))
+                .contentShape(Rectangle())
+                .onTapGesture {
                     configuration.data.isAscending.toggle()
                     if let index = self.modelObject.items.firstIndex(where: { $0.id == configuration.data.id }) {
                         self.dataChangeHandler(OrderPickerItemModel.Change.ascending(index: index, isAscending: configuration.data.isAscending))
                     }
-                } else {
-                    configuration.data.isSelected.toggle()
-                    if let index = self.modelObject.items.firstIndex(where: { $0.id == configuration.data.id }) {
-                        self.dataChangeHandler(OrderPickerItemModel.Change.selected(index: index, isSelected: configuration.data.isSelected))
-                    }
+                    self.modelObject.highlightedItemID = nil
                 }
-                self.modelObject.highlightedItemID = nil
             }
         }
     }
@@ -111,77 +89,6 @@ public struct SortCriterionBaseStyle: SortCriterionStyle {
     func getWidth(compactWidth: CGFloat) -> CGFloat {
         let width: CGFloat = self.horizontalSizeClass == .regular ? (compactWidth + 4) : compactWidth
         return width
-    }
-    
-    struct DraggableImage: View {
-        @Binding var item: OrderPickerItemModel
-        var modelObject: OrderPickerModelObject
-        var sortCriterionBaseStyle: SortCriterionBaseStyle
-        @State private var hasDragged = false
-        
-        var body: some View {
-            AccessoryIcon(accessoryIcon: self.item.accessoryIcon ?? Image(systemName: "line.horizontal.3"))
-                .typeErased
-                .padding(.trailing, self.sortCriterionBaseStyle.getWidth(compactWidth: 16))
-                .frame(width: 44, alignment: .center)
-                .frame(maxHeight: .infinity)
-                .contentShape(Rectangle())
-                .gesture(
-                    LongPressGesture(minimumDuration: 0.7)
-                        .onEnded { _ in
-                            withAnimation(.spring()) {
-                                self.hasDragged = false
-                                self.sortCriterionBaseStyle.originalModelObject = self.modelObject.items
-                                self.modelObject.isDragging = true
-                                self.modelObject.draggingItem = self.item
-                            }
-                        }
-                        .sequenced(before: DragGesture())
-                        .onChanged { sequence in
-                            switch sequence {
-                            case .first:
-                                break
-                            case .second(_, let dragValue):
-                                if let dragValue {
-                                    self.handleDrag(dragValue.translation)
-                                }
-                            @unknown default:
-                                break
-                            }
-                        }
-                )
-                .simultaneousGesture(
-                    DragGesture(minimumDistance: 0)
-                        .onEnded { _ in
-                            if self.modelObject.isDragging {
-                                withAnimation(.spring()) {
-                                    if self.hasDragged, self.modelObject.draggingItem != nil, self.sortCriterionBaseStyle.originalModelObject != self.modelObject.items, let sourceIndex = self.sortCriterionBaseStyle.originalModelObject.firstIndex(where: { $0.id == self.modelObject.draggingItem?.id }), let destinationIndex = self.modelObject.items.firstIndex(where: { $0.id == self.modelObject.draggingItem?.id }) {
-                                        self.sortCriterionBaseStyle.dataChangeHandler(OrderPickerItemModel.Change.order(sourceIndex: sourceIndex, destinationIndex: destinationIndex))
-                                    }
-                                    self.modelObject.isDragging = false
-                                    self.modelObject.draggingItem = nil
-                                    self.sortCriterionBaseStyle.originalModelObject = []
-                                }
-                            }
-                        }
-                )
-        }
-        
-        private func handleDrag(_ translation: CGSize) {
-            guard let draggingItem = self.modelObject.draggingItem,
-                  let from = self.modelObject.items.firstIndex(of: draggingItem) else { return }
-            
-            let offset = translation.height
-            let direction: Int = offset + 22 > 0 ? 1 : -1
-            let to = from + direction
-            
-            guard to >= 0, to < self.modelObject.items.count else { return }
-            
-            withAnimation(.spring()) {
-                self.modelObject.items.swapAt(from, to)
-                self.hasDragged = true
-            }
-        }
     }
 }
 
@@ -228,16 +135,6 @@ extension SortCriterionFioriStyle {
                 .multilineTextAlignment(.leading)
                 .foregroundStyle(Color.preferredColor(self.modelObject.configuration.controlState == .disabled ? .quaternaryLabel : .tintColor))
                 .font(.fiori(forTextStyle: .subheadline, weight: .semibold))
-        }
-    }
-    
-    struct AccessoryIconFioriStyle: AccessoryIconStyle {
-        let sortCriterionConfiguration: SortCriterionConfiguration
-    
-        func makeBody(_ configuration: AccessoryIconConfiguration) -> some View {
-            AccessoryIcon(configuration)
-                .font(.fiori(forTextStyle: .body))
-                .foregroundStyle(Color.preferredColor(.quaternaryLabel))
         }
     }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/SortCriterion/SortCriterion.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/SortCriterion/SortCriterion.generated.swift
@@ -7,7 +7,6 @@ public struct SortCriterion {
     let checkmark: any View
     let title: any View
     let subtitle: any View
-    let accessoryIcon: any View
     /// The data of the Order Picker Item
     @Binding var data: OrderPickerItemModel
 
@@ -20,14 +19,12 @@ public struct SortCriterion {
     public init(@ViewBuilder checkmark: () -> any View = { Image(systemName: "checkmark") },
                 @ViewBuilder title: () -> any View,
                 @ViewBuilder subtitle: () -> any View = { EmptyView() },
-                @ViewBuilder accessoryIcon: () -> any View = { EmptyView() },
                 data: Binding<OrderPickerItemModel>,
                 componentIdentifier: String? = SortCriterion.identifier)
     {
         self.checkmark = Checkmark(checkmark: checkmark, componentIdentifier: componentIdentifier)
         self.title = Title(title: title, componentIdentifier: componentIdentifier)
         self.subtitle = Subtitle(subtitle: subtitle, componentIdentifier: componentIdentifier)
-        self.accessoryIcon = AccessoryIcon(accessoryIcon: accessoryIcon, componentIdentifier: componentIdentifier)
         self._data = data
         self.componentIdentifier = componentIdentifier ?? SortCriterion.identifier
     }
@@ -41,10 +38,9 @@ public extension SortCriterion {
     init(checkmark: Image? = Image(systemName: "checkmark"),
          title: AttributedString,
          subtitle: AttributedString? = nil,
-         accessoryIcon: Image? = nil,
          data: Binding<OrderPickerItemModel>)
     {
-        self.init(checkmark: { checkmark }, title: { Text(title) }, subtitle: { OptionalText(subtitle) }, accessoryIcon: { accessoryIcon }, data: data)
+        self.init(checkmark: { checkmark }, title: { Text(title) }, subtitle: { OptionalText(subtitle) }, data: data)
     }
 }
 
@@ -57,7 +53,6 @@ public extension SortCriterion {
         self.checkmark = configuration.checkmark
         self.title = configuration.title
         self.subtitle = configuration.subtitle
-        self.accessoryIcon = configuration.accessoryIcon
         self._data = configuration.$data
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
         self.componentIdentifier = configuration.componentIdentifier
@@ -69,7 +64,7 @@ extension SortCriterion: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, checkmark: .init(self.checkmark), title: .init(self.title), subtitle: .init(self.subtitle), accessoryIcon: .init(self.accessoryIcon), data: self.$data)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, checkmark: .init(self.checkmark), title: .init(self.title), subtitle: .init(self.subtitle), data: self.$data)).typeErased
                 .transformEnvironment(\.sortCriterionStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -87,7 +82,7 @@ private extension SortCriterion {
     }
 
     func defaultStyle() -> some View {
-        SortCriterion(.init(componentIdentifier: self.componentIdentifier, checkmark: .init(self.checkmark), title: .init(self.title), subtitle: .init(self.subtitle), accessoryIcon: .init(self.accessoryIcon), data: self.$data))
+        SortCriterion(.init(componentIdentifier: self.componentIdentifier, checkmark: .init(self.checkmark), title: .init(self.title), subtitle: .init(self.subtitle), data: self.$data))
             .shouldApplyDefaultStyle(false)
             .sortCriterionStyle(SortCriterionFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/SortCriterion/SortCriterionStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/SortCriterion/SortCriterionStyle.generated.swift
@@ -26,13 +26,11 @@ public struct SortCriterionConfiguration {
     public let checkmark: Checkmark
     public let title: Title
     public let subtitle: Subtitle
-    public let accessoryIcon: AccessoryIcon
     @Binding public var data: OrderPickerItemModel
 
     public typealias Checkmark = ConfigurationViewWrapper
     public typealias Title = ConfigurationViewWrapper
     public typealias Subtitle = ConfigurationViewWrapper
-    public typealias AccessoryIcon = ConfigurationViewWrapper
 }
 
 extension SortCriterionConfiguration {
@@ -47,6 +45,5 @@ public struct SortCriterionFioriStyle: SortCriterionStyle {
             .checkmarkStyle(CheckmarkFioriStyle(sortCriterionConfiguration: configuration))
             .titleStyle(TitleFioriStyle(sortCriterionConfiguration: configuration))
             .subtitleStyle(SubtitleFioriStyle(sortCriterionConfiguration: configuration))
-            .accessoryIconStyle(AccessoryIconFioriStyle(sortCriterionConfiguration: configuration))
     }
 }

--- a/Sources/FioriSwiftUICore/_generated/SupportingFiles/ComponentStyleProtocol+Extension.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/SupportingFiles/ComponentStyleProtocol+Extension.generated.swift
@@ -7647,27 +7647,6 @@ public extension SortCriterionStyle where Self == SortCriterionSubtitleStyle {
     }
 }
 
-public struct SortCriterionAccessoryIconStyle: SortCriterionStyle {
-    let style: any AccessoryIconStyle
-
-    public func makeBody(_ configuration: SortCriterionConfiguration) -> some View {
-        SortCriterion(configuration)
-            .accessoryIconStyle(self.style)
-            .typeErased
-    }
-}
-
-public extension SortCriterionStyle where Self == SortCriterionAccessoryIconStyle {
-    static func accessoryIconStyle(_ style: some AccessoryIconStyle) -> SortCriterionAccessoryIconStyle {
-        SortCriterionAccessoryIconStyle(style: style)
-    }
-
-    static func accessoryIconStyle(@ViewBuilder content: @escaping (AccessoryIconConfiguration) -> some View) -> SortCriterionAccessoryIconStyle {
-        let style = AnyAccessoryIconStyle(content)
-        return SortCriterionAccessoryIconStyle(style: style)
-    }
-}
-
 // MARK: SortFilterViewStyle
 
 public extension SortFilterViewStyle where Self == SortFilterViewBaseStyle {

--- a/Sources/FioriSwiftUICore/_generated/SupportingFiles/ViewEmptyChecking+Extension.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/SupportingFiles/ViewEmptyChecking+Extension.generated.swift
@@ -1107,8 +1107,7 @@ extension SortCriterion: _ViewEmptyChecking {
     public var isEmpty: Bool {
         checkmark.isEmpty &&
             title.isEmpty &&
-            subtitle.isEmpty &&
-            accessoryIcon.isEmpty
+            subtitle.isEmpty
     }
 }
 


### PR DESCRIPTION
1. Leverage List for managing drag-and-drop and animating the Order Picker

2. Remove SortCriterion's accessoryIcon and use List's reorder icon instead

3. Optimize the data binding process