### PR TITLE
feat: 🎸 [HCPSDKFIORIUIKIT-2999] tool bar buttons update

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/ObjectItem/ObjectItemListView.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/ObjectItem/ObjectItemListView.swift
@@ -55,11 +55,13 @@ struct ObjectItemListView<T: ListDataProtocol>: View {
             }
             .objectItemStyle(.actionStyle(ObjectItemBorderedAction()))
         }
-        .navigationBarItems(trailing: HStack {
-            if self.showEditButton {
-                EditButton()
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                if self.showEditButton {
+                    EditButton()
+                }
             }
-        })
+        }
         .navigationBarTitle(self.title, displayMode: .inline)
         .sheet(isPresented: self.$cellTapped) {
             Text("Tapped the cell").padding()

--- a/Apps/Examples/Examples/FioriSwiftUICore/Onboarding/WelcomScreen/OnBoardingWelcomeScreenExamples.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/Onboarding/WelcomScreen/OnBoardingWelcomeScreenExamples.swift
@@ -172,7 +172,8 @@ struct OnBoardingWelcomeScreenExamples: View {
                         } label: { _ in
                             Text("Cancel".localizedFioriString())
                         }
-                        .fioriButtonStyle(FioriTertiaryButtonStyle(colorStyle: .tint).eraseToAnyFioriButtonStyle())
+                        .fioriButtonStyle(FioriNavigationButtonStyle())
+                        .fixedSize()
                     }
                 }
             }

--- a/Sources/FioriSwiftUICore/AIWritingAssistant/InternalWAForm.swift
+++ b/Sources/FioriSwiftUICore/AIWritingAssistant/InternalWAForm.swift
@@ -30,9 +30,11 @@ struct InternalWAForm: View {
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {
                 self.topLeadingButton()
+                    .fixedSize()
             }
             ToolbarItem(placement: .topBarTrailing) {
                 self.topTrailingButton()
+                    .fixedSize()
             }
         }
         .navigationBarBackButtonHidden()

--- a/Sources/FioriSwiftUICore/Components/CancellableResettableForm.swift
+++ b/Sources/FioriSwiftUICore/Components/CancellableResettableForm.swift
@@ -103,10 +103,14 @@ struct CancellableResettableDialogNavigationForm<Title: View, CancelAction: View
                     self.title
                 }
                 ToolbarItem(placement: .topBarLeading) {
-                    self.cancelAction.accessibilityIdentifier("Cancel")
+                    self.cancelAction
+                        .fixedSize()
+                        .accessibilityIdentifier("Cancel")
                 }
                 ToolbarItem(placement: .topBarTrailing) {
-                    self.resetAction.accessibilityIdentifier("Reset")
+                    self.resetAction
+                        .fixedSize()
+                        .accessibilityIdentifier("Reset")
                 }
             }
         }

--- a/Sources/FioriSwiftUICore/FioriButton/FioriButtonStyle.swift
+++ b/Sources/FioriSwiftUICore/FioriButton/FioriButtonStyle.swift
@@ -259,7 +259,7 @@ public struct FioriNavigationButtonStyle: FioriButtonStyle {
         let config = FioriButtonConfiguration(foregroundColor: foregroundColor,
                                               backgroundColor: Color.clear,
                                               font: .fiori(forTextStyle: .body, weight: .semibold),
-                                              padding: EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0),)
+                                              padding: EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
         return configuration.containerView(.unspecified)
             .fioriButtonConfiguration(config)
     }

--- a/Sources/FioriSwiftUICore/FioriButton/FioriButtonStyle.swift
+++ b/Sources/FioriSwiftUICore/FioriButton/FioriButtonStyle.swift
@@ -230,6 +230,41 @@ public struct FioriTertiaryButtonStyle: FioriButtonStyle {
     }
 }
 
