### PR TITLE
chore: 🤖 fix dupliate localization string(Cancel)

### DIFF
--- a/Sources/FioriSwiftUICore/_localization/en.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/en.lproj/FioriSwiftUICore.strings
@@ -395,9 +395,6 @@
 /* XBUT: Attachment deletion confirmation button */
 "Delete" = "Delete";
 
-/* XBUT: Attachment Deletion cancel button */
-"Cancel" = "Cancel";
-
 /* XBUT: Attachment add button */
 "Add attachment" = "Add attachment";
 


### PR DESCRIPTION
The "Cancel" string is duplicated in the localization file.