### PR TITLE
fix: 🐛 localization string format fix

### DIFF
--- a/Sources/FioriSwiftUICore/_localization/en.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/en.lproj/FioriSwiftUICore.strings
@@ -492,25 +492,25 @@
 "Redo" = "Redo";
 
 /* XTIT: Writing assistant cancel alert title */
-"Close Writing Assistant without saving changes?" = "Close Writing Assistant without saving changes?"
+"Close Writing Assistant without saving changes?" = "Close Writing Assistant without saving changes?";
 
 /* XBUT: Writing assistant cancel alert action title for keep working */
-"Keep Working" = "Keep Working"
+"Keep Working" = "Keep Working";
 
 /* XBUT: Writing assistant cancel alert action title for close */
-"Close" = "Close"
+"Close" = "Close";
 
 /* XMSG: A success toast message for feedback flow in writing assistant */
-"Thank you for your feedback" = "Thank you for your feedback"
+"Thank you for your feedback" = "Thank you for your feedback";
 
 /* XTIT: Title for feedback downvote flow in writing assistant */
-"What didn’t you like about this version?" = "What didn’t you like about this version?"
+"What didn’t you like about this version?" = "What didn’t you like about this version?";
 
 /* XTIT: Subtitle for feedback downvote flow in writing assistant */
-"Please rate your experience to help us improve." = "Please rate your experience to help us improve."
+"Please rate your experience to help us improve." = "Please rate your experience to help us improve.";
 
 /* XTIT: Navigation bar title for feedback flow */
-"Feedback" = "Feedback"
+"Feedback" = "Feedback";
 
 /* XTIT: Footnote text for feedback in writing assistant */
-"How was this response?" = "How was this response?"
+"How was this response?" = "How was this response?";


### PR DESCRIPTION
Build error:
cloud-sdk-ios-fiori/Sources/FioriSwiftUICore/_localization/en.lproj/FioriSwiftUICore.strings:1:1: error: validation failed: Couldn't parse property list because the input data was in an invalid format (in target 'FioriSwiftUICore' from project 'FioriSwiftUI')