### PR TITLE
fix: 🐛 [IOSSDKBUG-774] List row background in OrderPicker

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/Picker/OrderPickerExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/Picker/OrderPickerExample.swift
@@ -27,7 +27,7 @@ struct OrderPickerExample: View {
         
         return [
             OrderPickerItemModel(criterion: "Priority", isSelected: false, isAscending: true, ascendingText: "Lowest first", descendingText: "Highest first"),
-            OrderPickerItemModel(selectedIcon: customSelectedIcon, criterion: "Order Picker sort criterion 2 lines (Custom Style: First line Second line)", isSelected: true, isAscending: false, ascendingText: customAsc, descendingText: customDesc, customStyle: CustomSortCriterionStyle()),
+            OrderPickerItemModel(selectedIcon: customSelectedIcon, criterion: "Order Picker sort criterion 2 lines (Custom Style: First line Second line)", isSelected: true, isAscending: false, ascendingText: customAsc, descendingText: customDesc, customStyle: CustomSortCriterionStyle(), customListRowBackground: Color.indigo),
             OrderPickerItemModel(criterion: "Name", isSelected: false, isAscending: true, ascendingText: "Ascending", descendingText: "Descending")
         ]
     }()
@@ -60,6 +60,7 @@ struct OrderPickerExample: View {
                         .font(.fiori(forTextStyle: .largeTitle))
                         .foregroundStyle(Color.preferredColor(.red6))
                 }
+                .background(.gray)
         }
     }
 

--- a/Sources/FioriSwiftUICore/_FioriStyles/OrderPickerStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/OrderPickerStyle.fiori.swift
@@ -22,6 +22,7 @@ public struct OrderPickerBaseStyle: OrderPickerStyle {
                     .accessibilityElement(children: .combine)
                     .accessibilityLabel(item.wrappedValue.description)
                     .accessibilityAddTraits(.isButton)
+                    .listRowBackground(item.wrappedValue.customListRowBackground ?? Color.clear)
                 }.onMove(perform: self.moveItems)
             }
         }
@@ -112,6 +113,8 @@ public struct OrderPickerItemModel: Identifiable, Hashable, Equatable, CustomStr
     
     /// An optional `customStyle`
     public var customStyle: (any SortCriterionStyle)?
+    /// An optional color that determins the background color of the custom list row.
+    public var customListRowBackground: Color?
     
     /// Public initializer for OrderPickerItemModel.
     /// - Parameters:
@@ -122,8 +125,9 @@ public struct OrderPickerItemModel: Identifiable, Hashable, Equatable, CustomStr
     ///   - ascendingText: The text displayed when the criterion is ascending, such as "Ascending".
     ///   - descendingText: The text displayed when the criterion is descending, such as "Descending"
     ///   - customStyle: An optional `customStyle`
+    ///   - customListRowBackground: An optional color that determins the background color of the custom list row.
 