+/// A Fiori button style for the navigation bar action.
+public struct FioriNavigationButtonStyle: FioriButtonStyle {
+    private let colorStyle: FioriButtonColorStyle
+    
+    /// Create a `FioriNavigationButtonStyle` instance.
+    /// - Parameters:
+    ///   - colorStyle: The color style used for this button style.
+    ///   - maxWidth: Max width of the button visible area.
+    ///   - minHeight: Min height of the button visible area.
+    ///   - loadingState: Loading state of the button.
+    public init(colorStyle: FioriButtonColorStyle = .tint) {
+        self.colorStyle = colorStyle
+    }
+    
+    public func makeBody(configuration: Configuration) -> some View {
+        let foregroundColor: Color
+        switch configuration.state {
+        case .normal:
+            foregroundColor = .preferredColor(.tintColor)
+        case .highlighted, .selected:
+            foregroundColor = .preferredColor(.tintColorTapState)
+        case .disabled:
+            foregroundColor = .preferredColor(.quaternaryLabel)
+        default:
+            foregroundColor = .preferredColor(.separator)
+        }
+        let config = FioriButtonConfiguration(foregroundColor: foregroundColor,
+                                              backgroundColor: Color.clear,
+                                              font: .fiori(forTextStyle: .body, weight: .semibold),
+                                              padding: EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0),)
+        return configuration.containerView(.unspecified)
+            .fioriButtonConfiguration(config)
+    }
+}
+
 /// The color style of a Fiori button.
 public enum FioriButtonColorStyle {
     case normal

--- a/Sources/FioriSwiftUICore/_FioriStyles/AIUserFeedbackStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/AIUserFeedbackStyle.fiori.swift
@@ -287,7 +287,8 @@ public struct AIUserFeedbackBaseStyle: AIUserFeedbackStyle {
                             .font(.fiori(forTextStyle: .body, weight: .semibold))
                     }
                 }
