### PR TITLE
chore: 🤖 fix fatalError when running tests of a package that relies on FioriSwiftUI package

### DIFF
--- a/Sources/FioriSwiftUICore/Utils/Bundle+Extensions.swift
+++ b/Sources/FioriSwiftUICore/Utils/Bundle+Extensions.swift
@@ -5,6 +5,17 @@ private class CurrentBundleFinder {}
 extension Bundle {
     static var accessor: Bundle {
         #if SWIFT_PACKAGE
+
+            // patch for SwiftPM: ensure that bundle is found when accessed from a package that relies on FioriSwiftUI
+            if ProcessInfo.processInfo.processName == "xctest" {
+                // two names are evaluated because this source file is shared between FioriThemeManager & FioriSwiftUICore modules
+                for bundleName in ["FioriSwiftUI_FioriThemeManager", "FioriSwiftUI_FioriSwiftUICore"] {
+                    if let bundle = patchToFindBundle(with: bundleName) {
+                        return bundle
+                    }
+                }
+            }
+        
             return Bundle.module
         #else
             return Bundle(for: CurrentBundleFinder.self)

--- a/Sources/FioriSwiftUICore/Utils/FioriSwiftUICoreBundle+Extensions.swift
+++ b/Sources/FioriSwiftUICore/Utils/FioriSwiftUICoreBundle+Extensions.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+private class CurrentBundleFinder {}
+
+extension Bundle {
+    static var accessor: Bundle {
+        #if SWIFT_PACKAGE
+
+            // patch for SwiftPM: ensure that bundle is found when accessed from a package that relies on FioriSwiftUI
+            if ProcessInfo.processInfo.processName == "xctest" {
+                if let bundle = patchToFindBundle(with: "FioriSwiftUI_FioriSwiftUICore") {
+                    return bundle
+                }
+            }
+        
+            return Bundle.module
+        #else
+            return Bundle(for: CurrentBundleFinder.self)
+        #endif
+    }
+    
+    static func patchToFindBundle(with bundleName: String) -> Bundle? {
+        let candidates = [
+            /* Bundle should be present here when the package is linked into an App. */
+            Bundle.main.resourceURL,
+            
+            /* Bundle should be present here when the package is linked into a framework. */
+            Bundle(for: CurrentBundleFinder.self).resourceURL,
+            
+            /* For command-line tools. */
+            Bundle.main.bundleURL,
+            
+            /* Bundle should be present here when running previews from a different package (this is the path to "…/Debug-iphonesimulator/"). */
+            Bundle(for: CurrentBundleFinder.self).resourceURL?.deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent(),
+            Bundle(for: CurrentBundleFinder.self).resourceURL?.deletingLastPathComponent().deletingLastPathComponent()
+        ]
+        
+        for candidate in candidates {
+            let bundlePath = candidate?.appendingPathComponent(bundleName + ".bundle")
+            if let bundle = bundlePath.flatMap(Bundle.init(url:)) {
+                return bundle
+            }
+        }
+        
+        return nil
+    }
+}

--- a/Sources/FioriThemeManager/Utils/Bundle+Extensions.swift
+++ b/Sources/FioriThemeManager/Utils/Bundle+Extensions.swift
@@ -1,1 +1,0 @@
-../../FioriSwiftUICore/Utils/Bundle+Extensions.swift

--- a/Sources/FioriThemeManager/Utils/FioriThemeManagerBundle+Extensions.swift
+++ b/Sources/FioriThemeManager/Utils/FioriThemeManagerBundle+Extensions.swift
@@ -8,11 +8,8 @@ extension Bundle {
 
             // patch for SwiftPM: ensure that bundle is found when accessed from a package that relies on FioriSwiftUI
             if ProcessInfo.processInfo.processName == "xctest" {
-                // two names are evaluated because this source file is shared between FioriThemeManager & FioriSwiftUICore modules
-                for bundleName in ["FioriSwiftUI_FioriThemeManager", "FioriSwiftUI_FioriSwiftUICore"] {
-                    if let bundle = patchToFindBundle(with: bundleName) {
-                        return bundle
-                    }
+                if let bundle = patchToFindBundle(with: "FioriSwiftUI_FioriThemeManager") {
+                    return bundle
                 }
             }
         


### PR DESCRIPTION
Fix https://jira.tools.sap/browse/IOSSDKBUG-929

The issue was previously fixed with https://github.com/SAP/cloud-sdk-ios-fiori/pull/728 last year, but the relevant code seems to have been deleted in April this year with https://github.com/SAP/cloud-sdk-ios-fiori/pull/1041