### PR TITLE
feat: 🎸 add card footer button width mode [jira: 0]

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/Card/MobileCardExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/Card/MobileCardExample.swift
@@ -5,6 +5,8 @@ import SwiftUI
 
 struct MobileCardExample: View {
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
+    @State private var isPresented: Bool = false
+    @State private var buttonWidthMode: Int = 0
     
     var body: some View {
         List {
@@ -15,6 +17,7 @@ struct MobileCardExample: View {
                     }
                     .listRowBackground(Color.preferredColor(.primaryGroupedBackground))
                 }
+                .environment(\.cardFooterButtonWidthMode, CardFooterButtonWidthMode(rawValue: self.buttonWidthMode) ?? .auto)
                 .cardStyle(.card)
                 .listStyle(.plain)
                 .navigationBarTitle("Cards in List", displayMode: .inline)
@@ -31,6 +34,7 @@ struct MobileCardExample: View {
                                 .cardStyle(.intrinsicHeightCard)
                         }
                         .background(Color.preferredColor(.primaryGroupedBackground))
+                        .environment(\.cardFooterButtonWidthMode, CardFooterButtonWidthMode(rawValue: self.buttonWidthMode) ?? .auto)
                     }.padding()
                 }
                 .navigationBarTitle("Cards in VStack", displayMode: .inline)
@@ -44,6 +48,7 @@ struct MobileCardExample: View {
                         CardFooterTests.examples[i]
                     }
                     .listRowBackground(Color.preferredColor(.primaryGroupedBackground))
+                    .environment(\.cardFooterButtonWidthMode, CardFooterButtonWidthMode(rawValue: self.buttonWidthMode) ?? .auto)
                 }
                 .listStyle(.plain)
                 .navigationBarTitle("Footers", displayMode: .inline)
@@ -53,6 +58,7 @@ struct MobileCardExample: View {
             
             NavigationLink {
                 MasonryTestView()
+                    .environment(\.cardFooterButtonWidthMode, CardFooterButtonWidthMode(rawValue: self.buttonWidthMode) ?? .auto)
                     .navigationBarTitle("Masonry", displayMode: .inline)
             } label: {
                 Text("Masonry")
@@ -61,6 +67,7 @@ struct MobileCardExample: View {
             NavigationLink {
                 CarouselTestView(self.horizontalSizeClass == .compact ? 1 : (UIDevice.current.localizedModel == "iPhone" ? 2 : 3))
                     .navigationBarTitle("Carousel", displayMode: .inline)
+                    .environment(\.cardFooterButtonWidthMode, CardFooterButtonWidthMode(rawValue: self.buttonWidthMode) ?? .auto)
             } label: {
                 Text("Carousel")
             }
@@ -309,6 +316,22 @@ struct MobileCardExample: View {
             }
         }
         .navigationBarTitle("Cards", displayMode: .inline)
+        .sheet(isPresented: self.$isPresented) {
+            Form {
+                Text("Card Footer Button Width Mode")
+                Picker("", selection: self.$buttonWidthMode) {
+                    Text("Auto").tag(0)
+                    Text("Equal").tag(1)
+                    Text("Intrinsic").tag(2)
+                }
+                .pickerStyle(.segmented)
+            }
+        }
+        .toolbar(content: {
+            FioriButton(title: "Options") { _ in
+                self.isPresented = true
+            }
+        })
     }
 }
 

