### PR TITLE
fix: 🐛 button layout issue in CardFooter [jira: IOSSDKBUG-892]

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/Card/MobileCardExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/Card/MobileCardExample.swift
@@ -23,13 +23,28 @@ struct MobileCardExample: View {
             }
             
             NavigationLink {
+                ScrollView(.vertical) {
+                    VStack(alignment: .leading, spacing: 16) {
+                        ForEach(0 ..< CardTests.cardSamples.count, id: \.self) { i in
+                            CardTests.cardSamples[i]
+                                .cardStyle(.card)
+                                .cardStyle(.intrinsicHeightCard)
+                        }
+                        .background(Color.preferredColor(.primaryGroupedBackground))
+                    }.padding()
+                }
+                .navigationBarTitle("Cards in VStack", displayMode: .inline)
+            } label: {
+                Text("Cards in VStack")
+            }
+            
+            NavigationLink {
                 List {
-                    ForEach(0 ..< CardTests.cardFooterSamples.count, id: \.self) { i in
-                        CardTests.cardFooterSamples[i]
+                    ForEach(0 ..< CardFooterTests.examples.count, id: \.self) { i in
+                        CardFooterTests.examples[i]
                     }
                     .listRowBackground(Color.preferredColor(.primaryGroupedBackground))
                 }
-                .cardStyle(.card)
                 .listStyle(.plain)
                 .navigationBarTitle("Footers", displayMode: .inline)
             } label: {
@@ -326,9 +341,6 @@ struct CarouselTestView: View {
     var body: some View {
         ScrollView(.vertical) {
             VStack(alignment: .leading, spacing: 24) {
-                RoundedRectangle(cornerRadius: 16).foregroundStyle(Color.preferredColor(.grey3)).frame(height: 80)
-                    .padding(.horizontal, 16)
-                
                 Carousel(numberOfColumns: Int(self.numberOfColumns), contentInsets: EdgeInsets(top: 0, leading: self.padding, bottom: 0, trailing: self.padding), spacing: self.spacing, alignment: self.alignment == 0 ? .top : (self.alignment == 1 ? .center : .bottom), isSnapping: self.isSnapping, isSameHeight: self.isSameHeight) {
                     ForEach(0 ..< min(8, CardTests.cardSamples.count), id: \.self) { i in
                         NavigationLink {
@@ -338,9 +350,6 @@ struct CarouselTestView: View {
                         }
                     }
                 }
-                
-                RoundedRectangle(cornerRadius: 16).foregroundStyle(Color.preferredColor(.grey4)).frame(height: 80)
-                    .padding(.horizontal, 16)
             }
             .cardStyle(.card)
         }


### PR DESCRIPTION
Footer:
<img width="877" height="516" alt="Screenshot 2025-08-12 at 4 36 15 PM" src="https://github.com/user-attachments/assets/2cd36778-b4e9-4e32-b57a-7b1e04a20f7e" />
<img width="464" height="929" alt="Screenshot 2025-08-12 at 4 36 11 PM" src="https://github.com/user-attachments/assets/71fa2074-f0b0-495a-912e-eacd0c42bd76" />
