### PR TITLE
fix: 🐛 [jira: IOSSDKBUG-865] Carousel moves to the A11Y focused

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,16 +11,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13]
-        xcode: ['Xcode_15.0.1']
-    runs-on: ${{ matrix.os }}         
+        os: [macos-15]
+        xcode: ['Xcode_16.4']
+    runs-on: ${{ matrix.os }}
     env:
       DEVELOPER_DIR: /Applications/${{ matrix.xcode }}.app/Contents/Developer
 
     steps:
     - uses: actions/checkout@v3
     - name: Build and Test
-      run: set -o pipefail && xcodebuild -enableCodeCoverage YES -scheme FioriSwiftUI-Package -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 15' clean build test | xcpretty
+      run: set -o pipefail && xcodebuild -enableCodeCoverage YES -scheme FioriSwiftUI-Package -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.6' clean build test | xcpretty
     - name: Create code coverage report
       run: ./scripts/xccov-to-sonarqube-generic.sh /Users/runner/Library/Developer/Xcode/DerivedData/cloud-sdk-ios-fiori*/Logs/Test/*.xcresult/ > sonarqube-generic-coverage.xml
     - name: Store coverage for sonar job
@@ -51,9 +51,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-13]
-        xcode: ['Xcode_15.0.1']
-    runs-on: ${{ matrix.os }}         
+        os: [macos-15]
+        xcode: ['Xcode_16.4']
+    runs-on: ${{ matrix.os }}
     env:
       DEVELOPER_DIR: /Applications/${{ matrix.xcode }}.app/Contents/Developer
     
@@ -66,9 +66,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14]
-        xcode: ['Xcode_15.3']
-    runs-on: ${{ matrix.os }}         
+        os: [macos-15]
+        xcode: ['Xcode_16.4']
+    runs-on: ${{ matrix.os }}
     env:
       DEVELOPER_DIR: /Applications/${{ matrix.xcode }}.app/Contents/Developer
     

--- a/.github/workflows/pr_only.yml
+++ b/.github/workflows/pr_only.yml
@@ -47,12 +47,24 @@ jobs:
           path: /usr/local/lib/mint
           key: ${{ runner.os }}-mint-${{ hashFiles('**/Mintfile') }}
           restore-keys: ${{ runner.os }}-mint-
+      
       - name: Install Mint
         run: |
-          brew upgrade mint || brew install mint || true
-      - name: Install swiftformat via mint
-        if: steps.mint-cache.outputs.cache-hit != 'true'
-        run: mint bootstrap
+          brew install mint || true
+          echo "/opt/homebrew/bin" >> $GITHUB_PATH
+        
+      - name: Install SwiftLint
+        run: |
+            curl -L https://github.com/realm/SwiftLint/releases/download/0.59.1/portable_swiftlint.zip -o swiftlint.zip
+            unzip swiftlint.zip -d swiftlint-bin
+            sudo mv swiftlint-bin/swiftlint /usr/local/bin/
+
+      - name: Install SwiftFormat
+        run: |
+            curl -L https://github.com/nicklockwood/SwiftFormat/releases/download/0.53.4/swiftformat.zip -o swiftformat.zip
+            unzip swiftformat.zip -d swiftformat-bin
+            sudo mv swiftformat-bin/swiftformat /usr/local/bin/
+    
       - name: Format Swift code
         run: mint run swiftformat --verbose .
       - name: Verify formatted code is unchanged

--- a/Apps/Examples/Examples/FioriSwiftUICore/Card/MobileCardExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/Card/MobileCardExample.swift
@@ -19,6 +19,7 @@ struct MobileCardExample: View {
                 }
                 .environment(\.cardFooterButtonWidthMode, CardFooterButtonWidthMode(rawValue: self.buttonWidthMode) ?? .auto)
                 .cardStyle(.card)
+                .cardStyle(.intrinsicHeightCard)
                 .listStyle(.plain)
                 .navigationBarTitle("Cards in List", displayMode: .inline)
             } label: {
@@ -281,7 +282,7 @@ struct MobileCardExample: View {
                 Text("Left image card")
             }
         }