--- a/Sources/FioriSwiftUICore/_FioriStyles/CardFooterStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/CardFooterStyle.fiori.swift
@@ -17,7 +17,7 @@ public extension EnvironmentValues {
 
 /// CardFooter button width mode
 public enum CardFooterButtonWidthMode: Int {
-    /// auto size based on carder footer's width. When it is regular size class, up to 3 buttons are shown with intrinsic width; when it is compact size class, up to 2 buttons are shown with equal width.
+    /// auto size based on card footer's width. When it is regular size class, up to 3 buttons are shown with intrinsic width; when it is compact size class, up to 2 buttons are shown with equal width.
     case auto
     
     /// equal size and fill up the whole width except the overflow button

--- a/Sources/FioriSwiftUICore/_FioriStyles/CardFooterStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/CardFooterStyle.fiori.swift
@@ -74,9 +74,12 @@ private struct CardFooterLayout: Layout {
     func calculateLayout(proposal: ProposedViewSize, subviews: Subviews, cache: inout CacheData) {
         let isRegular: Bool
         switch self.cardFooterButtonWidthMode {
-        case .auto: isRegular = proposal.width ?? 1024 > 667
-        case .equal: isRegular = false
-        case .intrinsic: isRegular = true
+        case .auto:
+            isRegular = proposal.width ?? 1024 > 667
+        case .equal:
+            isRegular = false
+        case .intrinsic:
+            isRegular = true
         }
         
         let layoutMode = LayoutMode(mode: isRegular ? .intrinsic : .equal,
@@ -84,7 +87,7 @@ private struct CardFooterLayout: Layout {
         if !cache.frames.isEmpty, cache.fitSize.width == proposal.width, cache.layoutMode == layoutMode {
             return
         }
-
+        
         cache.clear()
         
         let subViewSizes = subviews.reversed().map {

--- a/Sources/FioriSwiftUICore/_FioriStyles/CardFooterStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/CardFooterStyle.fiori.swift
@@ -2,17 +2,34 @@ import FioriThemeManager
 import Foundation
 import SwiftUI
 
-private struct CardFooterLayout: Layout {
-    enum ButtonWidthMode {
-        /// same and fill its width to use available container width
-        case sameAndFill
-        
-        /// intrinsic size's width
-        case intrinsic
+struct CardFooterButtonWidthModeKey: EnvironmentKey {
+    /// Default value is `.auto`
+    public static let defaultValue: CardFooterButtonWidthMode = .auto
+}
+
+public extension EnvironmentValues {
+    /// Sets the button width mode for `CardFooter`.
+    var cardFooterButtonWidthMode: CardFooterButtonWidthMode {
+        get { self[CardFooterButtonWidthModeKey.self] }
+        set { self[CardFooterButtonWidthModeKey.self] = newValue }
     }
+}
+
+/// CardFooter button width mode
+public enum CardFooterButtonWidthMode: Int {
+    /// auto size based on carder footer's width. When it is regular size class, up to 3 buttons are shown with intrinsic width; when it is compact size class, up to 2 buttons are shown with equal width.
+    case auto
     
+    /// equal size and fill up the whole width except the overflow button
+    case equal
+    
+    /// intrinsic size's width
+    case intrinsic
+}
+
+private struct CardFooterLayout: Layout {
     struct LayoutMode: Equatable {
-        let mode: ButtonWidthMode
+        let mode: CardFooterButtonWidthMode
         let num: Int
     }
     
@@ -28,21 +45,18 @@ private struct CardFooterLayout: Layout {
         }
     }
     
-    @Binding var numButtonsDisplayInOverflow: Int
-    
     /// The distance between adjacent subviews.
     var spacing: CGFloat? = 8
     
     /// Maximum width for each element in the container
     var maxButtonWidth: CGFloat
     
-    var horizontalSizeClass: UserInterfaceSizeClass? = .compact
+    let cardFooterButtonWidthMode: CardFooterButtonWidthMode
     
-    init(numButtonsDisplayInOverflow: Binding<Int>, spacing: CGFloat? = nil, maxButtonWidth: CGFloat? = nil, horizontalSizeClass: UserInterfaceSizeClass? = nil) {
-        self._numButtonsDisplayInOverflow = numButtonsDisplayInOverflow
+    init(spacing: CGFloat? = nil, maxButtonWidth: CGFloat? = nil, cardFooterButtonWidthMode: CardFooterButtonWidthMode = .auto) {
         self.spacing = spacing
         self.maxButtonWidth = max(100, maxButtonWidth ?? CGFloat.greatestFiniteMagnitude)
-        self.horizontalSizeClass = horizontalSizeClass
+        self.cardFooterButtonWidthMode = cardFooterButtonWidthMode
     }
     
     func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout CacheData) -> CGSize {
@@ -58,29 +72,49 @@ private struct CardFooterLayout: Layout {
     }
     
     func calculateLayout(proposal: ProposedViewSize, subviews: Subviews, cache: inout CacheData) {
-        let isRegular = proposal.width ?? 1024 > 667
-        let layoutMode = LayoutMode(mode: isRegular ? .intrinsic : .sameAndFill,
+        let isRegular: Bool
+        switch self.cardFooterButtonWidthMode {
+        case .auto: isRegular = proposal.width ?? 1024 > 667
+        case .equal: isRegular = false
+        case .intrinsic: isRegular = true
+        }
+        
+        let layoutMode = LayoutMode(mode: isRegular ? .intrinsic : .equal,
                                     num: isRegular ? 3 : 2)
         if !cache.frames.isEmpty, cache.fitSize.width == proposal.width, cache.layoutMode == layoutMode {
             return
         }
-        
+
         cache.clear()
         
         let subViewSizes = subviews.reversed().map {
             $0.sizeThatFits(.unspecified)
         }
         
-        let hideRect = CGRect(x: -2000, y: 0, width: 0, height: 0)
-        self.calculateLayout(proposalWidth: proposal.width, subViewSizes: subViewSizes, hideRect: hideRect, layoutMode: layoutMode, cache: &cache)
+        self.calculateLayout(proposalWidth: proposal.width, subViewSizes: subViewSizes, layoutMode: layoutMode, cache: &cache)
     }
 
-    /// .compact, .sameAndFill, same size, up to 2 buttons
-    /// .reguar, .intrinsic, up to 3 buttons
-    func calculateLayout(proposalWidth: CGFloat?, subViewSizes: [CGSize], hideRect: CGRect, layoutMode: LayoutMode, cache: inout CacheData) {
-        let subViewNoOflSizes = subViewSizes.dropLast()
+    /**
+     case 1: totol is 5 buttons, 3 buttons (tertiary, secondary, primary), overflow menu with 2 buttons, overflow menu with 1 button
+     case 2: total is 3 buttons, 2 buttons (only two of tertiary, secondary and primary exist), overflow menu with 1 button
+     case 3: total is 1 button, 1 button, only one of tertiary, secondary or primary exist
+     
+     In compact width, .equal, same size, up to 2 buttons
+     In reguar width, .intrinsic, up to 3 buttons
+     */
+    func calculateLayout(proposalWidth: CGFloat?, subViewSizes: [CGSize], layoutMode: LayoutMode, cache: inout CacheData) {
+        let subViewNoOflSizes: [CGSize]
+        switch subViewSizes.count {
+        case 5:
+            subViewNoOflSizes = Array(subViewSizes.dropLast(2))
+        case 3:
+            subViewNoOflSizes = Array(subViewSizes.dropLast(1))
+        default:
+            subViewNoOflSizes = subViewSizes
+        }
+        
         let numButtons = subViewNoOflSizes.count
-        let overflowSize = subViewSizes[numButtons]
+        let overflowSize = subViewNoOflSizes.count < subViewSizes.count ? subViewSizes[numButtons] : CGSize.zero
         let theSpacing: CGFloat = self.spacing ?? 0
         var maxHeight: CGFloat = 0
         var requiredFinalWidth: CGFloat = 0
@@ -92,7 +126,7 @@ private struct CardFooterLayout: Layout {
         
         /// calculate numToShow, buttonWidth, requiredFinalWidth
         if finalWidth == 0 {
-            if layoutMode.mode == .sameAndFill {
+            if layoutMode.mode == .equal {
                 let tmpButtonWidth: CGFloat = subViewNoOflSizes.suffix(numToShow).reduce(0) { partialResult, size in
                     min(self.maxButtonWidth, max(partialResult, size.width))
                 }
@@ -117,7 +151,7 @@ private struct CardFooterLayout: Layout {
         } else { // there is a proposalWidth
             var tmpButtonWidth: CGFloat = 0
             for i in 0 ..< idealNumToShow {
-                if layoutMode.mode == .sameAndFill {
+                if layoutMode.mode == .equal {
                     tmpButtonWidth = min(self.maxButtonWidth, max(tmpButtonWidth, subViewNoOflSizes[i].width))
                     requiredFinalWidth = tmpButtonWidth * CGFloat(i + 1) + theSpacing * CGFloat(i)
                 } else {
@@ -131,7 +165,7 @@ private struct CardFooterLayout: Layout {
                     if numToShow > 1 {
                         numToShow -= 1
                     }
-                    if layoutMode.mode == .sameAndFill {
+                    if layoutMode.mode == .equal {
                         var availableWidth = finalWidth - theSpacing * CGFloat(max(0, numToShow - 1))
                         if numButtons > 1 {
                             availableWidth -= theSpacing + overflowSize.width
@@ -142,7 +176,7 @@ private struct CardFooterLayout: Layout {
                 }
             }
             
-            if buttonWidth == nil, layoutMode.mode == .sameAndFill {
+            if buttonWidth == nil, layoutMode.mode == .equal {
                 var availableWidth = finalWidth - theSpacing * CGFloat(numToShow - 1)
                 if numToShow < numButtons {
                     availableWidth -= min(self.maxButtonWidth, overflowSize.width) + theSpacing
@@ -159,11 +193,12 @@ private struct CardFooterLayout: Layout {
         /// set up frames for each subview
         
         let y = maxHeight / 2
-        
+        // Move the hidden buttons out of visible area
+        let hideRect = CGRect(x: -2000, y: y, width: 0, height: 0)
         var frames = [CGRect]()
         
         var x: CGFloat = 0
-        for i in 0 ... numButtons {
+        for i in 0 ..< subViewSizes.count {
             if i < numToShow {
                 let btWidth = buttonWidth ?? min(finalWidth - (numToHide > 0 ? theSpacing + overflowSize.width : 0), self.maxButtonWidth, subViewNoOflSizes[i].width)
                 x += btWidth + (i > 0 ? theSpacing : 0)
@@ -171,17 +206,14 @@ private struct CardFooterLayout: Layout {
             } else if i < numButtons { // rest button to hide
                 frames.append(hideRect)
             } else { // overflow
-                if numToHide > 0 {
+                if numToHide > 0, i == numButtons + numToHide - 1 { // last one to show overflow
                     frames.append(CGRect(x: overflowSize.width / 2, y: y, width: min(self.maxButtonWidth, overflowSize.width), height: overflowSize.height))
-                } else {
+                } else { // hide the other overflow
                     frames.append(hideRect)
                 }
             }
         }
-
-        DispatchQueue.main.async {
-            self.numButtonsDisplayInOverflow = numToHide
-        }
+        
         cache.frames = frames.reversed()
         cache.fitSize = CGSize(width: finalWidth, height: maxHeight)
         cache.layoutMode = layoutMode
@@ -214,29 +246,36 @@ private struct CardFooterLayout: Layout {
 
 // Base Layout style
 public struct CardFooterBaseStyle: CardFooterStyle {
-    @Environment(\.horizontalSizeClass) var horizontalSizeClass
-    @State var numButtonsDisplayInOverflow: Int = 0
+    @Environment(\.cardFooterButtonWidthMode) var cardFooterButtonWidthMode
 
     @ViewBuilder
     public func makeBody(_ configuration: CardFooterConfiguration) -> some View {
         // Add default layout here
-        CardFooterLayout(numButtonsDisplayInOverflow: self.$numButtonsDisplayInOverflow, spacing: 8, maxButtonWidth: nil, horizontalSizeClass: self.horizontalSizeClass) {
-            Menu {
-                if self.numButtonsDisplayInOverflow == 1 {
+        CardFooterLayout(spacing: 8, maxButtonWidth: nil, cardFooterButtonWidthMode: self.cardFooterButtonWidthMode) {
+            if self.numOfButtons(configuration) == 3 {
+                Menu {
+                    configuration.secondaryAction.environment(\.isInMenu, true)
+                    configuration.tertiaryAction.environment(\.isInMenu, true)
+                } label: {
+                    configuration.overflowAction
+                }
+                /// set the accessibilityLabel as same as SF symbol "ellipsis" which is "More"
+                .accessibilityLabel(Text(Image(systemName: "ellipsis")))
+            }
+            
+            if self.numOfButtons(configuration) > 1 {
+                Menu {
                     if !configuration.tertiaryAction.isEmpty {
                         configuration.tertiaryAction.environment(\.isInMenu, true)
                     } else {
                         configuration.secondaryAction.environment(\.isInMenu, true)
                     }
-                } else if self.numButtonsDisplayInOverflow == 2 {
-                    configuration.secondaryAction.environment(\.isInMenu, true)
-                    configuration.tertiaryAction.environment(\.isInMenu, true)
+                } label: {
+                    configuration.overflowAction
                 }
-            } label: {
-                configuration.overflowAction
+                /// set the accessibilityLabel as same as SF symbol "ellipsis" which is "More"
+                .accessibilityLabel(Text(Image(systemName: "ellipsis")))
             }
-            /// set the accessibilityLabel as same as SF symbol "ellipsis" which is "More"
-            .accessibilityLabel(Text(Image(systemName: "ellipsis")))
             
             if !configuration.tertiaryAction.isEmpty {
                 configuration.tertiaryAction
@@ -250,6 +289,27 @@ public struct CardFooterBaseStyle: CardFooterStyle {
                 configuration.action
             }
         }
+    }
+    
+    /**
+        case 1: totol is 5 buttons, 3 buttons (tertiary, secondary, primary), overflow menu with 2 buttons, overflow menu with 1 button
+        case 2: total is 3 buttons, 2 buttons (only two of tertiary, secondary and primary exist), overflow menu with 1 button
+        case 3: total is 1 button, 1 button, only one of tertiary, secondary or primary exist
+     */
+    func numOfButtons(_ configuration: CardFooterConfiguration) -> Int {
+        var value = 0
+        if !configuration.action.isEmpty {
+            value += 1
+        }
+        
+        if !configuration.secondaryAction.isEmpty {
+            value += 1
+        }
+        
+        if !configuration.tertiaryAction.isEmpty {
+            value += 1
+        }
+        return value
     }
 }
 
@@ -314,6 +374,16 @@ public enum CardFooterTests {
     static let footer9 = CardFooter(action: FioriButton(title: "Primary long long long long long"), secondaryAction: FioriButton(title: "Secondary long long long long long a b c long long long long"), tertiaryAction: FioriButton(title: "Tertiary"))
     static let footer10 = CardFooter(action: FioriButton(title: "Primary long long long long long long long long long long long long long long long long long long long"), secondaryAction: FioriButton(title: "Secondary long long long long long a b c long long long long"), tertiaryAction: FioriButton(title: "Tertiary"))
     public static let examples = [footer0, footer1, footer2, footer3, footer4, footer5, footer6, footer7, footer8, footer9, footer10]
+}
+
+#Preview("Empty") {
+    VStack {
+        CardFooter(action: { EmptyView() }, overflowAction: { EmptyView() }).border(Color.green)
+        
+        Text("Empty")
+            
+        CardFooter(action: { EmptyView() }).border(Color.green)
+    }.border(Color.red)
 }
 
 #Preview("P") {

--- a/Sources/FioriSwiftUICore/_FioriStyles/CardFooterStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/CardFooterStyle.fiori.swift
@@ -103,7 +103,7 @@ private struct CardFooterLayout: Layout {
      case 3: total is 1 button, 1 button, only one of tertiary, secondary or primary exist
      
      In compact width, .equal, same size, up to 2 buttons
-     In reguar width, .intrinsic, up to 3 buttons
+     In regular width, .intrinsic, up to 3 buttons
      */
     func calculateLayout(proposalWidth: CGFloat?, subViewSizes: [CGSize], layoutMode: LayoutMode, cache: inout CacheData) {
         let subViewNoOflSizes: [CGSize]


### PR DESCRIPTION
App can overwrite the default card footer button width mode:
<img width="457" height="914" alt="Screenshot 2025-08-22 at 12 31 20 PM" src="https://github.com/user-attachments/assets/2512340e-f93a-4602-839e-eb239026e0d9" />
<img width="457" height="914" alt="Screenshot 2025-08-22 at 12 31 25 PM" src="https://github.com/user-attachments/assets/a235c67c-88e0-4602-8cd9-04c6da482e27" />
<img width="457" height="914" alt="Screenshot 2025-08-22 at 12 31 31 PM" src="https://github.com/user-attachments/assets/4b054c96-4c7e-46d5-9d98-9b49906dcc62" />
