### PR TITLE
refactor: 💡 remove introspect spm dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,9 +25,6 @@ let package = Package(
             targets: ["FioriThemeManager"]
         )
     ],
-    dependencies: [
-        .package(url: "https://github.com/siteline/swiftui-introspect.git", from: "1.3.0")
-    ],
     targets: [
         .target(
             name: "FioriSwiftUI",
@@ -42,8 +39,7 @@ let package = Package(
             name: "FioriSwiftUICore",
             dependencies: [
                 .target(name: "FioriThemeManager", condition: .when(platforms: [.iOS, .macCatalyst, .visionOS])),
-                .target(name: "FioriCharts", condition: .when(platforms: [.iOS, .macCatalyst, .visionOS])),
-                .product(name: "SwiftUIIntrospect", package: "swiftui-introspect", condition: .when(platforms: [.iOS, .macCatalyst]))
+                .target(name: "FioriCharts", condition: .when(platforms: [.iOS, .macCatalyst, .visionOS]))
             ],
             resources: [.process("_localization")]
         ),

--- a/Sources/FioriSwiftUICore/FioriIntrospect/IntrospectSource/Introspect.swift
+++ b/Sources/FioriSwiftUICore/FioriIntrospect/IntrospectSource/Introspect.swift
@@ -1,0 +1,221 @@
+// Source: https://github.com/siteline/swiftui-introspect
+/**
+ MIT License:
+ 
+ Copyright 2019 Timber Software
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#if !os(watchOS)
+    import SwiftUI
+
+    /// The scope of introspection i.e. where introspect should look to find
+    /// the desired target view relative to the applied `.introspect(...)`
+    /// modifier.
+    struct IntrospectionScope: OptionSet, Sendable {
+        /// Look within the `receiver` of the `.introspect(...)` modifier.
+        static let receiver = Self(rawValue: 1 << 0)
+        /// Look for an `ancestor` relative to the `.introspect(...)` modifier.
+        static let ancestor = Self(rawValue: 1 << 1)
+
+        let rawValue: UInt
+
+        init(rawValue: UInt) {
+            self.rawValue = rawValue
+        }
+    }
+
+    extension View {
+        /// Introspects a SwiftUI view to find its underlying UIKit/AppKit instance.
+        ///
+        /// - Parameters:
+        ///   - viewType: The type of view to be introspected.
+        ///   - platforms: A list of version predicates that specify platform-specific entities associated with the view.
+        ///   - scope: Optionally overrides the view's default scope of introspection.
+        ///   - customize: A closure that hands over the underlying UIKit/AppKit instance ready for customization.
+        ///
+        /// Here's an example usage:
+        ///
+        /// ```swift
+        /// struct ContentView: View {
+        ///     @State var text = ""
+        ///
+        ///     var body: some View {
+        ///         TextField("Placeholder", text: $text)
+        ///             .introspect(.textField, on: .iOS(.v13, .v14, .v15, .v16, .v17, .v18, .v26)) {
+        ///                 print(type(of: $0)) // UITextField
+        ///             }
+        ///     }
+        /// }
+        /// ```
+        @MainActor
+        func introspect<SwiftUIViewType: IntrospectableViewType, PlatformSpecificEntity: PlatformEntity>(
+            _ viewType: SwiftUIViewType,
+            on platforms: PlatformViewVersionPredicate<SwiftUIViewType, PlatformSpecificEntity>...,
+            scope: IntrospectionScope? = nil,
+            customize: @escaping (PlatformSpecificEntity) -> Void
+        ) -> some View {
+            self.modifier(IntrospectModifier(viewType, platforms: platforms, scope: scope, customize: customize))
+        }
+    }
+
+    struct IntrospectModifier<SwiftUIViewType: IntrospectableViewType, PlatformSpecificEntity: PlatformEntity>: ViewModifier {
+        let id = IntrospectionViewID()
+        let scope: IntrospectionScope
+        let selector: IntrospectionSelector<PlatformSpecificEntity>?
+        let customize: (PlatformSpecificEntity) -> Void
+
+        @MainActor
+        init(
+            _ viewType: SwiftUIViewType,
+            platforms: [PlatformViewVersionPredicate<SwiftUIViewType, PlatformSpecificEntity>],
+            scope: IntrospectionScope?,
+            customize: @escaping (PlatformSpecificEntity) -> Void
+        ) {
+            self.scope = scope ?? viewType.scope
+            self.selector = platforms.lazy.compactMap(\.selector).first
+            self.customize = customize
+        }
+
+        func body(content: Content) -> some View {
+            if let selector {
+                content
+                    .background(
+                        Group {
+                            // box up content for more accurate `.view` introspection
+                            if SwiftUIViewType.self == ViewType.self {
+                                Color.white
+                                    .opacity(0)
+                                    .accessibility(hidden: true)
+                            }
+                        }
+                    )
+                    .background(
+                        IntrospectionAnchorView(id: self.id)
+                            .frame(width: 0, height: 0)
+                            .accessibility(hidden: true)
+                    )
+                    .overlay(
+                        IntrospectionView(id: self.id, selector: { selector($0, self.scope) }, customize: self.customize)
+                            .frame(width: 0, height: 0)
+                            .accessibility(hidden: true)
+                    )
+            } else {
+                content
+            }
+        }
+    }
+
+    @MainActor
+    protocol PlatformEntity: AnyObject {
+        associatedtype Base: PlatformEntity
+
+        var ancestor: Base? { get }
+
+        var descendants: [Base] { get }
+
+        func isDescendant(of other: Base) -> Bool
+    }
+
+    extension PlatformEntity {
+        var ancestor: Base? { nil }
+
+        var descendants: [Base] { [] }
+
+        func isDescendant(of other: Base) -> Bool { false }
+    }
+
+    extension PlatformEntity {
+        var ancestors: some Sequence<Base> {
+            sequence(first: self~, next: { $0.ancestor~ }).dropFirst()
+        }
+
+        var allDescendants: some Sequence<Base> {
+            recursiveSequence([self~], children: { $0.descendants~ }).dropFirst()
+        }
+
+        func nearestCommonAncestor(with other: Base) -> Base? {
+            var nearestAncestor: Base? = self~
+
+            while let currentEntity = nearestAncestor, !other.isDescendant(of: currentEntity~) {
+                nearestAncestor = currentEntity.ancestor~
+            }
+
+            return nearestAncestor
+        }
+
+        func allDescendants(between bottomEntity: Base, and topEntity: Base) -> some Sequence<Base> {
+            self.allDescendants
+                .lazy
+                .drop(while: { $0 !== bottomEntity })
+                .prefix(while: { $0 !== topEntity })
+        }
+
+        func receiver<PlatformSpecificEntity: PlatformEntity>(
+            ofType type: PlatformSpecificEntity.Type
+        ) -> PlatformSpecificEntity? {
+            let frontEntity = self
+            guard
+                let backEntity = frontEntity.introspectionAnchorEntity,
+                let commonAncestor = backEntity.nearestCommonAncestor(with: frontEntity~)
+            else {
+                return nil
+            }
+
+            return commonAncestor
+                .allDescendants(between: backEntity~, and: frontEntity~)
+                .filter { !$0.isIntrospectionPlatformEntity }
+                .compactMap { $0 as? PlatformSpecificEntity }
+                .first
+        }
+
+        func ancestor<PlatformSpecificEntity: PlatformEntity>(
+            ofType type: PlatformSpecificEntity.Type
+        ) -> PlatformSpecificEntity? {
+            self.ancestors
+                .lazy
+                .filter { !$0.isIntrospectionPlatformEntity }
+                .compactMap { $0 as? PlatformSpecificEntity }
+                .first
+        }
+    }
+
+    extension PlatformView: PlatformEntity {
+        var ancestor: PlatformView? {
+            superview
+        }
+
+        var descendants: [PlatformView] {
+            subviews
+        }
+    }
+
+    extension PlatformViewController: PlatformEntity {
+        var ancestor: PlatformViewController? {
+            parent
+        }
+
+        var descendants: [PlatformViewController] {
+            children
+        }
+
+        func isDescendant(of other: PlatformViewController) -> Bool {
+            self.ancestors.contains(other)
+        }
+    }
+
+    #if canImport(UIKit)
+        extension UIPresentationController: PlatformEntity {
+            typealias Base = UIPresentationController
+        }
+
+    #elseif canImport(AppKit)
+        extension NSWindow: PlatformEntity {
+            typealias Base = NSWindow
+        }
+    #endif
+#endif

--- a/Sources/FioriSwiftUICore/FioriIntrospect/IntrospectSource/IntrospectableViewType.swift
+++ b/Sources/FioriSwiftUICore/FioriIntrospect/IntrospectSource/IntrospectableViewType.swift
@@ -1,0 +1,32 @@
+// Source: https://github.com/siteline/swiftui-introspect
+/**
+ MIT License:
+ 
+ Copyright 2019 Timber Software
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#if !os(watchOS)
+    @MainActor
+    protocol IntrospectableViewType {
+        /// The scope of introspection for this particular view type, i.e. where introspect
+        /// should look to find the desired target view relative to the applied
+        /// `.introspect(...)` modifier.
+        ///
+        /// While the scope can be overridden by the user in their `.introspect(...)` call,
+        /// most of the time it's preferable to defer to the view type's own scope,
+        /// as it guarantees introspection is working as intended by the vendor.
+        ///
+        /// Defaults to `.receiver` if left unimplemented, which is a sensible one in
+        /// most cases if you're looking to implement your own view type.
+        var scope: IntrospectionScope { get }
+    }
+
+    extension IntrospectableViewType {
+        var scope: IntrospectionScope { .receiver }
+    }
+#endif

--- a/Sources/FioriSwiftUICore/FioriIntrospect/IntrospectSource/IntrospectionSelector.swift
+++ b/Sources/FioriSwiftUICore/FioriIntrospect/IntrospectSource/IntrospectionSelector.swift
@@ -1,0 +1,84 @@
+// Source: https://github.com/siteline/swiftui-introspect
+/**
+ MIT License:
+ 
+ Copyright 2019 Timber Software
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#if !os(watchOS)
+
+    @MainActor
+    struct IntrospectionSelector<Target: PlatformEntity> {
+        static var `default`: Self { .from(Target.self, selector: { $0 }) }
+
+        static func from<Entry: PlatformEntity>(_ entryType: Entry.Type, selector: @MainActor @escaping (Entry) -> Target?) -> Self {
+            .init(
+                receiverSelector: { controller in
+                    controller.as(Entry.Base.self)?.receiver(ofType: Entry.self).flatMap(selector)
+                },
+                ancestorSelector: { controller in
+                    controller.as(Entry.Base.self)?.ancestor(ofType: Entry.self).flatMap(selector)
+                }
+            )
+        }
+
+        private var receiverSelector: @MainActor (IntrospectionPlatformViewController) -> Target?
+        private var ancestorSelector: @MainActor (IntrospectionPlatformViewController) -> Target?
+
+        private init(
+            receiverSelector: @MainActor @escaping (IntrospectionPlatformViewController) -> Target?,
+            ancestorSelector: @MainActor @escaping (IntrospectionPlatformViewController) -> Target?
+        ) {
+            self.receiverSelector = receiverSelector
+            self.ancestorSelector = ancestorSelector
+        }
+
+        func withReceiverSelector(_ selector: @MainActor @escaping (PlatformViewController) -> Target?) -> Self {
+            var copy = self
+            copy.receiverSelector = selector
+            return copy
+        }
+
+        func withAncestorSelector(_ selector: @MainActor @escaping (PlatformViewController) -> Target?) -> Self {
+            var copy = self
+            copy.ancestorSelector = selector
+            return copy
+        }
+
+        func callAsFunction(_ controller: IntrospectionPlatformViewController, _ scope: IntrospectionScope) -> Target? {
+            if
+                scope.contains(.receiver),
+                let target = receiverSelector(controller)
+            {
+                return target
+            }
+            if
+                scope.contains(.ancestor),
+                let target = ancestorSelector(controller)
+            {
+                return target
+            }
+            return nil
+        }
+    }
+
+    extension PlatformViewController {
+        func `as`<Base: PlatformEntity>(_ baseType: Base.Type) -> (any PlatformEntity)? {
+            if Base.self == PlatformView.self {
+                #if canImport(UIKit)
+                    return viewIfLoaded
+                #elseif canImport(AppKit)
+                    return isViewLoaded ? view : nil
+                #endif
+            } else if Base.self == PlatformViewController.self {
+                return self
+            }
+            return nil
+        }
+    }
+#endif

--- a/Sources/FioriSwiftUICore/FioriIntrospect/IntrospectSource/IntrospectionView.swift
+++ b/Sources/FioriSwiftUICore/FioriIntrospect/IntrospectSource/IntrospectionView.swift
@@ -1,0 +1,261 @@
+// Source: https://github.com/siteline/swiftui-introspect
+/**
+ MIT License:
+ 
+ Copyright 2019 Timber Software
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#if !os(watchOS)
+    import SwiftUI
+
+    typealias IntrospectionViewID = UUID
+
+    @MainActor
+    fileprivate enum IntrospectionStore {
+        static var shared: [IntrospectionViewID: Pair] = [:]
+
+        struct Pair {
+            weak var controller: IntrospectionPlatformViewController?
+            weak var anchor: IntrospectionAnchorPlatformViewController?
+        }
+    }
+
+    extension PlatformEntity {
+        var introspectionAnchorEntity: Base? {
+            if let introspectionController = self as? IntrospectionPlatformViewController {
+                return IntrospectionStore.shared[introspectionController.id]?.anchor~
+            }
+            if
+                let view = self as? PlatformView,
+                let introspectionController = view.introspectionController
+            {
+                return IntrospectionStore.shared[introspectionController.id]?.anchor?.view~
+            }
+            return nil
+        }
+    }
+
+    /// ⚓️
+    struct IntrospectionAnchorView: PlatformViewControllerRepresentable {
+        #if canImport(UIKit)
+            typealias UIViewControllerType = IntrospectionAnchorPlatformViewController
+        #elseif canImport(AppKit)
+            typealias NSViewControllerType = IntrospectionAnchorPlatformViewController
+        #endif
+
+        @Binding
+        private var observed: Void // workaround for state changes not triggering view updates
+
+        let id: IntrospectionViewID
+
+        init(id: IntrospectionViewID) {
+            self._observed = .constant(())
+            self.id = id
+        }
+
+        func makePlatformViewController(context: Context) -> IntrospectionAnchorPlatformViewController {
+            IntrospectionAnchorPlatformViewController(id: self.id)
+        }
+
+        func updatePlatformViewController(_ controller: IntrospectionAnchorPlatformViewController, context: Context) {}
+
+        static func dismantlePlatformViewController(_ controller: IntrospectionAnchorPlatformViewController, coordinator: Coordinator) {}
+    }
+
+    final class IntrospectionAnchorPlatformViewController: PlatformViewController {
+        init(id: IntrospectionViewID) {
+            super.init(nibName: nil, bundle: nil)
+            self.isIntrospectionPlatformEntity = true
+            IntrospectionStore.shared[id, default: .init()].anchor = self
+        }
+
+        @available(*, unavailable)
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        #if canImport(UIKit)
+            override func viewDidLoad() {
+                super.viewDidLoad()
+                view.isIntrospectionPlatformEntity = true
+            }
+
+        #elseif canImport(AppKit)
+            override func loadView() {
+                view = NSView()
+                view.isIntrospectionPlatformEntity = true
+            }
+        #endif
+    }
+
+    struct IntrospectionView<Target: PlatformEntity>: PlatformViewControllerRepresentable {
+        #if canImport(UIKit)
+            typealias UIViewControllerType = IntrospectionPlatformViewController
+        #elseif canImport(AppKit)
+            typealias NSViewControllerType = IntrospectionPlatformViewController
+        #endif
+
+        final class TargetCache {
+            weak var target: Target?
+        }
+
+        @Binding
+        private var observed: Void // workaround for state changes not triggering view updates
+        private let id: IntrospectionViewID
+        private let selector: (IntrospectionPlatformViewController) -> Target?
+        private let customize: (Target) -> Void
+
+        init(
+            id: IntrospectionViewID,
+            selector: @escaping (IntrospectionPlatformViewController) -> Target?,
+            customize: @escaping (Target) -> Void
+        ) {
+            self._observed = .constant(())
+            self.id = id
+            self.selector = selector
+            self.customize = customize
+        }
+
+        func makeCoordinator() -> TargetCache {
+            TargetCache()
+        }
+
+        func makePlatformViewController(context: Context) -> IntrospectionPlatformViewController {
+            let controller = IntrospectionPlatformViewController(id: id) { controller in
+                guard let target = selector(controller) else {
+                    return
+                }
+                context.coordinator.target = target
+                self.customize(target)
+                controller.handler = nil
+            }
+
+            // - Workaround -
+            // iOS/tvOS 13 sometimes need a nudge on the next run loop.
+            if #available(iOS 14, tvOS 14, *) {} else {
+                DispatchQueue.main.async { [weak controller] in
+                    controller?.handler?()
+                }
+            }
+
+            return controller
+        }
+
+        func updatePlatformViewController(_ controller: IntrospectionPlatformViewController, context: Context) {
+            guard let target = context.coordinator.target ?? selector(controller) else {
+                return
+            }
+            self.customize(target)
+        }
+
+        static func dismantlePlatformViewController(_ controller: IntrospectionPlatformViewController, coordinator: Coordinator) {
+            controller.handler = nil
+        }
+    }
+
+    final class IntrospectionPlatformViewController: PlatformViewController {
+        let id: IntrospectionViewID
+        var handler: (() -> Void)? = nil
+
+        fileprivate init(
+            id: IntrospectionViewID,
+            handler: ((IntrospectionPlatformViewController) -> Void)?
+        ) {
+            self.id = id
+            super.init(nibName: nil, bundle: nil)
+            self.handler = { [weak self] in
+                guard let self else {
+                    return
+                }
+                handler?(self)
+            }
+            self.isIntrospectionPlatformEntity = true
+            IntrospectionStore.shared[id, default: .init()].controller = self
+        }
+
+        @available(*, unavailable)
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        #if canImport(UIKit)
+            #if os(iOS)
+                override var preferredStatusBarStyle: UIStatusBarStyle {
+                    parent?.preferredStatusBarStyle ?? super.preferredStatusBarStyle
+                }
+            #endif
+
+            override func viewDidLoad() {
+                super.viewDidLoad()
+                view.introspectionController = self
+                view.isIntrospectionPlatformEntity = true
+                self.handler?()
+            }
+
+            override func didMove(toParent parent: UIViewController?) {
+                super.didMove(toParent: parent)
+                self.handler?()
+            }
+
+            override func viewDidLayoutSubviews() {
+                super.viewDidLayoutSubviews()
+                self.handler?()
+            }
+
+            override func viewDidAppear(_ animated: Bool) {
+                super.viewDidAppear(animated)
+                self.handler?()
+            }
+
+        #elseif canImport(AppKit)
+            override func loadView() {
+                view = NSView()
+                view.introspectionController = self
+                view.isIntrospectionPlatformEntity = true
+            }
+
+            override func viewDidLoad() {
+                super.viewDidLoad()
+                self.handler?()
+            }
+
+            override func viewDidAppear() {
+                super.viewDidAppear()
+                self.handler?()
+            }
+        #endif
+    }
+
+    import ObjectiveC
+
+    fileprivate extension PlatformView {
+        var introspectionController: IntrospectionPlatformViewController? {
+            get {
+                let key = unsafeBitCast(Selector(#function), to: UnsafeRawPointer.self)
+                return objc_getAssociatedObject(self, key) as? IntrospectionPlatformViewController
+            }
+            set {
+                let key = unsafeBitCast(Selector(#function), to: UnsafeRawPointer.self)
+                objc_setAssociatedObject(self, key, newValue, .OBJC_ASSOCIATION_ASSIGN)
+            }
+        }
+    }
+
+    extension PlatformEntity {
+        var isIntrospectionPlatformEntity: Bool {
+            get {
+                let key = unsafeBitCast(Selector(#function), to: UnsafeRawPointer.self)
+                return objc_getAssociatedObject(self, key) as? Bool ?? false
+            }
+            set {
+                let key = unsafeBitCast(Selector(#function), to: UnsafeRawPointer.self)
+                objc_setAssociatedObject(self, key, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            }
+        }
+    }
+#endif

--- a/Sources/FioriSwiftUICore/FioriIntrospect/IntrospectSource/PlatformVersion.swift
+++ b/Sources/FioriSwiftUICore/FioriIntrospect/IntrospectSource/PlatformVersion.swift
@@ -1,0 +1,435 @@
+// Source: https://github.com/siteline/swiftui-introspect
+/**
+ MIT License:
+ 
+ Copyright 2019 Timber Software
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#if !os(watchOS)
+    import Foundation
+
+    enum PlatformVersionCondition: Sendable {
+        case past
+        case current
+        case future
+    }
+
+    protocol PlatformVersion: Sendable {
+        var condition: PlatformVersionCondition? { get }
+    }
+
+    extension PlatformVersion {
+        var isCurrent: Bool {
+            self.condition == .current
+        }
+
+        var isCurrentOrPast: Bool {
+            self.condition == .current || self.condition == .past
+        }
+  
+        var condition: PlatformVersionCondition? { nil }
+    }
+
+    struct iOSVersion: PlatformVersion {
+        let condition: PlatformVersionCondition?
+
+        init(condition: () -> PlatformVersionCondition?) {
+            self.condition = condition()
+        }
+    }
+
+    extension iOSVersion {
+        static let v13 = iOSVersion {
+            #if os(iOS)
+                if #available(iOS 14, *) {
+                    return .past
+                }
+                if #available(iOS 13, *) {
+                    return .current
+                }
+                return .future
+            #else
+                return nil
+            #endif
+        }
+
+        static let v14 = iOSVersion {
+            #if os(iOS)
+                if #available(iOS 15, *) {
+                    return .past
+                }
+                if #available(iOS 14, *) {
+                    return .current
+                }
+                return .future
+            #else
+                return nil
+            #endif
+        }
+
+        static let v15 = iOSVersion {
+            #if os(iOS)
+                if #available(iOS 16, *) {
+                    return .past
+                }
+                if #available(iOS 15, *) {
+                    return .current
+                }
+                return .future
+            #else
+                return nil
+            #endif
+        }
+
+        static let v16 = iOSVersion {
+            #if os(iOS)
+                if #available(iOS 17, *) {
+                    return .past
+                }
+                if #available(iOS 16, *) {
+                    return .current
+                }
+                return .future
+            #else
+                return nil
+            #endif
+        }
+
+        static let v17 = iOSVersion {
+            #if os(iOS)
+                if #available(iOS 18, *) {
+                    return .past
+                }
+                if #available(iOS 17, *) {
+                    return .current
+                }
+                return .future
+            #else
+                return nil
+            #endif
+        }
+
+        static let v18 = iOSVersion {
+            #if os(iOS)
+                if #available(iOS 19, *) {
+                    return .past
+                }
+                if #available(iOS 18, *) {
+                    return .current
+                }
+                return .future
+            #else
+                return nil
+            #endif
+        }
+
+        static let v26 = iOSVersion {
+            #if os(iOS)
+                if #available(iOS 27, *) {
+                    return .past
+                }
+                // Apps built before the iOS 26 SDK get "19.0" as the system version from ProcessInfo.
+                // Once built with the iOS 26 SDK, the version then becomes "26.0".
+                if #available(iOS 19, *) {
+                    return .current
+                }
+                return .future
+            #else
+                return nil
+            #endif
+        }
+    }
+
+    struct tvOSVersion: PlatformVersion {
+        let condition: PlatformVersionCondition?
+
+        init(condition: () -> PlatformVersionCondition?) {
+            self.condition = condition()
+        }
+    }
+
+    extension tvOSVersion {
+        static let v13 = tvOSVersion {
+            #if os(tvOS)
+                if #available(tvOS 14, *) {
+                    return .past
+                }
+                if #available(tvOS 13, *) {
+                    return .current
+                }
+                return .future
+            #else
+                return nil
+            #endif
+        }
+
+        static let v14 = tvOSVersion {
+            #if os(tvOS)
+                if #available(tvOS 15, *) {
+                    return .past
+                }
+                if #available(tvOS 14, *) {
+                    return .current
+                }
+                return .future
+            #else
+                return nil
+            #endif
+        }
+
+        static let v15 = tvOSVersion {
+            #if os(tvOS)
+                if #available(tvOS 16, *) {
+                    return .past
+                }
+                if #available(tvOS 15, *) {
+                    return .current
+                }
+                return .future
+            #else
+                return nil
+            #endif
+        }
+
+        static let v16 = tvOSVersion {
+            #if os(tvOS)
+                if #available(tvOS 17, *) {
+                    return .past
+                }
+                if #available(tvOS 16, *) {
+                    return .current
+                }
+                return .future
+            #else
+                return nil
+            #endif
+        }
+    
+        static let v17 = tvOSVersion {
+            #if os(tvOS)
+                if #available(tvOS 18, *) {
+                    return .past
+                }
+                if #available(tvOS 17, *) {
+                    return .current
+                }
+                return .future
+            #else
+                return nil
+            #endif
+        }
+
+        static let v18 = tvOSVersion {
+            #if os(tvOS)
+                if #available(tvOS 19, *) {
+                    return .past
+                }
+                if #available(tvOS 18, *) {
+                    return .current
+                }
+                return .future
+            #else
+                return nil
+            #endif
+        }
+
+        static let v26 = tvOSVersion {
+            #if os(tvOS)
+                if #available(tvOS 27, *) {
+                    return .past
+                }
+                // Apps built before the tvOS 26 SDK get "19.0" as the system version from ProcessInfo.
+                // Once built with the tvOS 26 SDK, the version then becomes "26.0".
+                if #available(tvOS 19, *) {
+                    return .current
+                }
+                return .future
+            #else
+                return nil
+            #endif
+        }
+    }
+
+    struct macOSVersion: PlatformVersion {
+        let condition: PlatformVersionCondition?
+
+        init(condition: () -> PlatformVersionCondition?) {
+            self.condition = condition()
+        }
+    }
+
+    extension macOSVersion {
+        static let v10_15 = macOSVersion {
+            #if os(macOS)
+                if #available(macOS 11, *) {
+                    return .past
+                }
+                if #available(macOS 10.15, *) {
+                    return .current
+                }
+                return .future
+            #else
+                return nil
+            #endif
+        }
+
+        static let v10_15_4 = macOSVersion {
+            #if os(macOS)
+                if #available(macOS 11, *) {
+                    return .past
+                }
+                if #available(macOS 10.15.4, *) {
+                    return .current
+                }
+                return .future
+            #else
+                return nil
+            #endif
+        }
+
+        static let v11 = macOSVersion {
+            #if os(macOS)
+                if #available(macOS 12, *) {
+                    return .past
+                }
+                if #available(macOS 11, *) {
+                    return .current
+                }
+                return .future
+            #else
+                return nil
+            #endif
+        }
+
+        static let v12 = macOSVersion {
+            #if os(macOS)
+                if #available(macOS 13, *) {
+                    return .past
+                }
+                if #available(macOS 12, *) {
+                    return .current
+                }
+                return .future
+            #else
+                return nil
+            #endif
+        }
+
+        static let v13 = macOSVersion {
+            #if os(macOS)
+                if #available(macOS 14, *) {
+                    return .past
+                }
+                if #available(macOS 13, *) {
+                    return .current
+                }
+                return .future
+            #else
+                return nil
+            #endif
+        }
+
+        static let v14 = macOSVersion {
+            #if os(macOS)
+                if #available(macOS 15, *) {
+                    return .past
+                }
+                if #available(macOS 14, *) {
+                    return .current
+                }
+                return .future
+            #else
+                return nil
+            #endif
+        }
+
+        static let v15 = macOSVersion {
+            #if os(macOS)
+                if #available(macOS 16, *) {
+                    return .past
+                }
+                if #available(macOS 15, *) {
+                    return .current
+                }
+                return .future
+            #else
+                return nil
+            #endif
+        }
+
+        static let v26 = macOSVersion {
+            #if os(macOS)
+                if #available(macOS 27, *) {
+                    return .past
+                }
+                // Apps built before the macOS 26 SDK get "16.0" as the system version from ProcessInfo.
+                // Once built with the macOS 26 SDK, the version then becomes "26.0".
+                if #available(macOS 16, *) {
+                    return .current
+                }
+                return .future
+            #else
+                return nil
+            #endif
+        }
+    }
+
+    struct visionOSVersion: PlatformVersion {
+        let condition: PlatformVersionCondition?
+
+        init(condition: () -> PlatformVersionCondition?) {
+            self.condition = condition()
+        }
+    }
+
+    extension visionOSVersion {
+        static let v1 = visionOSVersion {
+            #if os(visionOS)
+                if #available(visionOS 2, *) {
+                    return .past
+                }
+                if #available(visionOS 1, *) {
+                    return .current
+                }
+                return .future
+            #else
+                return nil
+            #endif
+        }
+
+        static let v2 = visionOSVersion {
+            #if os(visionOS)
+                if #available(visionOS 3, *) {
+                    return .past
+                }
+                if #available(visionOS 2, *) {
+                    return .current
+                }
+                return .future
+            #else
+                return nil
+            #endif
+        }
+
+        static let v26 = visionOSVersion {
+            #if os(visionOS)
+                if #available(visionOS 27, *) {
+                    return .past
+                }
+                // Apps built before the visionOS 26 SDK get "3.0" as the system version from ProcessInfo.
+                // Once built with the visionOS 26 SDK, the version then becomes "26.0".
+                if #available(visionOS 3, *) {
+                    return .current
+                }
+                return .future
+            #else
+                return nil
+            #endif
+        }
+    }
+#endif

--- a/Sources/FioriSwiftUICore/FioriIntrospect/IntrospectSource/PlatformView.swift
+++ b/Sources/FioriSwiftUICore/FioriIntrospect/IntrospectSource/PlatformView.swift
@@ -1,0 +1,67 @@
+// Source: https://github.com/siteline/swiftui-introspect
+/**
+ MIT License:
+ 
+ Copyright 2019 Timber Software
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#if !os(watchOS)
+    import SwiftUI
+
+    #if canImport(UIKit)
+        typealias PlatformView = UIView
+        typealias PlatformViewController = UIViewController
+        typealias _PlatformViewControllerRepresentable = UIViewControllerRepresentable
+    #elseif canImport(AppKit)
+        typealias PlatformView = NSView
+        typealias PlatformViewController = NSViewController
+        typealias _PlatformViewControllerRepresentable = NSViewControllerRepresentable
+    #endif
+
+    @MainActor
+    protocol PlatformViewControllerRepresentable: _PlatformViewControllerRepresentable {
+        #if canImport(UIKit)
+            typealias ViewController = UIViewControllerType
+        #elseif canImport(AppKit)
+            typealias ViewController = NSViewControllerType
+        #endif
+
+        func makePlatformViewController(context: Context) -> ViewController
+        func updatePlatformViewController(_ controller: ViewController, context: Context)
+        static func dismantlePlatformViewController(_ controller: ViewController, coordinator: Coordinator)
+    }
+
+    extension PlatformViewControllerRepresentable {
+        #if canImport(UIKit)
+            func makeUIViewController(context: Context) -> ViewController {
+                makePlatformViewController(context: context)
+            }
+
+            func updateUIViewController(_ controller: ViewController, context: Context) {
+                updatePlatformViewController(controller, context: context)
+            }
+
+            static func dismantleUIViewController(_ controller: ViewController, coordinator: Coordinator) {
+                dismantlePlatformViewController(controller, coordinator: coordinator)
+            }
+
+        #elseif canImport(AppKit)
+            func makeNSViewController(context: Context) -> ViewController {
+                makePlatformViewController(context: context)
+            }
+
+            func updateNSViewController(_ controller: ViewController, context: Context) {
+                updatePlatformViewController(controller, context: context)
+            }
+
+            static func dismantleNSViewController(_ controller: ViewController, coordinator: Coordinator) {
+                dismantlePlatformViewController(controller, coordinator: coordinator)
+            }
+        #endif
+    }
+#endif

--- a/Sources/FioriSwiftUICore/FioriIntrospect/IntrospectSource/PlatformViewVersion.swift
+++ b/Sources/FioriSwiftUICore/FioriIntrospect/IntrospectSource/PlatformViewVersion.swift
@@ -1,0 +1,136 @@
+// Source: https://github.com/siteline/swiftui-introspect
+/**
+ MIT License:
+ 
+ Copyright 2019 Timber Software
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#if !os(watchOS)
+    import SwiftUI
+
+    @MainActor
+    struct PlatformViewVersionPredicate<SwiftUIViewType: IntrospectableViewType, PlatformSpecificEntity: PlatformEntity> {
+        let selector: IntrospectionSelector<PlatformSpecificEntity>?
+
+        private init<Version: PlatformVersion>(
+            _ versions: [PlatformViewVersion<Version, SwiftUIViewType, PlatformSpecificEntity>],
+            matches: (PlatformViewVersion<Version, SwiftUIViewType, PlatformSpecificEntity>) -> Bool
+        ) {
+            if let matchingVersion = versions.first(where: matches) {
+                self.selector = matchingVersion.selector ?? .default
+            } else {
+                self.selector = nil
+            }
+        }
+
+        static func iOS(_ versions: iOSViewVersion<SwiftUIViewType, PlatformSpecificEntity>...) -> Self {
+            Self(versions, matches: \.isCurrent)
+        }
+    
+        static func iOS(_ versions: PartialRangeFrom<iOSViewVersion<SwiftUIViewType, PlatformSpecificEntity>>) -> Self {
+            Self([versions.lowerBound], matches: \.isCurrentOrPast)
+        }
+
+        static func tvOS(_ versions: tvOSViewVersion<SwiftUIViewType, PlatformSpecificEntity>...) -> Self {
+            Self(versions, matches: \.isCurrent)
+        }
+
+        static func tvOS(_ versions: PartialRangeFrom<tvOSViewVersion<SwiftUIViewType, PlatformSpecificEntity>>) -> Self {
+            Self([versions.lowerBound], matches: \.isCurrentOrPast)
+        }
+
+        static func macOS(_ versions: macOSViewVersion<SwiftUIViewType, PlatformSpecificEntity>...) -> Self {
+            Self(versions, matches: \.isCurrent)
+        }
+
+        static func macOS(_ versions: PartialRangeFrom<macOSViewVersion<SwiftUIViewType, PlatformSpecificEntity>>) -> Self {
+            Self([versions.lowerBound], matches: \.isCurrentOrPast)
+        }
+
+        static func visionOS(_ versions: visionOSViewVersion<SwiftUIViewType, PlatformSpecificEntity>...) -> Self {
+            Self(versions, matches: \.isCurrent)
+        }
+
+        static func visionOS(_ versions: PartialRangeFrom<visionOSViewVersion<SwiftUIViewType, PlatformSpecificEntity>>) -> Self {
+            Self([versions.lowerBound], matches: \.isCurrentOrPast)
+        }
+    }
+
+    typealias iOSViewVersion<SwiftUIViewType: IntrospectableViewType, PlatformSpecificEntity: PlatformEntity> =
+        PlatformViewVersion<iOSVersion, SwiftUIViewType, PlatformSpecificEntity>
+    typealias tvOSViewVersion<SwiftUIViewType: IntrospectableViewType, PlatformSpecificEntity: PlatformEntity> =
+        PlatformViewVersion<tvOSVersion, SwiftUIViewType, PlatformSpecificEntity>
+    typealias macOSViewVersion<SwiftUIViewType: IntrospectableViewType, PlatformSpecificEntity: PlatformEntity> =
+        PlatformViewVersion<macOSVersion, SwiftUIViewType, PlatformSpecificEntity>
+    typealias visionOSViewVersion<SwiftUIViewType: IntrospectableViewType, PlatformSpecificEntity: PlatformEntity> =
+        PlatformViewVersion<visionOSVersion, SwiftUIViewType, PlatformSpecificEntity>
+
+    @MainActor
+    enum PlatformViewVersion<Version: PlatformVersion, SwiftUIViewType: IntrospectableViewType, PlatformSpecificEntity: PlatformEntity>: Sendable {
+        case available(Version, IntrospectionSelector<PlatformSpecificEntity>?)
+        case unavailable
+
+        init(for version: Version, selector: IntrospectionSelector<PlatformSpecificEntity>? = nil) {
+            self = .available(version, selector)
+        }
+
+        static func unavailable(file: StaticString = #file, line: UInt = #line) -> Self {
+            let filePath = file.withUTF8Buffer { String(decoding: $0, as: UTF8.self) }
+            let fileName = URL(fileURLWithPath: filePath).lastPathComponent
+            print(
+                """
+                If you're seeing this, someone forgot to mark \(fileName):\(line) as unavailable.
+
+                This won't have any effect, but it should be disallowed altogether.
+
+                Please report it upstream so we can properly fix it by using the following link:
+
+                https://github.com/siteline/swiftui-introspect/issues/new?title=`\(fileName):\(line)`+should+be+marked+unavailable
+                """
+            )
+            return .unavailable
+        }
+
+        private var version: Version? {
+            if case .available(let version, _) = self {
+                return version
+            } else {
+                return nil
+            }
+        }
+
+        @MainActor
+        fileprivate var selector: IntrospectionSelector<PlatformSpecificEntity>? {
+            if case .available(_, let selector) = self {
+                return selector
+            } else {
+                return nil
+            }
+        }
+
+        fileprivate var isCurrent: Bool {
+            self.version?.isCurrent ?? false
+        }
+
+        fileprivate var isCurrentOrPast: Bool {
+            self.version?.isCurrentOrPast ?? false
+        }
+    }
+
+    // This conformance isn't meant to be used directly by the user,
+    // it's only to satisfy requirements for forming ranges (e.g. `.v15...`).
+    extension PlatformViewVersion: Comparable {
+        public nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
+            true
+        }
+
+        public nonisolated static func < (lhs: Self, rhs: Self) -> Bool {
+            true
+        }
+    }
+#endif

--- a/Sources/FioriSwiftUICore/FioriIntrospect/IntrospectSource/Utils.swift
+++ b/Sources/FioriSwiftUICore/FioriIntrospect/IntrospectSource/Utils.swift
@@ -1,0 +1,40 @@
+// Source: https://github.com/siteline/swiftui-introspect
+/**
+ MIT License:
+ 
+ Copyright 2019 Timber Software
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+postfix operator ~
+
+postfix func ~ <T>(lhs: some Any) -> T {
+    lhs as! T
+}
+
+postfix func ~ <T>(lhs: (some Any)?) -> T? {
+    lhs as? T
+}
+
+func recursiveSequence<S: Sequence>(_ sequence: S, children: @escaping (S.Element) -> S) -> AnySequence<S.Element> {
+    AnySequence {
+        var mainIterator = sequence.makeIterator()
+        // Current iterator, or `nil` if all sequences are exhausted:
+        var iterator: AnyIterator<S.Element>?
+
+        return AnyIterator {
+            guard let iterator, let element = iterator.next() else {
+                if let element = mainIterator.next() {
+                    iterator = recursiveSequence(children(element), children: children).makeIterator()
+                    return element
+                }
+                return nil
+            }
+            return element
+        }
+    }
+}

--- a/Sources/FioriSwiftUICore/FioriIntrospect/IntrospectSource/ViewTypes/ScrollView.swift
+++ b/Sources/FioriSwiftUICore/FioriIntrospect/IntrospectSource/ViewTypes/ScrollView.swift
@@ -1,0 +1,121 @@
+// Source: https://github.com/siteline/swiftui-introspect
+/**
+ MIT License:
+ 
+ Copyright 2019 Timber Software
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#if !os(watchOS)
+    import SwiftUI
+
+    /// An abstract representation of the `ScrollView` type in SwiftUI.
+    ///
+    /// ### iOS
+    ///
+    /// ```swift
+    /// struct ContentView: View {
+    ///     var body: some View {
+    ///         ScrollView {
+    ///             Text("Item")
+    ///         }
+    ///         .introspect(.scrollView, on: .iOS(.v13, .v14, .v15, .v16, .v17, .v18, .v26)) {
+    ///             print(type(of: $0)) // UIScrollView
+    ///         }
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// ### tvOS
+    ///
+    /// ```swift
+    /// struct ContentView: View {
+    ///     var body: some View {
+    ///         ScrollView {
+    ///             Text("Item")
+    ///         }
+    ///         .introspect(.scrollView, on: .tvOS(.v13, .v14, .v15, .v16, .v17, .v18, .v26)) {
+    ///             print(type(of: $0)) // UIScrollView
+    ///         }
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// ### macOS
+    ///
+    /// ```swift
+    /// struct ContentView: View {
+    ///     var body: some View {
+    ///         ScrollView {
+    ///             Text("Item")
+    ///         }
+    ///         .introspect(.scrollView, on: .macOS(.v10_15, .v11, .v12, .v13, .v14, .v15, .v26)) {
+    ///             print(type(of: $0)) // NSScrollView
+    ///         }
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// ### visionOS
+    ///
+    /// ```swift
+    /// struct ContentView: View {
+    ///     var body: some View {
+    ///         ScrollView {
+    ///             Text("Item")
+    ///         }
+    ///         .introspect(.scrollView, on: .visionOS(.v1, .v2, .v26)) {
+    ///             print(type(of: $0)) // UIScrollView
+    ///         }
+    ///     }
+    /// }
+    /// ```
+    struct ScrollViewType: IntrospectableViewType {}
+
+    extension IntrospectableViewType where Self == ScrollViewType {
+        static var scrollView: Self { .init() }
+    }
+
+    #if canImport(UIKit)
+        extension iOSViewVersion<ScrollViewType, UIScrollView> {
+            static let v13 = Self(for: .v13)
+            static let v14 = Self(for: .v14)
+            static let v15 = Self(for: .v15)
+            static let v16 = Self(for: .v16)
+            static let v17 = Self(for: .v17)
+            static let v18 = Self(for: .v18)
+            static let v26 = Self(for: .v26)
+        }
+
+        extension tvOSViewVersion<ScrollViewType, UIScrollView> {
+            static let v13 = Self(for: .v13)
+            static let v14 = Self(for: .v14)
+            static let v15 = Self(for: .v15)
+            static let v16 = Self(for: .v16)
+            static let v17 = Self(for: .v17)
+            static let v18 = Self(for: .v18)
+            static let v26 = Self(for: .v26)
+        }
+
+        extension visionOSViewVersion<ScrollViewType, UIScrollView> {
+            static let v1 = Self(for: .v1)
+            static let v2 = Self(for: .v2)
+            static let v26 = Self(for: .v26)
+        }
+
+    #elseif canImport(AppKit)
+        extension macOSViewVersion<ScrollViewType, NSScrollView> {
+            static let v10_15 = Self(for: .v10_15)
+            static let v11 = Self(for: .v11)
+            static let v12 = Self(for: .v12)
+            static let v13 = Self(for: .v13)
+            static let v14 = Self(for: .v14)
+            static let v15 = Self(for: .v15)
+            static let v26 = Self(for: .v26)
+        }
+    #endif
+#endif

--- a/Sources/FioriSwiftUICore/FioriIntrospect/IntrospectSource/ViewTypes/TextEditor.swift
+++ b/Sources/FioriSwiftUICore/FioriIntrospect/IntrospectSource/ViewTypes/TextEditor.swift
@@ -1,0 +1,104 @@
+// Source: https://github.com/siteline/swiftui-introspect
+/**
+ MIT License:
+ 
+ Copyright 2019 Timber Software
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#if !os(watchOS)
+    import SwiftUI
+
+    /// An abstract representation of the `TextEditor` type in SwiftUI.
+    ///
+    /// ### iOS
+    ///
+    /// ```swift
+    /// struct ContentView: View {
+    ///     @State var text = "Lorem ipsum"
+    ///
+    ///     var body: some View {
+    ///         TextEditor(text: $text)
+    ///             .introspect(.textEditor, on: .iOS(.v14, .v15, .v16, .v17, .v18, .v26)) {
+    ///                 print(type(of: $0)) // UITextView
+    ///             }
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// ### tvOS
+    ///
+    /// Not available.
+    ///
+    /// ### macOS
+    ///
+    /// ```swift
+    /// struct ContentView: View {
+    ///     @State var text = "Lorem ipsum"
+    ///
+    ///     var body: some View {
+    ///         TextEditor(text: $text)
+    ///             .introspect(.textEditor, on: .macOS(.v11, .v12, .v13, .v14, .v15, .v26)) {
+    ///                 print(type(of: $0)) // NSTextView
+    ///             }
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// ### visionOS
+    ///
+    /// ```swift
+    /// struct ContentView: View {
+    ///     @State var text = "Lorem ipsum"
+    ///
+    ///     var body: some View {
+    ///         TextEditor(text: $text)
+    ///             .introspect(.textEditor, on: .visionOS(.v1, .v2, .v26)) {
+    ///                 print(type(of: $0)) // UITextView
+    ///             }
+    ///     }
+    /// }
+    /// ```
+    struct TextEditorType: IntrospectableViewType {}
+
+    #if !os(tvOS)
+        extension IntrospectableViewType where Self == TextEditorType {
+            static var textEditor: Self { .init() }
+        }
+
+        #if canImport(UIKit)
+            extension iOSViewVersion<TextEditorType, UITextView> {
+                @available(*, unavailable, message: "TextEditor isn't available on iOS 13")
+                static let v13 = Self.unavailable()
+                static let v14 = Self(for: .v14)
+                static let v15 = Self(for: .v15)
+                static let v16 = Self(for: .v16)
+                static let v17 = Self(for: .v17)
+                static let v18 = Self(for: .v18)
+                static let v26 = Self(for: .v26)
+            }
+
+            extension visionOSViewVersion<TextEditorType, UITextView> {
+                static let v1 = Self(for: .v1)
+                static let v2 = Self(for: .v2)
+                static let v26 = Self(for: .v26)
+            }
+
+        #elseif canImport(AppKit)
+            extension macOSViewVersion<TextEditorType, NSTextView> {
+                @available(*, unavailable, message: "TextEditor isn't available on macOS 10.15")
+                static let v10_15 = Self.unavailable()
+                static let v11 = Self(for: .v11)
+                static let v12 = Self(for: .v12)
+                static let v13 = Self(for: .v13)
+                static let v14 = Self(for: .v14)
+                static let v15 = Self(for: .v15)
+                static let v26 = Self(for: .v26)
+            }
+        #endif
+    #endif
+#endif

--- a/Sources/FioriSwiftUICore/FioriIntrospect/IntrospectSource/ViewTypes/TextField.swift
+++ b/Sources/FioriSwiftUICore/FioriIntrospect/IntrospectSource/ViewTypes/TextField.swift
@@ -1,0 +1,121 @@
+// Source: https://github.com/siteline/swiftui-introspect
+/**
+ MIT License:
+ 
+ Copyright 2019 Timber Software
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#if !os(watchOS)
+    import SwiftUI
+
+    /// An abstract representation of the `TextField` type in SwiftUI.
+    ///
+    /// ### iOS
+    ///
+    /// ```swift
+    /// struct ContentView: View {
+    ///     @State var text = "Lorem ipsum"
+    ///
+    ///     var body: some View {
+    ///         TextField("Text Field", text: $text)
+    ///             .introspect(.textField, on: .iOS(.v13, .v14, .v15, .v16, .v17, .v18, .v26)) {
+    ///                 print(type(of: $0)) // UITextField
+    ///             }
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// ### tvOS
+    ///
+    /// ```swift
+    /// struct ContentView: View {
+    ///     @State var text = "Lorem ipsum"
+    ///
+    ///     var body: some View {
+    ///         TextField("Text Field", text: $text)
+    ///             .introspect(.textField, on: .tvOS(.v13, .v14, .v15, .v16, .v17, .v18, .v26)) {
+    ///                 print(type(of: $0)) // UITextField
+    ///             }
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// ### macOS
+    ///
+    /// ```swift
+    /// struct ContentView: View {
+    ///     @State var text = "Lorem ipsum"
+    ///
+    ///     var body: some View {
+    ///         TextField("Text Field", text: $text)
+    ///             .introspect(.textField, on: .macOS(.v10_15, .v11, .v12, .v13, .v14, .v15, .v26)) {
+    ///                 print(type(of: $0)) // NSTextField
+    ///             }
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// ### visionOS
+    ///
+    /// ```swift
+    /// struct ContentView: View {
+    ///     @State var text = "Lorem ipsum"
+    ///
+    ///     var body: some View {
+    ///         TextField("Text Field", text: $text)
+    ///             .introspect(.textField, on: .visionOS(.v1, .v2, .v26)) {
+    ///                 print(type(of: $0)) // UITextField
+    ///             }
+    ///     }
+    /// }
+    /// ```
+    struct TextFieldType: IntrospectableViewType {}
+
+    extension IntrospectableViewType where Self == TextFieldType {
+        static var textField: Self { .init() }
+    }
+
+    #if canImport(UIKit)
+        extension iOSViewVersion<TextFieldType, UITextField> {
+            static let v13 = Self(for: .v13)
+            static let v14 = Self(for: .v14)
+            static let v15 = Self(for: .v15)
+            static let v16 = Self(for: .v16)
+            static let v17 = Self(for: .v17)
+            static let v18 = Self(for: .v18)
+            static let v26 = Self(for: .v26)
+        }
+
+        extension tvOSViewVersion<TextFieldType, UITextField> {
+            static let v13 = Self(for: .v13)
+            static let v14 = Self(for: .v14)
+            static let v15 = Self(for: .v15)
+            static let v16 = Self(for: .v16)
+            static let v17 = Self(for: .v17)
+            static let v18 = Self(for: .v18)
+            static let v26 = Self(for: .v26)
+        }
+
+        extension visionOSViewVersion<TextFieldType, UITextField> {
+            static let v1 = Self(for: .v1)
+            static let v2 = Self(for: .v2)
+            static let v26 = Self(for: .v26)
+        }
+
+    #elseif canImport(AppKit)
+        extension macOSViewVersion<TextFieldType, NSTextField> {
+            static let v10_15 = Self(for: .v10_15)
+            static let v11 = Self(for: .v11)
+            static let v12 = Self(for: .v12)
+            static let v13 = Self(for: .v13)
+            static let v14 = Self(for: .v14)
+            static let v15 = Self(for: .v15)
+            static let v26 = Self(for: .v26)
+        }
+    #endif
+#endif

--- a/Sources/FioriSwiftUICore/FioriIntrospect/IntrospectSource/ViewTypes/TextFieldWithVerticalAxis.swift
+++ b/Sources/FioriSwiftUICore/FioriIntrospect/IntrospectSource/ViewTypes/TextFieldWithVerticalAxis.swift
@@ -1,0 +1,139 @@
+// Source: https://github.com/siteline/swiftui-introspect
+/**
+ MIT License:
+ 
+ Copyright 2019 Timber Software
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#if !os(watchOS)
+    import SwiftUI
+
+    /// An abstract representation of the `TextField` type in SwiftUI, with `.vertical` axis.
+    ///
+    /// ### iOS
+    ///
+    /// ```swift
+    /// struct ContentView: View {
+    ///     @State var text = "Lorem ipsum"
+    ///
+    ///     var body: some View {
+    ///         TextField("Text Field", text: $text, axis: .vertical)
+    ///             .introspect(.textField(axis: .vertical), on: .iOS(.v16, .v17, .v18, .v26)) {
+    ///                 print(type(of: $0)) // UITextView
+    ///             }
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// ### tvOS
+    ///
+    /// ```swift
+    /// struct ContentView: View {
+    ///     @State var text = "Lorem ipsum"
+    ///
+    ///     var body: some View {
+    ///         TextField("Text Field", text: $text, axis: .vertical)
+    ///             .introspect(.textField(axis: .vertical), on: .tvOS(.v16, .v17, .v18, .v26)) {
+    ///                 print(type(of: $0)) // UITextField
+    ///             }
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// ### macOS
+    ///
+    /// ```swift
+    /// struct ContentView: View {
+    ///     @State var text = "Lorem ipsum"
+    ///
+    ///     var body: some View {
+    ///         TextField("Text Field", text: $text, axis: .vertical)
+    ///             .introspect(.textField(axis: .vertical), on: .macOS(.v13, .v14, .v15, .v26)) {
+    ///                 print(type(of: $0)) // NSTextField
+    ///             }
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// ### visionOS
+    ///
+    /// ```swift
+    /// struct ContentView: View {
+    ///     @State var text = "Lorem ipsum"
+    ///
+    ///     var body: some View {
+    ///         TextField("Text Field", text: $text, axis: .vertical)
+    ///             .introspect(.textField(axis: .vertical), on: .visionOS(.v1, .v2, .v26)) {
+    ///                 print(type(of: $0)) // UITextView
+    ///             }
+    ///     }
+    /// }
+    /// ```
+    struct TextFieldWithVerticalAxisType: IntrospectableViewType {
+        enum Axis: Sendable {
+            case vertical
+        }
+    }
+
+    extension IntrospectableViewType where Self == TextFieldWithVerticalAxisType {
+        static func textField(axis: Self.Axis) -> Self { .init() }
+    }
+
+    // MARK: SwiftUI.TextField(..., axis: .vertical) - iOS
+
+    #if canImport(UIKit)
+        extension iOSViewVersion<TextFieldWithVerticalAxisType, UITextView> {
+            @available(*, unavailable, message: "TextField(..., axis: .vertical) isn't available on iOS 13")
+            static let v13 = Self.unavailable()
+            @available(*, unavailable, message: "TextField(..., axis: .vertical) isn't available on iOS 14")
+            static let v14 = Self.unavailable()
+            @available(*, unavailable, message: "TextField(..., axis: .vertical) isn't available on iOS 15")
+            static let v15 = Self.unavailable()
+
+            static let v16 = Self(for: .v16)
+            static let v17 = Self(for: .v17)
+            static let v18 = Self(for: .v18)
+            static let v26 = Self(for: .v26)
+        }
+
+        extension tvOSViewVersion<TextFieldWithVerticalAxisType, UITextField> {
+            @available(*, unavailable, message: "TextField(..., axis: .vertical) isn't available on tvOS 13")
+            static let v13 = Self.unavailable()
+            @available(*, unavailable, message: "TextField(..., axis: .vertical) isn't available on tvOS 14")
+            static let v14 = Self.unavailable()
+            @available(*, unavailable, message: "TextField(..., axis: .vertical) isn't available on tvOS 15")
+            static let v15 = Self.unavailable()
+
+            static let v16 = Self(for: .v16)
+            static let v17 = Self(for: .v17)
+            static let v18 = Self(for: .v18)
+            static let v26 = Self(for: .v26)
+        }
+
+        extension visionOSViewVersion<TextFieldWithVerticalAxisType, UITextView> {
+            static let v1 = Self(for: .v1)
+            static let v2 = Self(for: .v2)
+            static let v26 = Self(for: .v26)
+        }
+
+    #elseif canImport(AppKit)
+        extension macOSViewVersion<TextFieldWithVerticalAxisType, NSTextField> {
+            @available(*, unavailable, message: "TextField(..., axis: .vertical) isn't available on macOS 10.15")
+            static let v10_15 = Self.unavailable()
+            @available(*, unavailable, message: "TextField(..., axis: .vertical) isn't available on macOS 11")
+            static let v11 = Self.unavailable()
+            @available(*, unavailable, message: "TextField(..., axis: .vertical) isn't available on macOS 12")
+            static let v12 = Self.unavailable()
+
+            static let v13 = Self(for: .v13)
+            static let v14 = Self(for: .v14)
+            static let v15 = Self(for: .v15)
+            static let v26 = Self(for: .v26)
+        }
+    #endif
+#endif

--- a/Sources/FioriSwiftUICore/FioriIntrospect/IntrospectSource/ViewTypes/View.swift
+++ b/Sources/FioriSwiftUICore/FioriIntrospect/IntrospectSource/ViewTypes/View.swift
@@ -1,0 +1,125 @@
+// Source: https://github.com/siteline/swiftui-introspect
+/**
+ MIT License:
+ 
+ Copyright 2019 Timber Software
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+#if !os(watchOS)
+    import SwiftUI
+
+    /// An abstract representation of a generic SwiftUI view type.
+    ///
+    /// ### iOS
+    ///
+    /// ```swift
+    /// struct ContentView: View {
+    ///     var body: some View {
+    ///         HStack {
+    ///             Image(systemName: "scribble")
+    ///             Text("Some text")
+    ///         }
+    ///         .introspect(.view, on: .iOS(.v13, .v14, .v15, .v16, .v17, .v18, .v26)) {
+    ///             print(type(of: $0)) // some subclass of UIView
+    ///         }
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// ### tvOS
+    ///
+    /// ```swift
+    /// struct ContentView: View {
+    ///     var body: some View {
+    ///         HStack {
+    ///             Image(systemName: "scribble")
+    ///             Text("Some text")
+    ///         }
+    ///         .introspect(.view, on: .tvOS(.v13, .v14, .v15, .v16, .v17, .v18, .v26)) {
+    ///             print(type(of: $0)) // some subclass of UIView
+    ///         }
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// ### macOS
+    ///
+    /// ```swift
+    /// struct ContentView: View {
+    ///     var body: some View {
+    ///         HStack {
+    ///             Image(systemName: "scribble")
+    ///             Text("Some text")
+    ///         }
+    ///         .introspect(.view, on: .macOS(.v10_15, .v11, .v12, .v13, .v14, .v15, .v26)) {
+    ///             print(type(of: $0)) // some subclass of NSView
+    ///         }
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// ### visionOS
+    ///
+    /// ```swift
+    /// struct ContentView: View {
+    ///     var body: some View {
+    ///         HStack {
+    ///             Image(systemName: "scribble")
+    ///             Text("Some text")
+    ///         }
+    ///         .introspect(.view, on: .visionOS(.v1, .v2, .v26)) {
+    ///             print(type(of: $0)) // some subclass of UIView
+    ///         }
+    ///     }
+    /// }
+    /// ```
+    struct ViewType: IntrospectableViewType {}
+
+    extension IntrospectableViewType where Self == ViewType {
+        static var view: Self { .init() }
+    }
+
+    #if canImport(UIKit)
+        extension iOSViewVersion<ViewType, UIView> {
+            static let v13 = Self(for: .v13)
+            static let v14 = Self(for: .v14)
+            static let v15 = Self(for: .v15)
+            static let v16 = Self(for: .v16)
+            static let v17 = Self(for: .v17)
+            static let v18 = Self(for: .v18)
+            static let v26 = Self(for: .v26)
+        }
+
+        extension tvOSViewVersion<ViewType, UIView> {
+            static let v13 = Self(for: .v13)
+            static let v14 = Self(for: .v14)
+            static let v15 = Self(for: .v15)
+            static let v16 = Self(for: .v16)
+            static let v17 = Self(for: .v17)
+            static let v18 = Self(for: .v18)
+            static let v26 = Self(for: .v26)
+        }
+
+        extension visionOSViewVersion<ViewType, UIView> {
+            static let v1 = Self(for: .v1)
+            static let v2 = Self(for: .v2)
+            static let v26 = Self(for: .v26)
+        }
+
+    #elseif canImport(AppKit)
+        extension macOSViewVersion<ViewType, NSView> {
+            static let v10_15 = Self(for: .v10_15)
+            static let v11 = Self(for: .v11)
+            static let v12 = Self(for: .v12)
+            static let v13 = Self(for: .v13)
+            static let v14 = Self(for: .v14)
+            static let v15 = Self(for: .v15)
+            static let v26 = Self(for: .v26)
+        }
+    #endif
+#endif

--- a/Sources/FioriSwiftUICore/Utils/FioriIntrospect.swift
+++ b/Sources/FioriSwiftUICore/Utils/FioriIntrospect.swift
@@ -1,7 +1,6 @@
-#if canImport(SwiftUIIntrospect) && canImport(UIKit)
+#if canImport(UIKit)
     import SwiftUI
     import UIKit
-    @_spi(Advanced) import SwiftUIIntrospect
 
     @MainActor
     struct FioriIntrospectModifier<Target>: ViewModifier {


### PR DESCRIPTION
For introspect, SPM dependency can not be archived into dynamic framework.
Just add source code and repo url and MIT statement added at each file.