-        .navigationBarTitle("Cards", displayMode: .inline)
+        .navigationBarTitle("Cards and Layouts", displayMode: .inline)
         .sheet(isPresented: self.$isPresented) {
             Form {
                 Text("Card Footer Button Width Mode")
@@ -428,17 +429,18 @@ extension VerticalAlignment: @retroactive Hashable {
 }
 
 struct CarouselTestView: View {
-    let defaultNumberOfColumns: Double
-    
+    let defaultNumberOfColumns: Int
     @State var isPresented: Bool = false
     @State var isSameHeight: Bool = true
     @State var isSnapping: Bool = true
-    @State var numberOfColumns: Double
+    @State var numberOfColumns: Int
     @State var spacing = 16.0
     @State var padding = 16.0
     @State var alignment = 0
+    @State var cards = CardTests.cardSamples.prefix(8)
+    @Environment(\.layoutDirection) var layoutDirection
     
-    init(_ n: Double = 1) {
+    init(_ n: Int = 1) {
         self.defaultNumberOfColumns = n
         self._numberOfColumns = State(initialValue: n)
     }
@@ -446,26 +448,38 @@ struct CarouselTestView: View {
     var body: some View {
         ScrollView(.vertical) {
             VStack(alignment: .leading, spacing: 24) {
-                Carousel(numberOfColumns: Int(self.numberOfColumns), contentInsets: EdgeInsets(top: 0, leading: self.padding, bottom: 0, trailing: self.padding), spacing: self.spacing, alignment: self.alignment == 0 ? .top : (self.alignment == 1 ? .center : .bottom), isSnapping: self.isSnapping, isSameHeight: self.isSameHeight) {
-                    ForEach(0 ..< min(8, CardTests.cardSamples.count), id: \.self) { i in
-                        NavigationLink {
-                            CardTests.cardSamples[i]
-                        } label: {
-                            CardTests.cardSamples[i]
+                ScrollViewReader { proxy in
+                    Carousel(numberOfColumns: self.numberOfColumns, contentInsets: EdgeInsets(top: 16, leading: self.padding, bottom: 16, trailing: self.padding), spacing: self.spacing, alignment: self.alignment == 0 ? .top : (self.alignment == 1 ? .center : .bottom), isSnapping: self.isSnapping, isSameHeight: self.isSameHeight) {
+                        ForEach(0 ..< self.cards.count, id: \.self) { i in
+                            NavigationLink {
+                                self.cards[i].cardStyle(.card).cardStyle(.intrinsicHeightCard).padding()
+                            } label: {
+                                self.cards[i]
+                                    .id(i)
+                                    .contextMenu {
+                                        Button("Delete") {
+                                            self.cards.remove(at: i)
+                                        }
+                                    }
+                            }
                         }
                     }
-                }
+                    .onAppear {
+                        DispatchQueue.main.async {
+                            proxy.scrollTo(0, anchor: self.layoutDirection == .rightToLeft ? .trailing : .leading)
+                        }
+                    }
+                }.cardStyle(.card)
             }
-            .cardStyle(.card)
         }
         .background(Color.preferredColor(.primaryGroupedBackground))
         .sheet(isPresented: self.$isPresented, content: {
-            VStack {
+            List {
                 Toggle("Same card height", isOn: self.$isSameHeight)
-                
-                HStack {
-                    Text("numberOfColumns: \(Int(self.numberOfColumns))")
-                    Slider(value: self.$numberOfColumns, in: 1 ... self.defaultNumberOfColumns + 2, step: 1)
+                Picker("numberOfColumns", selection: self.$numberOfColumns) {
+                    ForEach(1 ... 3, id: \.self) {
+                        Text("\($0)").tag($0)
+                    }
                 }
                 HStack {
                     Text("spacing: \(Int(self.spacing))")
@@ -482,14 +496,11 @@ struct CarouselTestView: View {
                 }
                 Toggle("isSnapping", isOn: self.$isSnapping)
                 
-                Divider()
-                
                 HStack {
                     Text("contentInsets(top: 0, leading: \(Int(self.padding)), bottom: 0, trailing: \(Int(self.padding)))")
                     Slider(value: self.$padding, in: 0 ... 24, step: 4)
                 }
             }
-            .padding()
             .presentationDetents([.medium])
         })
         .toolbar(content: {

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 test_watch:
 	bash scripts/setup_spm_tests.sh
-	xcodebuild -scheme FioriThemeManagerTests -destination 'platform=watchOS Simulator,name=Apple Watch Series 8 (45mm)' test
+	xcodebuild -scheme FioriThemeManagerTests -destination 'platform=watchOS Simulator,name=Apple Watch Series 10 (46mm)' test
 test_vision:
 	xcodebuild -scheme FioriSwiftUI-Package -destination 'platform=visionOS Simulator,name=Apple Vision Pro' clean build test | xcbeautify
 test_ios:
-	xcodebuild -scheme FioriSwiftUI-Package -destination 'platform=iOS Simulator,name=iPhone 14 Pro' clean build test | xcbeautify
+	xcodebuild -scheme FioriSwiftUI-Package -destination 'platform=iOS Simulator,name=iPhone 16' clean build test | xcbeautify

--- a/Sources/FioriSwiftUICore/Views/Carousel.swift
+++ b/Sources/FioriSwiftUICore/Views/Carousel.swift
@@ -1,38 +1,5 @@
 import SwiftUI
 
-/// It only works properly for one subview
-private struct CarouselViewLayout: Layout {
-    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
-        guard let containerWidth = proposal.width else {
-            return .zero
-        }
-           
-        let size: CGSize = subviews.map {
-            $0.sizeThatFits(ProposedViewSize(width: containerWidth, height: nil))
-        }.reduce(.zero) { partial, size in
-            CGSize(width: max(partial.width, size.width), height: max(partial.height, size.height))
-        }
-
-        return CGSize(width: containerWidth, height: size.height)
-    }
-    
-    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
-        guard let containerWidth = proposal.width else {
-            return
-        }
-        
-        let _: CGSize = subviews.map {
-            $0.sizeThatFits(ProposedViewSize(width: containerWidth, height: nil))
-        }.reduce(.zero) { partial, size in
-            CGSize(width: max(partial.width, size.width), height: max(partial.height, size.height))
-        }
-        
-        for view in subviews {
-            view.place(at: bounds.origin, proposal: ProposedViewSize(width: containerWidth, height: nil))
-        }
-    }
-}
-
 private struct CarouselLayout: Layout {
     struct CacheData {
         var width: CGFloat
@@ -45,9 +12,9 @@ private struct CarouselLayout: Layout {
             self.columns.removeAll()
         }
     }
-    
-    /// Number of columns
-    let numberOfColumns: Int
+
+    /// Width of each item
+    let itemWidth: CGFloat
     
     /// Horizontal spacing between views
     let spacing: CGFloat
@@ -58,27 +25,21 @@ private struct CarouselLayout: Layout {
     /// Whether all subviews have same height which is the maximum height of all subviews
     let isSameHeight: Bool
     
-    init(numberOfColumns: Int = 1, spacing: CGFloat = 8, alignment: VerticalAlignment = .top, isSameHeight: Bool = false) {
-        self.numberOfColumns = max(1, numberOfColumns)
+    init(itemWidth: CGFloat, spacing: CGFloat = 8, alignment: VerticalAlignment = .top, isSameHeight: Bool = false) {
+        self.itemWidth = itemWidth
         self.spacing = spacing
         self.alignment = alignment
         self.isSameHeight = isSameHeight
     }
     
     func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout CacheData) -> CGSize {
-        guard let containerWidth = proposal.width else {
-            return .zero
-        }
-        self.calculateLayout(for: subviews, containerWidth: containerWidth, cache: &cache)
-        return CGSize(width: cache.columns.last?.maxX ?? containerWidth, height: cache.height)
+        self.calculateLayout(for: subviews, cache: &cache)
+        return CGSize(width: cache.columns.last?.maxX ?? 1, height: cache.height)
     }
     
     func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout CacheData) {
-        guard let containerWidth = proposal.width else {
-            return
-        }
-        self.calculateLayout(for: subviews, containerWidth: containerWidth, cache: &cache)
-        
+        self.calculateLayout(for: subviews, cache: &cache)
+    
         for (i, column) in cache.columns.enumerated() {
             let y: CGFloat
             
@@ -105,25 +66,18 @@ private struct CarouselLayout: Layout {
         CacheData(width: 0, height: 0, columns: [])
     }
     
-    func calculateLayout(for subviews: Subviews, containerWidth: CGFloat, cache: inout CacheData) {
-        guard cache.width != containerWidth, !subviews.isEmpty, containerWidth > 0 else {
+    func calculateLayout(for subviews: Subviews, cache: inout CacheData) {
+        if cache.width == self.itemWidth, subviews.count == cache.columns.count {
             return
         }
         cache.clear()
-        cache.width = containerWidth
+        cache.width = self.itemWidth
 
-        let itemWidth: CGFloat
-        if subviews.count > self.numberOfColumns {
-            itemWidth = (containerWidth - CGFloat(self.numberOfColumns + 2) * self.spacing) / CGFloat(self.numberOfColumns)
-        } else {
-            itemWidth = (containerWidth - CGFloat(self.numberOfColumns) * self.spacing + self.spacing) / CGFloat(self.numberOfColumns)
-        }
-        
         let sizes = subviews.map {
-            $0.sizeThatFits(ProposedViewSize(width: itemWidth, height: nil))
+            $0.sizeThatFits(ProposedViewSize(width: self.itemWidth, height: nil))
         }.map {
-            if $0.width > itemWidth {
-                return CGSize(width: itemWidth, height: $0.width)
+            if $0.width > self.itemWidth {
+                return CGSize(width: self.itemWidth, height: $0.width)
             }
             return $0
         }
@@ -137,66 +91,67 @@ private struct CarouselLayout: Layout {
     }
 }
 
-private struct CarouselSizePreferenceKey: PreferenceKey {
-    typealias Value = CGSize
-    
-    static var defaultValue: CGSize = .zero
-    
-    static func reduce(value: inout CGSize, nextValue: () -> CGSize) {
-        value = CGSize(width: max(value.width, nextValue().width),
-                       height: max(value.height, nextValue().height))
-    }
-}
-
-private struct CarouselSizeModifier: ViewModifier {
-    func body(content: Content) -> some View {
-        content.background(GeometryReader { proxy in
-            Color.clear.preference(key: CarouselSizePreferenceKey.self, value: proxy.size)
-        })
-    }
-}
-
-private struct CarouselContentSizePreferenceKey: PreferenceKey {
-    typealias Value = CGSize
-    
-    static var defaultValue: CGSize = .zero
-    
-    static func reduce(value: inout CGSize, nextValue: () -> CGSize) {
-        value = CGSize(width: max(value.width, nextValue().width),
-                       height: max(value.height, nextValue().height))
-    }
-}
-
-private struct CarouselContentSizeModifier: ViewModifier {
-    func body(content: Content) -> some View {
-        content.background(GeometryReader { proxy in
-            Color.clear.preference(key: CarouselContentSizePreferenceKey.self, value: proxy.size)
-        })
-    }
-}
-
 /**
- Carousel
- A container view that arranges its child views  horizontally, one after the other, with a protion of the next child view visible in the container. It allows users to swipe or scroll through the child views to view fiffeernt piece of content.
+ Carousel is a container view that arranges its child views  horizontally, one after the other, with a portion of the next child view visible in the container. It allows users to swipe or scroll through the child views to see different piece of content.
  
- ## Example Initialization and Configuration
+ ## Carousel with numberOfColumns:
  ```swift
- Carousel(numberOfColumns: 3, spacing: 8, alignment: .top, isSnapping: true) {
+ Carousel(numberOfColumns: 2, spacing: 8, alignment: .top, isSnapping: true) {
      ForEach(0..<16, id: \.self) { i in
-         Text("Text \(i)")
+         Text("Long long long Text \(i)")
              .font(.title)
              .padding()
-             .frame(height: 100)
              .background(Color.gray)
      }
  }
  .padding(8)
  .border(Color.gray)
  ```
+ 
+ ## Carousel with fixed item width:
+ ```swift
+ Carousel(itemWidth: 320, spacing: 8, alignment: .top, isSnapping: true) {
+     ForEach(0..<16, id: \.self) { i in
+        Text("Long long long long Text \(i)")
+             .font(.title)
+             .padding()
+             .background(Color.gray)
+     }
+ }
+ .padding(8)
+ .border(Color.gray)
+ ```
+ 
+ ## To display a specific view as the initial visible item in the Carousel, use ScrollViewReader to programmatically scroll to the view identified by a unique id.
+ ```swift
+ ScrollViewReader { proxy in
+     Carousel(numberOfColumns: 2, spacing: 8, alignment: .top, isSnapping: true) {
+         ForEach(0..<16, id: \.self) { i in
+             Text("Long long long Text \(i)")
+                 .font(.title)
+                 .padding()
+                 .frame(height: 100)
+                 .background(Color.gray)
+                 .id(i) // set id for each view
+         }
+     }
+     .onAppear {
+         DispatchQueue.main.async {
+             proxy.scrollTo(0, anchor: layoutDirection == .rightToLeft ? .trailing : .leading) // scroll to the view with your desisred id
+         }
+     }
+ }
+ .padding(8)
+ .border(Color.gray)
+ ```
+
  */
 public struct Carousel<Content>: View where Content: View {
     /// Number of columns
-    let numberOfColumns: Int
+    let numberOfColumns: Int?
+    
+    /// Width of each item
+    let itemWidth: CGFloat?
     
     /// Horizontal spacing between views
     let spacing: CGFloat
@@ -216,21 +171,49 @@ public struct Carousel<Content>: View where Content: View {
     /// The views representing the content of the Carousel
     var content: () -> Content
     
-    @Environment(\.layoutDirection) var layoutDirection
-    
-    /// Carousel content offset
-    @State private var contentOffset = CGPoint.zero
-    
-    /// Carousel previous content offset
-    @State private var preContentOffset = CGPoint.zero
-    
     /// Carousel content size
     @State private var contentSize = CGSize.zero
     
-    /// Carousel view size
-    @State private var viewSize = CGSize.zero
+    @State private var containerWidth: CGFloat = 128
     
-    /// Create a Carousel View
+    var finalItemWidth: CGFloat {
+        if let itemWidth = self.itemWidth {
+            return itemWidth
+        } else {
+            let numberOfColumns = self.numberOfColumns ?? 1
+            
+            return max(1.0, (self.containerWidth - self.contentInsets.leading - CGFloat(numberOfColumns + 2) * self.spacing) / CGFloat(numberOfColumns))
+        }
+    }
+    
+    // Scroll target behavior for snapping
+    private struct SnapScrollTargetBehavior: ScrollTargetBehavior {
+        let isSnapping: Bool
+        let itemWidth: CGFloat
+        let contentInsets: EdgeInsets
+        let spacing: CGFloat
+        
+        init(isSnapping: Bool = true, itemWidth: CGFloat, contentInsets: EdgeInsets, spacing: CGFloat) {
+            self.isSnapping = isSnapping
+            self.itemWidth = itemWidth
+            self.contentInsets = contentInsets
+            self.spacing = spacing
+        }
+        
+        func updateTarget(_ target: inout ScrollTarget, context: TargetContext) {
+            let maxX = max(0, context.contentSize.width - context.containerSize.width)
+            var finalX = min(maxX, target.rect.origin.x)
+            
+            if self.isSnapping {
+                let index = ((target.rect.origin.x - self.contentInsets.leading) / (self.itemWidth + self.spacing)).rounded()
+                let idealX = index * self.itemWidth + max(0, index - 1) * self.spacing + (index == 0 ? 0 : self.contentInsets.leading)
+                finalX = max(0, min(maxX, idealX))
+            }
+            target.rect.origin.x = finalX
+        }
+    }
+        
+    /// Create a Carousel View with number of columns
     /// - Parameters:
     ///   - numberOfColumns: Number of columns. The default is 1.
     ///   - contentInsets: Padding inside of the Carousel View
@@ -241,6 +224,27 @@ public struct Carousel<Content>: View where Content: View {
     ///   - content: The views representing the content of the Carousel
     public init(numberOfColumns: Int = 1, contentInsets: EdgeInsets = EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16), spacing: CGFloat = 8, alignment: VerticalAlignment = .top, isSnapping: Bool = true, isSameHeight: Bool = false, @ViewBuilder content: @escaping () -> Content) {
         self.numberOfColumns = numberOfColumns
+        self.itemWidth = nil
+        self.contentInsets = contentInsets
+        self.spacing = spacing
+        self.alignment = alignment
+        self.isSnapping = isSnapping
+        self.isSameHeight = isSameHeight
+        self.content = content
+    }
+    
+    /// Create a Carousel View with fixed item width
+    /// - Parameters:
+    ///   - itemWidth: Width of each item
+    ///   - contentInsets: Padding inside of the Carousel View
+    ///   - spacing: Horizontal spacing between views. The default is 8.
+    ///   - alignment: Vertical alignment in the carousel. The default is `.top`.
+    ///   - isSnapping: Whether it stops at a right position that the first visible subview can be displayed fully after scrolling. The default is `true`.
+    ///   - isSameHeight: Whether all subviews have same height which is the maximum height of all subviews
+    ///   - content: The views representing the content of the Carousel
+    public init(itemWidth: CGFloat, contentInsets: EdgeInsets = EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16), spacing: CGFloat = 8, alignment: VerticalAlignment = .top, isSnapping: Bool = true, isSameHeight: Bool = false, @ViewBuilder content: @escaping () -> Content) {
+        self.numberOfColumns = nil
+        self.itemWidth = min(10000, max(1, itemWidth))
         self.contentInsets = contentInsets
         self.spacing = spacing
         self.alignment = alignment
@@ -250,77 +254,42 @@ public struct Carousel<Content>: View where Content: View {
     }
     
     public var body: some View {
-        CarouselViewLayout {
-            HStack {
-                CarouselLayout(numberOfColumns: self.numberOfColumns, spacing: self.spacing, alignment: self.alignment, isSameHeight: self.isSameHeight) {
-                    self.content()
-                }
+        ScrollView(.horizontal, showsIndicators: false) {
+            CarouselLayout(itemWidth: self.finalItemWidth, spacing: self.spacing, alignment: self.alignment, isSameHeight: self.isSameHeight) {
+                self.content()
             }
             .padding(self.contentInsets)
-            .offset(x: -self.contentOffset.x)
-            .modifier(CarouselContentSizeModifier())
-            .onPreferenceChange(CarouselContentSizePreferenceKey.self) { size in
-                DispatchQueue.main.async {
-                    self.contentSize = size
-                    let finalX = self.calculateContentOffsetX(from: self.contentOffset.x)
-                    if abs(finalX.distance(to: self.contentOffset.x)) > 0.1 {
-                        self.contentOffset.x = finalX
-                        self.preContentOffset = self.contentOffset
-                    }
-                }
+            .onGeometryChange(for: CGSize.self) { proxy in
+                proxy.size
+            } action: { newValue in
+                self.contentSize = newValue
             }
-            .contentShape(Rectangle())
-            .highPriorityGesture(
-                DragGesture(minimumDistance: 20)
-                    .onChanged { value in
-                        self.contentOffset.x = self.preContentOffset.x + (self.layoutDirection == .leftToRight ? -1 : 1) * value.translation.width
-                    }
-                    .onEnded { value in
-                        withAnimation(.easeOut(duration: 0.5)) {
-                            let expectedX = max(0, preContentOffset.x + (self.layoutDirection == .leftToRight ? -1 : 1) * value.predictedEndTranslation.width)
-                            let finalX = self.calculateContentOffsetX(from: expectedX)
-                            self.contentOffset.x = finalX
-                            self.preContentOffset = self.contentOffset
-                        }
-                    }
-            )
-        }
-        .modifier(CarouselSizeModifier())
-        .onPreferenceChange(CarouselSizePreferenceKey.self) { size in
-            DispatchQueue.main.async {
-                self.viewSize = size
-                let finalX = self.calculateContentOffsetX(from: self.contentOffset.x)
-                if abs(finalX.distance(to: self.contentOffset.x)) > 0.1 {
-                    self.contentOffset.x = finalX
-                    self.preContentOffset = self.contentOffset
-                }
-            }
-        }
-    }
-    
-    func calculateContentOffsetX(from x: CGFloat) -> CGFloat {
-        let maxX = max(0, contentSize.width - self.viewSize.width)
-        var finalX = min(maxX, x)
-        
-        if self.isSnapping {
-            let itemWidth: CGFloat = (viewSize.width - self.contentInsets.horizontal - CGFloat(self.numberOfColumns + 2) * self.spacing) / CGFloat(self.numberOfColumns)
-            let index = ((x - self.contentInsets.leading) / (itemWidth + self.spacing)).rounded()
-            let idealX = index * itemWidth + max(0, index - 1) * self.spacing + (index == 0 ? 0 : self.contentInsets.leading)
-            finalX = max(0, min(maxX, idealX))
-        }
-        
-        return finalX
+            .scrollTargetLayout()
+        }.onGeometryChange(for: CGFloat.self, of: { proxy in
+            proxy.size.width
+        }, action: { newValue in
+            self.containerWidth = newValue
+        })
+        .scrollTargetBehavior(SnapScrollTargetBehavior(isSnapping: self.isSnapping, itemWidth: self.finalItemWidth, contentInsets: self.contentInsets, spacing: self.spacing))
+        .frame(height: self.contentSize.height)
     }
 }
 
-#Preview {
-    Carousel(numberOfColumns: 3, spacing: 8, alignment: .top, isSnapping: true) {
-        ForEach(0 ..< 16, id: \.self) { i in
-            Text("Text \(i)")
-                .font(.title)
-                .padding()
-                .frame(height: 100)
-                .background(Color.gray)
+#Preview("RTL") {
+    ScrollViewReader { proxy in
+        Carousel(numberOfColumns: 2, spacing: 8, alignment: .top, isSnapping: true) {
+            ForEach(0 ..< 16, id: \.self) { i in
+                Text("Long long long Text \(i)")
+                    .font(.title)
+                    .padding()
+                    .background(Color.gray)
+                    .id(i) // set id for each view
+            }
+        }
+        .onAppear {
+            DispatchQueue.main.async {
+                proxy.scrollTo(3, anchor: .trailing) // scroll to the view with your desired id
+            }
         }
     }
     .padding(8)
@@ -328,25 +297,22 @@ public struct Carousel<Content>: View where Content: View {
     .environment(\.layoutDirection, .rightToLeft)
 }
 
-#Preview {
-    Carousel(numberOfColumns: 2, spacing: 16, alignment: .bottom) {
-        ForEach(0 ..< CardTests.cardSamples.count, id: \.self) { i in
-            CardTests.cardSamples[i].border(Color.green)
-        }
-    }
-    .padding()
-    .border(Color.black)
-    .cardStyle(.card)
-}
-
-#Preview {
-    ScrollView(.horizontal) {
-        LazyHStack {
-            ForEach(0 ..< CardTests.cardSamples.count, id: \.self) { i in
-                CardTests.cardSamples[i]
-                    .frame(width: 200)
+#Preview("LTR") {
+    ScrollViewReader { proxy in
+        Carousel(itemWidth: 320, contentInsets: EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16), spacing: 8, alignment: .top, isSnapping: true) {
+            ForEach(0 ..< 16, id: \.self) { i in
+                Text("Long long long long Text \(i)")
+                    .font(.title)
+                    .padding()
+                    .background(Color.gray)
             }
         }
-        .cardStyle(.card)
-    }.padding()
+        .onAppear {
+            DispatchQueue.main.async {
+                proxy.scrollTo(3, anchor: .leading) // scroll to the view with your desisred id
+            }
+        }
+    }
+    .padding(8)
+    .border(Color.gray)
 }

--- a/Sources/FioriSwiftUICore/_FioriStyles/CardStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/CardStyle.fiori.swift
@@ -105,7 +105,7 @@ struct CardLayout: Layout {
         let containerWidth = proposal.width
         let height: CGFloat
         if self.useProposedHeight, let value = proposal.height, value > 0, value < CGFloat.greatestFiniteMagnitude {
-            height = max(value, cache.height)
+            height = value
         } else {
             height = cache.rows.last?.maxY ?? 0
         }


### PR DESCRIPTION
New features:
1. add a new Carousel init with itemWidth
2. allow apps to set the initial visible item in the Carousel

Changes:
1. Update ci.yml and pr_only.yml to use macos-15 and Xcode 16.4

Once the a11y focus is changed the Carousel moves to the focused item automatically:

https://github.com/user-attachments/assets/5949dc39-4947-414d-838c-54b1d8832a0c

Snapping:

https://github.com/user-attachments/assets/9e1b554e-7fa1-4089-b61c-b30db23eee8e

