### PR TITLE
fix: [IOSSDKBUG-822] Voiceover for SortFilterItem.switch not clear, value vocalised as "Not selected" or "Selected" instead of 0 or 1 

### DIFF
--- a/Sources/FioriSwiftUICore/Views/SortFilter/SortFilterCFGItemContainer.swift
+++ b/Sources/FioriSwiftUICore/Views/SortFilter/SortFilterCFGItemContainer.swift
@@ -247,6 +247,12 @@ extension SortFilterCFGItemContainer: View {
                 .padding([.top, .bottom], 12)
         case .switch:
             self.switcher(row: r, column: c)
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(self._items[r][c].switch.name)
+                .accessibilityValue(self._items[r][c].switch.isChecked ?
+                    NSLocalizedString("selected", tableName: "FioriSwiftUICore", bundle: Bundle.accessor, comment: "selected") :
+                    NSLocalizedString("not selected", tableName: "FioriSwiftUICore", bundle: Bundle.accessor, comment: "not selected"))
+                .accessibilityHint(self._items[r][c].switch.hint ?? "")
         case .slider:
             self.slider(row: r, column: c)
                 .padding([.top], 12)


### PR DESCRIPTION
Dev result
<img width="1007" height="831" alt="iShot_2025-07-31_16 27 21" src="https://github.com/user-attachments/assets/1766bc60-cd66-449d-a78f-5f4d6bf261d4" />
<img width="1006" height="835" alt="iShot_2025-07-31_16 27 04" src="https://github.com/user-attachments/assets/367219c0-24b7-4671-b012-09019b994b60" />
