### PR TITLE
fix: 🐛 ObjectHeader's parameters preserve space [IOSSDKBUG-973]; cherrypick from main

### DIFF
--- a/Sources/FioriSwiftUICore/_FioriStyles/ObjectHeaderStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/ObjectHeaderStyle.fiori.swift
@@ -45,14 +45,11 @@ public struct ObjectHeaderBaseStyle: ObjectHeaderStyle {
     
     func regularView(_ configuration: ObjectHeaderConfiguration) -> some View {
         HStack(alignment: .top) {
-            if !configuration.detailImage.isEmpty {
-                configuration.detailImage
-                    .frame(width: 70, height: 70)
-                    .cornerRadius(6)
-                    .clipped()
-                
-                Spacer().frame(width: 16)
-            }
+            configuration.detailImage
+                .frame(width: 70, height: 70)
+                .cornerRadius(6)
+                .clipped()
+                .padding(.trailing)
             
             HStack(alignment: .iconStackAlignmentGuide) {
                 HStack {
@@ -64,27 +61,24 @@ public struct ObjectHeaderBaseStyle: ObjectHeaderStyle {
                 
                 Spacer(minLength: 48)
                 
-                if !self.isMiddleViewInRegularEmpty(configuration) {
-                    self.middleViewInRegular(configuration)
-                        .layoutPriority(1)
-                        .sizeReader(size: { size in
-                            self.middleViewSize = size
-                        })
-                        .frame(width: min(312, self.middleViewSize.width))
-                }
-                
-                if !self.isMiddleViewInRegularEmpty(configuration), !configuration.status.isEmpty || !configuration.substatus.isEmpty {
-                    Spacer().frame(width: 40)
-                }
+                self.middleViewInRegular(configuration)
+                    .layoutPriority(1)
+                    .onGeometryChange(for: CGSize.self, of: { proxy in
+                        proxy.size
+                    }, action: { newValue in
+                        self.middleViewSize = newValue
+                    })
+                    .frame(width: min(312, self.middleViewSize.width))
                 
                 self.rightViewInRegular(configuration)
                     .layoutPriority(2)
-                    .sizeReader(size: { size in
-                        DispatchQueue.main.async {
-                            self.rightViewSize = size
-                        }
+                    .onGeometryChange(for: CGSize.self, of: { proxy in
+                        proxy.size
+                    }, action: { newValue in
+                        self.rightViewSize = newValue
                     })
                     .frame(width: min(120, self.rightViewSize.width))
+                    .padding(.leading, 40)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -210,11 +204,12 @@ public struct ObjectHeaderBaseStyle: ObjectHeaderStyle {
                     .disabled(true)
                 
                 self.statusViewInCompact(configuration)
-                    .sizeReader(size: { size in
-                        DispatchQueue.main.async {
-                            self.statusViewSize = size
-                        }
-                    }).hidden()
+                    .onGeometryChange(for: CGSize.self, of: { proxy in
+                        proxy.size
+                    }, action: { newValue in
+                        self.statusViewSize = newValue
+                    })
+                    .hidden()
             }
             
             if tabsCount > 1 {
@@ -233,10 +228,10 @@ public struct ObjectHeaderBaseStyle: ObjectHeaderStyle {
                 Spacer().frame(height: 8)
             }
         }
-        .sizeReader(size: { size in
-            DispatchQueue.main.async {
-                self.mainViewSize = size
-            }
+        .onGeometryChange(for: CGSize.self, of: { proxy in
+            proxy.size
+        }, action: { newValue in
+            self.mainViewSize = newValue
         })
     }
     
@@ -265,9 +260,7 @@ public struct ObjectHeaderBaseStyle: ObjectHeaderStyle {
     func tab1WhenSizeCategoryGreatThanLarge(_ configuration: ObjectHeaderConfiguration) -> some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(alignment: .center, spacing: 8) {
-                if configuration.detailImage.isEmpty {
-                    configuration.detailImage
-                }
+                configuration.detailImage
                 
                 Spacer(minLength: 8)
                 
@@ -296,13 +289,10 @@ public struct ObjectHeaderBaseStyle: ObjectHeaderStyle {
     }
     
     func tab1InGeneral(_ configuration: ObjectHeaderConfiguration) -> some View {
-        HStack(alignment: .top) {
-            if !configuration.detailImage.isEmpty {
-                configuration.detailImage
-                    .frame(width: 45, height: 45)
-                
-                Spacer().frame(width: 16)
-            }
+        HStack(alignment: .top, spacing: 0) {
+            configuration.detailImage
+                .frame(width: 45, height: 45)
+                .padding(.trailing, 16)
             
             VStack(alignment: .leading, spacing: 16) {
                 HStack(alignment: .top) {
@@ -311,13 +301,12 @@ public struct ObjectHeaderBaseStyle: ObjectHeaderStyle {
                         configuration.subtitle.multilineTextAlignment(.leading)
                     }
                     
-                    if !configuration.status.isEmpty || !configuration.substatus.isEmpty {
-                        Spacer(minLength: 8)
-                        
-                        self.statusViewInCompact(configuration)
-                            .layoutPriority(2)
-                            .frame(width: self.statusViewSize.width == 0 ? nil : min(self.statusViewSize.width, self.mainViewSize.width * 0.23))
-                    }
+                    Spacer(minLength: 0)
+                    
+                    self.statusViewInCompact(configuration)
+                        .layoutPriority(2)
+                        .frame(width: self.statusViewSize.width == 0 ? nil : min(self.statusViewSize.width, self.mainViewSize.width * 0.23))
+                        .padding(.leading, 8)
                 }
                 
                 if !self.isAdditionalInfoViewEmpty(configuration) {


### PR DESCRIPTION
ObjectHeader's parameters preserve space even if they are empty

Before:
<img width="598" height="1220" alt="Screenshot 2025-10-10 at 11 16 51 AM" src="https://github.com/user-attachments/assets/6df1f03a-0500-43fd-bb4a-a2104a81ee62" />
<img width="1168" height="650" alt="Screenshot 2025-10-10 at 11 16 41 AM" src="https://github.com/user-attachments/assets/f907fb14-c95f-48bb-bdfd-314ff998f3e4" />
<img width="1168" height="650" alt="Screenshot 2025-10-10 at 11 16 14 AM" src="https://github.com/user-attachments/assets/040cd9b1-3d13-42c8-903a-5f48721c3a56" />