-    public init(id: UUID = UUID(), selectedIcon: Image? = nil, criterion: AttributedString, isSelected: Bool = false, isAscending: Bool = true, ascendingText: AttributedString, descendingText: AttributedString, customStyle: (any SortCriterionStyle)? = nil) {
+    public init(id: UUID = UUID(), selectedIcon: Image? = nil, criterion: AttributedString, isSelected: Bool = false, isAscending: Bool = true, ascendingText: AttributedString, descendingText: AttributedString, customStyle: (any SortCriterionStyle)? = nil, customListRowBackground: Color? = nil) {
         self.selectedIcon = selectedIcon
         self.criterion = criterion
         self.isSelected = isSelected
@@ -131,6 +135,7 @@ public struct OrderPickerItemModel: Identifiable, Hashable, Equatable, CustomStr
         self.ascendingText = ascendingText
         self.descendingText = descendingText
         self.customStyle = customStyle
+        self.customListRowBackground = customListRowBackground
     }
     
     public var description: String {

--- a/Sources/FioriSwiftUICore/_FioriStyles/OrderPickerStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/OrderPickerStyle.fiori.swift
@@ -113,7 +113,7 @@ public struct OrderPickerItemModel: Identifiable, Hashable, Equatable, CustomStr
     
     /// An optional `customStyle`
     public var customStyle: (any SortCriterionStyle)?
-    /// An optional color that determins the background color of the custom list row.
+    /// An optional color that determines the background color of the custom list row.
     public var customListRowBackground: Color?
     
     /// Public initializer for OrderPickerItemModel.
@@ -125,7 +125,7 @@ public struct OrderPickerItemModel: Identifiable, Hashable, Equatable, CustomStr
     ///   - ascendingText: The text displayed when the criterion is ascending, such as "Ascending".
     ///   - descendingText: The text displayed when the criterion is descending, such as "Descending"
     ///   - customStyle: An optional `customStyle`
-    ///   - customListRowBackground: An optional color that determins the background color of the custom list row.
+    ///   - customListRowBackground: An optional color that determines the background color of the custom list row.
 
     public init(id: UUID = UUID(), selectedIcon: Image? = nil, criterion: AttributedString, isSelected: Bool = false, isAscending: Bool = true, ascendingText: AttributedString, descendingText: AttributedString, customStyle: (any SortCriterionStyle)? = nil, customListRowBackground: Color? = nil) {
         self.selectedIcon = selectedIcon

--- a/Tests/FioriSwiftUITests/FioriSwiftUICore/OrderPickerTests.swift
+++ b/Tests/FioriSwiftUITests/FioriSwiftUICore/OrderPickerTests.swift
@@ -70,8 +70,8 @@ final class OrderPickerTests: XCTestCase {
             OrderPickerItemModel(criterion: "data1_criterion 1", isSelected: false, isAscending: true, ascendingText: "data1_asc 1", descendingText: "data1_des 1"),
             OrderPickerItemModel(criterion: "data1_criterion 2", isSelected: true, isAscending: false, ascendingText: "data1_asc 2", descendingText: "data1_des 2"),
             OrderPickerItemModel(criterion: "data1_criterion 3", isSelected: true, isAscending: true, ascendingText: customAsc, descendingText: customDesc),
-            OrderPickerItemModel(criterion: "data1_criterion 4", isSelected: false, isAscending: false, ascendingText: "data1_asc 4", descendingText: "data1_des 4", customStyle: CustomSortCriterionStyle()),
-            OrderPickerItemModel(criterion: "data1_criterion 5", isSelected: true, isAscending: false, ascendingText: "data1_asc 5", descendingText: "data1_des 5")
+            OrderPickerItemModel(criterion: "data1_criterion 4", isSelected: false, isAscending: false, ascendingText: "data1_asc 4", descendingText: "data1_des 4", customStyle: CustomSortCriterionStyle(), customListRowBackground: Color.green),
+            OrderPickerItemModel(criterion: "data1_criterion 5", isSelected: true, isAscending: false, ascendingText: "data1_asc 5", descendingText: "data1_des 5", customListRowBackground: Color.clear)
         ]
     }()
     
@@ -119,8 +119,8 @@ final class OrderPickerTests: XCTestCase {
     }
     
     func testSortCriterion() throws {
-        let orderPickerItemModel = OrderPickerItemModel(selectedIcon: Image(systemName: "checkmark.circle.fill"), criterion: "Price 1", isSelected: true, isAscending: false, ascendingText: "asc", descendingText: "des", customStyle: CustomSortCriterionStyle())
-        
+        let orderPickerItemModel = OrderPickerItemModel(selectedIcon: Image(systemName: "checkmark.circle.fill"), criterion: "Price 1", isSelected: true, isAscending: false, ascendingText: "asc", descendingText: "des", customStyle: CustomSortCriterionStyle(), customListRowBackground: Color.red)
+
         let sortCriterionView = SortCriterion(title: orderPickerItemModel.criterion, data: .constant(orderPickerItemModel))
         
         XCTAssertEqual(sortCriterionView.data.criterion, orderPickerItemModel.criterion)
@@ -130,6 +130,7 @@ final class OrderPickerTests: XCTestCase {
         XCTAssertEqual(sortCriterionView.data.descendingText, orderPickerItemModel.descendingText)
         
         XCTAssertEqual(sortCriterionView.data.selectedIcon, orderPickerItemModel.selectedIcon)
+        XCTAssertEqual(sortCriterionView.data.customListRowBackground, orderPickerItemModel.customListRowBackground)
         
         XCTAssertTrue(self.compareData(sortCriterionView.title, orderPickerItemModel.criterion))
     }
@@ -184,5 +185,8 @@ final class OrderPickerTests: XCTestCase {
         XCTAssertEqual(orderPickerView.data[2].isAscending, self.data1[2].isAscending)
         XCTAssertEqual(orderPickerView.data[2].ascendingText, self.data1[2].ascendingText)
         XCTAssertEqual(orderPickerView.data[2].descendingText, self.data1[2].descendingText)
+        
+        XCTAssertEqual(orderPickerView.data[3].customListRowBackground, self.data1[3].customListRowBackground)
+        XCTAssertEqual(orderPickerView.data[4].customListRowBackground, self.data1[4].customListRowBackground)
     }
 }


### PR DESCRIPTION
1. Set the default background of the list row to be transparent
2. Add a property to the OrderPickerItemModel to allow setting a custom background color for the list row.