-                .fioriButtonStyle(AIUserFeedbackToolbarItemStyle())
+                .fioriButtonStyle(FioriNavigationButtonStyle())
+                .fixedSize()
                 .onSimultaneousTapGesture {
                     configuration.onCancel?()
                     self.dismiss()
@@ -296,7 +297,8 @@ public struct AIUserFeedbackBaseStyle: AIUserFeedbackStyle {
         } else {
             ToolbarItem(placement: .topBarLeading) {
                 configuration.cancelAction
-                    .fioriButtonStyle(AIUserFeedbackToolbarItemStyle())
+                    .fioriButtonStyle(FioriNavigationButtonStyle())
+                    .fixedSize()
                     .onSimultaneousTapGesture {
                         configuration.onCancel?()
                         if configuration.displayMode != .inspector {
@@ -465,25 +467,6 @@ extension AIUserFeedbackFioriStyle {
         func makeBody(_ configuration: IllustratedMessageConfiguration) -> some View {
             IllustratedMessage(configuration)
         }
-    }
-}
-
-private struct AIUserFeedbackToolbarItemStyle: FioriButtonStyle {
-    func makeBody(configuration: FioriButtonStyle.Configuration) -> some View {
-        let foregroundColor: Color
-        switch configuration.state {
-        case .normal:
-            foregroundColor = Color.preferredColor(.tintColor)
-        case .highlighted, .selected:
-            foregroundColor = Color.preferredColor(.tintColorTapState)
-        default:
-            foregroundColor = Color.preferredColor(.separator)
-        }
-        
-        let config = FioriButtonConfiguration(foregroundColor: foregroundColor, backgroundColor: Color.clear, font: .fiori(forTextStyle: .body, weight: .semibold), padding: EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
-        
-        return configuration.label
-            .fioriButtonConfiguration(config)
     }
 }
 

--- a/Sources/FioriSwiftUICore/_FioriStyles/BackActionStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/BackActionStyle.fiori.swift
@@ -16,6 +16,6 @@ public struct BackActionFioriStyle: BackActionStyle {
     @ViewBuilder
     public func makeBody(_ configuration: BackActionConfiguration) -> some View {
         BackAction(configuration)
-            .fioriButtonStyle(NavigationBarActionStyle())
+            .fioriButtonStyle(FioriNavigationButtonStyle())
     }
 }

--- a/Sources/FioriSwiftUICore/_FioriStyles/EULAViewStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/EULAViewStyle.fiori.swift
@@ -39,6 +39,7 @@ public struct EULAViewBaseStyle: EULAViewStyle {
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
                 self.navBarLeadingView(configuration)
+                    .fixedSize()
             }
         }
     }
@@ -104,7 +105,7 @@ extension EULAViewFioriStyle {
 
         func makeBody(_ configuration: CancelActionConfiguration) -> some View {
             CancelAction(configuration)
-                .fioriButtonStyle(FioriPlainButtonStyle())
+                .fioriButtonStyle(FioriNavigationButtonStyle())
         }
     }
 }

--- a/Sources/FioriSwiftUICore/_FioriStyles/UserConsentFormStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/UserConsentFormStyle.fiori.swift
@@ -20,8 +20,17 @@ public struct UserConsentFormBaseStyle: UserConsentFormStyle {
     @ViewBuilder
     func makeContent(_ configuration: UserConsentFormConfiguration) -> some View {
         configuration.userConsentPages.view(at: self.pageIndex).typeErased
-            .navigationBarItems(leading: self.navBarLeadingView(configuration), trailing: self.navBarTrailingView(configuration))
-            .navigationBarTitle(self.navTitle(configuration))
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    self.navBarLeadingView(configuration)
+                        .fixedSize()
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    self.navBarTrailingView(configuration)
+                        .fixedSize()
+                }
+            }
+            .navigationTitle(self.navTitle(configuration))
             .alert(configuration: self.alertConfiguration(configuration), isPresented: self.$showAlert.0)
     }
     
@@ -169,7 +178,7 @@ extension UserConsentFormFioriStyle {
         
         func makeBody(_ configuration: NextActionConfiguration) -> some View {
             NextAction(configuration)
-                .fioriButtonStyle(FioriPlainButtonStyle())
+                .fioriButtonStyle(FioriNavigationButtonStyle())
         }
     }
     
@@ -178,7 +187,7 @@ extension UserConsentFormFioriStyle {
         
         func makeBody(_ configuration: CancelActionConfiguration) -> some View {
             CancelAction(configuration)
-                .fioriButtonStyle(FioriPlainButtonStyle())
+                .fioriButtonStyle(FioriNavigationButtonStyle())
         }
     }
     

--- a/Sources/FioriSwiftUICore/_FioriStyles/WritingAssistantFormStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/WritingAssistantFormStyle.fiori.swift
@@ -27,7 +27,7 @@ extension WritingAssistantFormFioriStyle {
         
         func makeBody(_ configuration: CancelActionConfiguration) -> some View {
             CancelAction(configuration)
-                .fioriButtonStyle(NavigationBarActionStyle())
+                .fioriButtonStyle(FioriNavigationButtonStyle())
         }
     }
     
@@ -36,7 +36,7 @@ extension WritingAssistantFormFioriStyle {
         
         func makeBody(_ configuration: DoneActionConfiguration) -> some View {
             DoneAction(configuration)
-                .fioriButtonStyle(NavigationBarActionStyle())
+                .fioriButtonStyle(FioriNavigationButtonStyle())
         }
     }
     
@@ -146,16 +146,6 @@ struct AIVoteActionButtonStyle: FioriButtonStyle {
         return configuration.label
             .frame(width: 38, height: 38)
             .font(Font.fiori(forTextStyle: .body))
-            .foregroundColor(.preferredColor(isPressed ? .tintColorTapState : isDisabled ? .quaternaryLabel : .tintColor))
-    }
-}
-
-struct NavigationBarActionStyle: FioriButtonStyle {
-    func makeBody(configuration: Configuration) -> some View {
-        let isPressed = configuration.state == .highlighted || configuration.state == .selected
-        let isDisabled = configuration.state == .disabled
-        return configuration.label
-            .font(Font.fiori(forTextStyle: .body, weight: .semibold))
             .foregroundColor(.preferredColor(isPressed ? .tintColorTapState : isDisabled ? .quaternaryLabel : .tintColor))
     }
 }


### PR DESCRIPTION
Update to fixed size for buttons in navigation bar.
|feedback|sort & filter|W.A.|
|-|-|-|
|<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-08-22 at 16 25 45" src="https://github.com/user-attachments/assets/ac1e40c0-56cc-45a8-966a-a0e2c99da1f2" />|<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-08-22 at 16 25 45" src="https://github.com/user-attachments/assets/9635b5bb-16a1-4484-b6d6-fe142f26511c" />|<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-08-22 at 16 26 17" src="https://github.com/user-attachments/assets/c3fa2008-6d84-432a-8047-ad89cd311202" />|

|Welcome|EULA|User Consent|
|-|-|-|
|<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-08-22 at 16 26 32" src="https://github.com/user-attachments/assets/6982038d-14a1-4c07-b990-5b69c14e6c48" />|<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-08-22 at 16 26 40" src="https://github.com/user-attachments/assets/380d0cb0-0953-4c6d-a8f4-c3d9b0257033" />|<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-08-22 at 16 26 48" src="https://github.com/user-attachments/assets/b0132011-66de-4447-bc62-a7d5cbce1ed7" />|
