### PR TITLE
fix: 🐛 Card layout return small height some times

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/Card/MobileCardExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/Card/MobileCardExample.swift
@@ -17,11 +17,44 @@ struct MobileCardExample: View {
                 }
                 .cardStyle(.card)
                 .listStyle(.plain)
-                .navigationBarTitle("Cards", displayMode: .inline)
+                .navigationBarTitle("Cards in List", displayMode: .inline)
             } label: {
-                Text("Cards")
+                Text("Cards in List")
             }
             
+            NavigationLink {
+                ScrollView(.vertical) {
+                    VStack(alignment: .leading, spacing: 8) {
+                        ForEach(0 ..< CardTests.cardSamples.count, id: \.self) { i in
+                            CardTests.cardSamples[i]
+                        }
+                        .background(Color.preferredColor(.primaryGroupedBackground))
+                    }
+                }
+                .cardStyle(.card)
+                .navigationBarTitle("Cards in VStack", displayMode: .inline)
+            } label: {
+                Text("Cards in VStack")
+            }
+            
+            NavigationLink {
+                ScrollView(.horizontal) {
+                    HStack(alignment: .top, spacing: 8) {
+                        ForEach(0 ..< CardTests.cardSamples.count, id: \.self) { i in
+                            CardTests.cardSamples[i]
+                                .cardStyle(.card)
+                                .cardStyle(.intrinsicHeightCard)
+                                .padding()
+                        }
+                        .background(Color.preferredColor(.primaryGroupedBackground))
+                    }
+                }
+                .cardStyle(.card)
+                .navigationBarTitle("Cards in HStack", displayMode: .inline)
+            } label: {
+                Text("Cards in HStack")
+            }
+
             NavigationLink {
                 List {
                     ForEach(0 ..< CardTests.cardFooterSamples.count, id: \.self) { i in

--- a/Sources/FioriSwiftUICore/_FioriStyles/CardMainHeaderStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/CardMainHeaderStyle.fiori.swift
@@ -65,6 +65,7 @@ extension CardMainHeaderFioriStyle {
                 // Add default style for Title
                 .foregroundStyle(Color.preferredColor(self.isLoading ? .separator : .primaryLabel))
                 .font(.fiori(forTextStyle: .title3, weight: .bold))
+                .multilineTextAlignment(.leading)
                 .environment(\.numberOfLines, 3)
         }
     }
@@ -77,6 +78,7 @@ extension CardMainHeaderFioriStyle {
                 // Add default style for Subtitle
                 .foregroundStyle(Color.preferredColor(self.isLoading ? .separator : .secondaryLabel))
                 .font(.fiori(forTextStyle: .body))
+                .multilineTextAlignment(.leading)
                 .environment(\.numberOfLines, 2)
         }
     }


### PR DESCRIPTION
This happens when cards are put into a List.