### PR TITLE
test: 💍 refactor FormView examples to move Options to Nav Bar

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/FormViews/CurrencyInputExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/FormViews/CurrencyInputExample.swift
@@ -14,6 +14,7 @@ struct CurrencyInputExampleView: View {
     @State private var ilsAmount: String = ""
     @State private var isRequired: Bool = true
     @State private var isoCode: String = "USD"
+    @State private var showingOptions = false
     
     let currencyToLocale: [String: String] = [
         "USD": "en_US", // US Dollar - English (United States)
@@ -43,21 +44,7 @@ struct CurrencyInputExampleView: View {
 
     var body: some View {
         VStack {
-            Text("Currency Input Examples")
-                .font(.title)
-                .padding(.top, 20)
-            
             List {
-                HStack {
-                    Text("Mandatory field")
-                    Spacer()
-                    Switch(isOn: self.$isRequired)
-                }
-                Picker("Currency Code", selection: self.$isoCode) {
-                    ForEach(Array(self.currencyToLocale.keys), id: \.self) { code in
-                        Text("\(code)").tag(code)
-                    }
-                }
                 VStack(spacing: 24) {
                     VStack(alignment: .leading, spacing: 8) {
                         // USD input - US Dollar example
@@ -128,6 +115,41 @@ struct CurrencyInputExampleView: View {
                     }
                 }
             }
+        }
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationTitle("Currency Input Examples")
+        .toolbar {
+            FioriButton(title: "Options") { _ in
+                self.showingOptions = true
+            }
+        }
+        .sheet(isPresented: self.$showingOptions) {
+            NavigationStack {
+                List {
+                    Toggle("Mandatory Field", isOn: self.$isRequired)
+                        .padding(.leading, 16)
+                        .padding(.trailing, 16)
+                    
+                    Picker("Currency Code", selection: self.$isoCode) {
+                        ForEach(Array(self.currencyToLocale.keys).sorted(), id: \.self) { code in
+                            Text("\(code)").tag(code)
+                        }
+                    }
+                    .padding(.leading, 16)
+                    .padding(.trailing, 16)
+                }
+                .navigationTitle("Options")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        Button("Done") {
+                            self.showingOptions = false
+                        }
+                    }
+                }
+            }
+            .presentationDetents([.medium, .large])
+            .presentationDragIndicator(.visible)
         }
     }
     

--- a/Apps/Examples/Examples/FioriSwiftUICore/FormViews/FilterFormViewExamples.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/FormViews/FilterFormViewExamples.swift
@@ -12,6 +12,7 @@ struct FilterFormViewExamples: View {
     @State private var showMandatoryField = false
     @State private var customizedMandatoryIndicator = false
     @State private var isEnabled = true
+    @State private var showingOptions = false
     
     @State private var multiSelectionEmptySelectionValue: [Int] = [1, 2]
     @State private var multiSelectionEmptySelectionNoCheckmarkValue: [Int] = [1, 2]
@@ -44,25 +45,6 @@ struct FilterFormViewExamples: View {
     
     var body: some View {
         List {
-            Toggle(isOn: self.$showMandatoryField) {
-                Text("Mandatory Field")
-                    .font(.fiori(forTextStyle: .subheadline, weight: .semibold))
-                    .foregroundStyle(Color.preferredColor(.primaryLabel))
-            }
-            .tint(Color.preferredColor(.tintColor))
-            Toggle(isOn: self.$customizedMandatoryIndicator) {
-                Text("Customized Mandatory Indicator")
-                    .font(.fiori(forTextStyle: .subheadline, weight: .semibold))
-                    .foregroundStyle(Color.preferredColor(.primaryLabel))
-            }
-            .tint(Color.preferredColor(.tintColor))
-            Toggle(isOn: self.$isEnabled) {
-                Text("Enabled")
-                    .font(.fiori(forTextStyle: .subheadline, weight: .semibold))
-                    .foregroundStyle(Color.preferredColor(.primaryLabel))
-            }
-            .tint(Color.preferredColor(.tintColor))
-            
             FilterFormView(title: "MultiSelection, EmptySelection", mandatoryFieldIndicator: self.mandatoryField(), isRequired: self.showMandatoryField, options: self.valueOptions, errorMessage: "Validation Message", isEnabled: self.isEnabled, allowsMultipleSelection: true, allowsEmptySelection: true, value: self.$multiSelectionEmptySelectionValue, buttonSize: .fixed, onValueChange: { value in
                 print("MultiSelection, EmptySelection value change: \(value)")
             })
@@ -193,6 +175,39 @@ struct FilterFormViewExamples: View {
                 ])
         }
         .listStyle(.plain)
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationTitle("FilterFormView Examples")
+        .toolbar {
+            FioriButton(title: "Options") { _ in
+                self.showingOptions = true
+            }
+        }
+        .sheet(isPresented: self.$showingOptions) {
+            NavigationStack {
+                List {
+                    Toggle("Mandatory Field", isOn: self.$showMandatoryField)
+                        .padding(.leading, 16)
+                        .padding(.trailing, 16)
+                    Toggle("Customized Mandatory Indicator", isOn: self.$customizedMandatoryIndicator)
+                        .padding(.leading, 16)
+                        .padding(.trailing, 16)
+                    Toggle("Enabled", isOn: self.$isEnabled)
+                        .padding(.leading, 16)
+                        .padding(.trailing, 16)
+                }
+                .navigationTitle("Options")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        Button("Done") {
+                            self.showingOptions = false
+                        }
+                    }
+                }
+            }
+            .presentationDetents([.medium, .large])
+            .presentationDragIndicator(.visible)
+        }
     }
     
     func mandatoryFieldIndicatorColor() -> Color {

--- a/Apps/Examples/Examples/FioriSwiftUICore/FormViews/RatingControlFormViewExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/FormViews/RatingControlFormViewExample.swift
@@ -38,6 +38,8 @@ struct RatingControlFormViewExample: View {
     @State var setsReviewCountCeiling = false
     @State var showAINotice: Bool = false
     @State var showBottomSheet: Bool = false
+    @State var showingOptions = false
+    @State var isLoading = false
     
     var customizeNoticeMsg: AttributedString {
         var msgText = AttributedString("Customized AI Notice. ")
@@ -54,213 +56,253 @@ struct RatingControlFormViewExample: View {
     }
 
     var body: some View {
-        List {
-            Text("RatingControlFormView Examples")
-            Toggle("Shows Hint Message", isOn: self.$showsHintMessage)
-                .padding(.leading, 16)
-                .padding(.trailing, 16)
-            Toggle("Shows Value Label", isOn: self.$showsValueLabel)
-                .padding(.leading, 16)
-                .padding(.trailing, 16)
-            Toggle("Shows Review Count Label", isOn: self.$showsReviewCountLabel)
-                .padding(.leading, 16)
-                .padding(.trailing, 16)
-            Toggle("Sets Average Rating", isOn: self.$setsAverageRating)
-                .padding(.leading, 16)
-                .padding(.trailing, 16)
-            Toggle("Sets Review Count", isOn: self.$setsReviewCount)
-                .padding(.leading, 16)
-                .padding(.trailing, 16)
-            Toggle("Sets Review Count Ceiling", isOn: self.$setsReviewCountCeiling)
-                .padding(.leading, 16)
-                .padding(.trailing, 16)
-            Toggle("AI Notice", isOn: self.$showAINotice)
-                .padding(.leading, 16)
-                .padding(.trailing, 16)
+        VStack {
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 16) {
+                    Button("Dismiss Keyboard") {
+                        self.hideKeyboard()
+                    }
+                    .padding(.leading, 16)
+                    .padding(.trailing, 16)
+                    
+                    Text("Default Examples").italic()
+                    RatingControlFormView(title: "Rating 1", rating: self.$rating1, showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel)
+                        .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
+                        .aiNoticeView(isPresented: self.$showAINotice)
+                    
+                    RatingControlFormView(title: "Rating 2 (Disabled)", rating: self.$rating2, ratingControlStyle: .editableDisabled, showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel)
+                        .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
+                        .aiNoticeView(isPresented: self.$showAINotice, icon: Image(fioriName: "fiori.ai"), description: "AI Notice message. ", actionLabel: "View more link", viewMoreAction: self.openURL)
+                        .disabled(true)
 
-            Text("Default Examples")
-            RatingControlFormView(title: "Rating 1", rating: self.$rating1, showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel)
-                .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
-                .aiNoticeView(isPresented: self.$showAINotice)
+                    RatingControlFormView(title: "Rating 3 (Read Only) Rating 3 (Read Only)", rating: self.$rating3, ratingControlStyle: .standard, showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel)
+                        .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
+                        .aiNoticeView(isPresented: self.$showAINotice, description: "AI Notice")
             
-            RatingControlFormView(title: "Rating 2 (Disabled)", rating: self.$rating2, ratingControlStyle: .editableDisabled, showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel)
-                .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
-                .aiNoticeView(isPresented: self.$showAINotice, icon: Image(fioriName: "fiori.ai"), description: "AI Notice message. ", actionLabel: "View more link", viewMoreAction: self.openURL)
-                .disabled(true)
+                    RatingControlFormView(title: "Rating 4 (Read Only Large) Rating 4 (Read Only Large)", rating: self.$rating4, ratingControlStyle: .standardLarge, showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel)
+                        .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
+                        .aiNoticeView(isPresented: self.$showAINotice, icon: Image(fioriName: "fiori.ai"), description: "AI Notice with icon. ", actionLabel: "View more details", viewMoreAction: self.toggleShowSheet)
+                        .sheet(isPresented: self.$showBottomSheet) {
+                            Text("detail information")
+                                .presentationDetents([.height(250), .medium])
+                                .presentationDragIndicator(.visible)
+                        }
+                    
+                    RatingControlFormView(title: "Rating 5 (Accented)", rating: self.$rating5, ratingControlStyle: .accented, showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel)
+                        .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
+                        .aiNoticeView(isPresented: self.$showAINotice, icon: Image(fioriName: "fiori.ai"), description: "AI Notice with icon, long long long long long long message. ", actionLabel: "View more link", viewMoreAction: self.openURL)
+                    
+                    RatingControlFormView(title: "Rating 6 (Accented Large)", rating: self.$rating6, ratingControlStyle: .accentedLarge, showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel)
+                        .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
+                        .aiNoticeView(isPresented: self.$showAINotice, icon: Image(systemName: "wand.and.sparkles"), description: self.customizeNoticeMsg, actionLabel: self.customizeNoticeActionLabel, viewMoreAction: self.openURL)
+                        .iconStyle(content: { config in
+                            config.icon.foregroundStyle(Color.purple)
+                        })
+                    
+                    Text("Stacked").italic()
+                    RatingControlFormView(title: "Rating 7", rating: self.$rating7, showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel, axis: .vertical)
+                        .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
+                    RatingControlFormView(title: "Rating 8 (Disabled)", rating: self.$rating8, ratingControlStyle: .editableDisabled, showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel, axis: .vertical)
+                        .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
+                    RatingControlFormView(title: "Rating 9 (Read Only)", rating: self.$rating9, ratingControlStyle: .standard, showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel, axis: .vertical)
+                        .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
+                    RatingControlFormView(title: "Rating 10 (Read Only Large)", rating: self.$rating10, ratingControlStyle: .standardLarge, showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel, axis: .vertical)
+                        .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
+                    RatingControlFormView(title: "Rating 11 (Accented)", rating: self.$rating11, ratingControlStyle: .accented, showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel, axis: .vertical)
+                        .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
+                    RatingControlFormView(title: "Rating 12 (Accented Large)", rating: self.$rating12, ratingControlStyle: .accentedLarge, showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel, axis: .vertical)
+                        .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
 
-            RatingControlFormView(title: "Rating 3 (Read Only) Rating 3 (Read Only)", rating: self.$rating3, ratingControlStyle: .standard, showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel)
-                .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
-                .aiNoticeView(isPresented: self.$showAINotice, description: "AI Notice")
-            
-            RatingControlFormView(title: "Rating 4 (Read Only Large) Rating 4 (Read Only Large)", rating: self.$rating4, ratingControlStyle: .standardLarge, showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel)
-                .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
-                .aiNoticeView(isPresented: self.$showAINotice, icon: Image(fioriName: "fiori.ai"), description: "AI Notice with icon. ", actionLabel: "View more details", viewMoreAction: self.toggleShowSheet)
-                .sheet(isPresented: self.$showBottomSheet) {
-                    Text("detail information")
-                        .presentationDetents([.height(250), .medium])
-                        .presentationDragIndicator(.visible)
-                }
-            
-            RatingControlFormView(title: "Rating 5 (Accented)", rating: self.$rating5, ratingControlStyle: .accented, showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel)
-                .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
-                .aiNoticeView(isPresented: self.$showAINotice, icon: Image(fioriName: "fiori.ai"), description: "AI Notice with icon, long long long long long long message. ", actionLabel: "View more link", viewMoreAction: self.openURL)
-            
-            RatingControlFormView(title: "Rating 6 (Accented Large)", rating: self.$rating6, ratingControlStyle: .accentedLarge, showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel)
-                .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
-                .aiNoticeView(isPresented: self.$showAINotice, icon: Image(systemName: "wand.and.sparkles"), description: self.customizeNoticeMsg, actionLabel: self.customizeNoticeActionLabel, viewMoreAction: self.openURL)
-                .iconStyle(content: { config in
-                    config.icon.foregroundStyle(Color.purple)
-                })
-            
-            Text("Stacked")
-            RatingControlFormView(title: "Rating 7", rating: self.$rating7, showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel, axis: .vertical)
-                .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
-            RatingControlFormView(title: "Rating 8 (Disabled)", rating: self.$rating8, ratingControlStyle: .editableDisabled, showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel, axis: .vertical)
-                .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
-            RatingControlFormView(title: "Rating 9 (Read Only)", rating: self.$rating9, ratingControlStyle: .standard, showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel, axis: .vertical)
-                .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
-            RatingControlFormView(title: "Rating 10 (Read Only Large)", rating: self.$rating10, ratingControlStyle: .standardLarge, showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel, axis: .vertical)
-                .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
-            RatingControlFormView(title: "Rating 11 (Accented)", rating: self.$rating11, ratingControlStyle: .accented, showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel, axis: .vertical)
-                .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
-            RatingControlFormView(title: "Rating 12 (Accented Large)", rating: self.$rating12, ratingControlStyle: .accentedLarge, showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel, axis: .vertical)
-                .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
+                    Text("With Subtitle").italic()
+                    RatingControlFormView(title: "Rating 13", rating: self.$rating13, showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel, subtitle: "Rating 13 Subtitle")
+                        .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
+                    RatingControlFormView(title: "Rating 14 (Disabled)", rating: self.$rating14, ratingControlStyle: .editableDisabled, showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel, subtitle: "Rating 14 Subtitle")
+                        .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
+                    RatingControlFormView(title: "Rating 15 (Read Only)", rating: self.$rating15, ratingControlStyle: .standard, showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel, subtitle: "Rating 15 Subtitle")
+                        .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
+                    RatingControlFormView(title: "Rating 16 (Read Only Large)", rating: self.$rating16, ratingControlStyle: .standardLarge, showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel, subtitle: "Rating 16 Subtitle")
+                        .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
+                    RatingControlFormView(title: "Rating 17 (Accented)", rating: self.$rating17, ratingControlStyle: .accented, showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel, subtitle: "Rating 17 Subtitle")
+                        .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
+                    RatingControlFormView(title: "Rating 18 (Accented Large)", rating: self.$rating18, ratingControlStyle: .accentedLarge, showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel, subtitle: "Rating 18 Subtitle")
+                        .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
 
-            Text("With Subtitle")
-            RatingControlFormView(title: "Rating 13", rating: self.$rating13, showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel, subtitle: "Rating 13 Subtitle")
-                .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
-            RatingControlFormView(title: "Rating 14 (Disabled)", rating: self.$rating14, ratingControlStyle: .editableDisabled, showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel, subtitle: "Rating 14 Subtitle")
-                .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
-            RatingControlFormView(title: "Rating 15 (Read Only)", rating: self.$rating15, ratingControlStyle: .standard, showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel, subtitle: "Rating 15 Subtitle")
-                .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
-            RatingControlFormView(title: "Rating 16 (Read Only Large)", rating: self.$rating16, ratingControlStyle: .standardLarge, showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel, subtitle: "Rating 16 Subtitle")
-                .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
-            RatingControlFormView(title: "Rating 17 (Accented)", rating: self.$rating17, ratingControlStyle: .accented, showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel, subtitle: "Rating 17 Subtitle")
-                .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
-            RatingControlFormView(title: "Rating 18 (Accented Large)", rating: self.$rating18, ratingControlStyle: .accentedLarge, showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel, subtitle: "Rating 18 Subtitle")
-                .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
-
-            Text("Customized")
-            RatingControlFormView(title: "Rating 19", onStarImage: Image(systemName: "hand.thumbsup.fill").renderingMode(.template).resizable(), offStarImage: Image(systemName: "hand.thumbsdown.fill").renderingMode(.template).resizable(), halfStarImage: Image(systemName: "hand.thumbsup.circle").renderingMode(.template).resizable(), rating: self.$rating19, itemSize: CGSize(width: 40, height: 40), showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel)
-                .onStarImageStyle { style in
-                    OnStarImage(style)
-                        .foregroundStyle(.red)
+                    Text("Customized").italic()
+                    RatingControlFormView(title: "Rating 19", onStarImage: Image(systemName: "hand.thumbsup.fill").renderingMode(.template).resizable(), offStarImage: Image(systemName: "hand.thumbsdown.fill").renderingMode(.template).resizable(), halfStarImage: Image(systemName: "hand.thumbsup.circle").renderingMode(.template).resizable(), rating: self.$rating19, itemSize: CGSize(width: 40, height: 40), showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel)
+                        .onStarImageStyle { style in
+                            OnStarImage(style)
+                                .foregroundStyle(.red)
+                        }
+                        .offStarImageStyle { style in
+                            OffStarImage(style)
+                                .foregroundStyle(.yellow)
+                        }
+                        .valueLabelStyle { style in
+                            ValueLabel(style)
+                                .font(.fiori(forTextStyle: .headline))
+                                .foregroundStyle(.brown)
+                        }
+                        .reviewCountLabelStyle { style in
+                            ReviewCountLabel(style)
+                                .font(.fiori(forTextStyle: .headline))
+                                .foregroundStyle(.brown)
+                        }
+                        .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
+                    RatingControlFormView(title: "Rating 20 (Disabled)", onStarImage: Image(systemName: "hand.thumbsup.fill").renderingMode(.template).resizable(), offStarImage: Image(systemName: "hand.thumbsdown.fill").renderingMode(.template).resizable(), halfStarImage: Image(systemName: "hand.thumbsup.circle").renderingMode(.template).resizable(), rating: self.$rating20, ratingControlStyle: .editableDisabled, itemSize: CGSize(width: 30, height: 30), showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel)
+                        .onStarImageStyle { style in
+                            OnStarImage(style)
+                                .foregroundStyle(.red)
+                        }
+                        .offStarImageStyle { style in
+                            OffStarImage(style)
+                                .foregroundStyle(.yellow)
+                        }
+                        .valueLabelStyle { style in
+                            ValueLabel(style)
+                                .font(.fiori(forTextStyle: .headline))
+                                .foregroundStyle(.brown)
+                        }
+                        .reviewCountLabelStyle { style in
+                            ReviewCountLabel(style)
+                                .font(.fiori(forTextStyle: .headline))
+                                .foregroundStyle(.brown)
+                        }
+                        .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
+                    RatingControlFormView(title: "Rating 21 (Read Only) Rating 21 (Read Only)", onStarImage: Image(systemName: "hand.thumbsup.fill").renderingMode(.template).resizable(), offStarImage: Image(systemName: "hand.thumbsdown.fill").renderingMode(.template).resizable(), halfStarImage: Image(systemName: "hand.thumbsup.circle").renderingMode(.template).resizable(), rating: self.$rating21, ratingControlStyle: .standard, itemSize: CGSize(width: 10, height: 10), showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel)
+                        .onStarImageStyle { style in
+                            OnStarImage(style)
+                                .foregroundStyle(.red)
+                        }
+                        .offStarImageStyle { style in
+                            OffStarImage(style)
+                                .foregroundStyle(.yellow)
+                        }
+                        .valueLabelStyle { style in
+                            ValueLabel(style)
+                                .font(.fiori(forTextStyle: .headline))
+                                .foregroundStyle(.brown)
+                        }
+                        .reviewCountLabelStyle { style in
+                            ReviewCountLabel(style)
+                                .font(.fiori(forTextStyle: .headline))
+                                .foregroundStyle(.brown)
+                        }
+                        .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
+                    RatingControlFormView(title: "Rating 22 (Read Only Large) Rating 22 (Read Only Large)", onStarImage: Image(systemName: "hand.thumbsup.fill").renderingMode(.template).resizable(), offStarImage: Image(systemName: "hand.thumbsdown.fill").renderingMode(.template).resizable(), halfStarImage: Image(systemName: "hand.thumbsup.circle").renderingMode(.template).resizable(), rating: self.$rating22, ratingControlStyle: .standardLarge, itemSize: CGSize(width: 20, height: 20), showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel)
+                        .onStarImageStyle { style in
+                            OnStarImage(style)
+                                .foregroundStyle(.red)
+                        }
+                        .offStarImageStyle { style in
+                            OffStarImage(style)
+                                .foregroundStyle(.yellow)
+                        }
+                        .valueLabelStyle { style in
+                            ValueLabel(style)
+                                .font(.fiori(forTextStyle: .headline))
+                                .foregroundStyle(.brown)
+                        }
+                        .reviewCountLabelStyle { style in
+                            ReviewCountLabel(style)
+                                .font(.fiori(forTextStyle: .headline))
+                                .foregroundStyle(.brown)
+                        }
+                        .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
+                    RatingControlFormView(title: "Rating 23 (Accented)", onStarImage: Image(systemName: "hand.thumbsup.fill").renderingMode(.template).resizable(), offStarImage: Image(systemName: "hand.thumbsdown.fill").renderingMode(.template).resizable(), halfStarImage: Image(systemName: "hand.thumbsup.circle").renderingMode(.template).resizable(), rating: self.$rating23, ratingControlStyle: .accented, itemSize: CGSize(width: 5, height: 5), showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel)
+                        .onStarImageStyle { style in
+                            OnStarImage(style)
+                                .foregroundStyle(.red)
+                        }
+                        .offStarImageStyle { style in
+                            OffStarImage(style)
+                                .foregroundStyle(.yellow)
+                        }
+                        .valueLabelStyle { style in
+                            ValueLabel(style)
+                                .font(.fiori(forTextStyle: .headline))
+                                .foregroundStyle(.brown)
+                        }
+                        .reviewCountLabelStyle { style in
+                            ReviewCountLabel(style)
+                                .font(.fiori(forTextStyle: .headline))
+                                .foregroundStyle(.brown)
+                        }
+                        .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
+                    RatingControlFormView(title: "Rating 24 (Accented Large)", onStarImage: Image(systemName: "hand.thumbsup.fill").renderingMode(.template).resizable(), offStarImage: Image(systemName: "hand.thumbsdown.fill").renderingMode(.template).resizable(), halfStarImage: Image(systemName: "hand.thumbsup.circle").renderingMode(.template).resizable(), rating: self.$rating24, ratingControlStyle: .accentedLarge, itemSize: CGSize(width: 10, height: 10), showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel)
+                        .onStarImageStyle { style in
+                            OnStarImage(style)
+                                .foregroundStyle(.red)
+                        }
+                        .offStarImageStyle { style in
+                            OffStarImage(style)
+                                .foregroundStyle(.yellow)
+                        }
+                        .valueLabelStyle { style in
+                            ValueLabel(style)
+                                .font(.fiori(forTextStyle: .headline))
+                                .foregroundStyle(.brown)
+                        }
+                        .reviewCountLabelStyle { style in
+                            ReviewCountLabel(style)
+                                .font(.fiori(forTextStyle: .headline))
+                                .foregroundStyle(.brown)
+                        }
+                        .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
                 }
-                .offStarImageStyle { style in
-                    OffStarImage(style)
-                        .foregroundStyle(.yellow)
+                .padding(.horizontal, 16)
+            }
+            .environment(\.isLoading, self.isLoading)
+            #if !os(visionOS)
+                .scrollDismissesKeyboard(.immediately)
+            #endif
+                .navigationBarTitleDisplayMode(.inline)
+                .navigationTitle("Examples")
+                .toolbar {
+                    FioriButton(title: "Options") { _ in
+                        self.showingOptions = true
+                    }
                 }
-                .valueLabelStyle { style in
-                    ValueLabel(style)
-                        .font(.fiori(forTextStyle: .headline))
-                        .foregroundStyle(.brown)
+                .sheet(isPresented: self.$showingOptions) {
+                    NavigationStack {
+                        List {
+                            Toggle("Shows Hint Message", isOn: self.$showsHintMessage)
+                                .padding(.leading, 16)
+                                .padding(.trailing, 16)
+                            Toggle("Shows Value Label", isOn: self.$showsValueLabel)
+                                .padding(.leading, 16)
+                                .padding(.trailing, 16)
+                            Toggle("Shows Review Count Label", isOn: self.$showsReviewCountLabel)
+                                .padding(.leading, 16)
+                                .padding(.trailing, 16)
+                            Toggle("Sets Average Rating", isOn: self.$setsAverageRating)
+                                .padding(.leading, 16)
+                                .padding(.trailing, 16)
+                            Toggle("Sets Review Count", isOn: self.$setsReviewCount)
+                                .padding(.leading, 16)
+                                .padding(.trailing, 16)
+                            Toggle("Sets Review Count Ceiling", isOn: self.$setsReviewCountCeiling)
+                                .padding(.leading, 16)
+                                .padding(.trailing, 16)
+                            Toggle("AI Notice", isOn: self.$showAINotice)
+                                .padding(.leading, 16)
+                                .padding(.trailing, 16)
+                            Toggle("Show Skeleton Loading", isOn: self.$isLoading)
+                                .padding(.leading, 16)
+                                .padding(.trailing, 16)
+                        }
+                        .navigationTitle("Options")
+                        .navigationBarTitleDisplayMode(.inline)
+                        .toolbar {
+                            ToolbarItem(placement: .navigationBarTrailing) {
+                                Button("Done") {
+                                    self.showingOptions = false
+                                }
+                            }
+                        }
+                    }
+                    .presentationDetents([.medium, .large])
+                    .presentationDragIndicator(.visible)
                 }
-                .reviewCountLabelStyle { style in
-                    ReviewCountLabel(style)
-                        .font(.fiori(forTextStyle: .headline))
-                        .foregroundStyle(.brown)
-                }
-                .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
-            RatingControlFormView(title: "Rating 20 (Disabled)", onStarImage: Image(systemName: "hand.thumbsup.fill").renderingMode(.template).resizable(), offStarImage: Image(systemName: "hand.thumbsdown.fill").renderingMode(.template).resizable(), halfStarImage: Image(systemName: "hand.thumbsup.circle").renderingMode(.template).resizable(), rating: self.$rating20, ratingControlStyle: .editableDisabled, itemSize: CGSize(width: 30, height: 30), showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel)
-                .onStarImageStyle { style in
-                    OnStarImage(style)
-                        .foregroundStyle(.red)
-                }
-                .offStarImageStyle { style in
-                    OffStarImage(style)
-                        .foregroundStyle(.yellow)
-                }
-                .valueLabelStyle { style in
-                    ValueLabel(style)
-                        .font(.fiori(forTextStyle: .headline))
-                        .foregroundStyle(.brown)
-                }
-                .reviewCountLabelStyle { style in
-                    ReviewCountLabel(style)
-                        .font(.fiori(forTextStyle: .headline))
-                        .foregroundStyle(.brown)
-                }
-                .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
-            RatingControlFormView(title: "Rating 21 (Read Only) Rating 21 (Read Only)", onStarImage: Image(systemName: "hand.thumbsup.fill").renderingMode(.template).resizable(), offStarImage: Image(systemName: "hand.thumbsdown.fill").renderingMode(.template).resizable(), halfStarImage: Image(systemName: "hand.thumbsup.circle").renderingMode(.template).resizable(), rating: self.$rating21, ratingControlStyle: .standard, itemSize: CGSize(width: 10, height: 10), showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel)
-                .onStarImageStyle { style in
-                    OnStarImage(style)
-                        .foregroundStyle(.red)
-                }
-                .offStarImageStyle { style in
-                    OffStarImage(style)
-                        .foregroundStyle(.yellow)
-                }
-                .valueLabelStyle { style in
-                    ValueLabel(style)
-                        .font(.fiori(forTextStyle: .headline))
-                        .foregroundStyle(.brown)
-                }
-                .reviewCountLabelStyle { style in
-                    ReviewCountLabel(style)
-                        .font(.fiori(forTextStyle: .headline))
-                        .foregroundStyle(.brown)
-                }
-                .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
-            RatingControlFormView(title: "Rating 22 (Read Only Large) Rating 22 (Read Only Large)", onStarImage: Image(systemName: "hand.thumbsup.fill").renderingMode(.template).resizable(), offStarImage: Image(systemName: "hand.thumbsdown.fill").renderingMode(.template).resizable(), halfStarImage: Image(systemName: "hand.thumbsup.circle").renderingMode(.template).resizable(), rating: self.$rating22, ratingControlStyle: .standardLarge, itemSize: CGSize(width: 20, height: 20), showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel)
-                .onStarImageStyle { style in
-                    OnStarImage(style)
-                        .foregroundStyle(.red)
-                }
-                .offStarImageStyle { style in
-                    OffStarImage(style)
-                        .foregroundStyle(.yellow)
-                }
-                .valueLabelStyle { style in
-                    ValueLabel(style)
-                        .font(.fiori(forTextStyle: .headline))
-                        .foregroundStyle(.brown)
-                }
-                .reviewCountLabelStyle { style in
-                    ReviewCountLabel(style)
-                        .font(.fiori(forTextStyle: .headline))
-                        .foregroundStyle(.brown)
-                }
-                .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
-            RatingControlFormView(title: "Rating 23 (Accented)", onStarImage: Image(systemName: "hand.thumbsup.fill").renderingMode(.template).resizable(), offStarImage: Image(systemName: "hand.thumbsdown.fill").renderingMode(.template).resizable(), halfStarImage: Image(systemName: "hand.thumbsup.circle").renderingMode(.template).resizable(), rating: self.$rating23, ratingControlStyle: .accented, itemSize: CGSize(width: 5, height: 5), showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel)
-                .onStarImageStyle { style in
-                    OnStarImage(style)
-                        .foregroundStyle(.red)
-                }
-                .offStarImageStyle { style in
-                    OffStarImage(style)
-                        .foregroundStyle(.yellow)
-                }
-                .valueLabelStyle { style in
-                    ValueLabel(style)
-                        .font(.fiori(forTextStyle: .headline))
-                        .foregroundStyle(.brown)
-                }
-                .reviewCountLabelStyle { style in
-                    ReviewCountLabel(style)
-                        .font(.fiori(forTextStyle: .headline))
-                        .foregroundStyle(.brown)
-                }
-                .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
-            RatingControlFormView(title: "Rating 24 (Accented Large)", onStarImage: Image(systemName: "hand.thumbsup.fill").renderingMode(.template).resizable(), offStarImage: Image(systemName: "hand.thumbsdown.fill").renderingMode(.template).resizable(), halfStarImage: Image(systemName: "hand.thumbsup.circle").renderingMode(.template).resizable(), rating: self.$rating24, ratingControlStyle: .accentedLarge, itemSize: CGSize(width: 10, height: 10), showsValueLabel: self.showsValueLabel, averageRating: self.getAverageRatingValue(), reviewCount: self.getReviewCount(), reviewCountCeiling: self.getReviewCountCeiling(), showsReviewCountLabel: self.showsReviewCountLabel)
-                .onStarImageStyle { style in
-                    OnStarImage(style)
-                        .foregroundStyle(.red)
-                }
-                .offStarImageStyle { style in
-                    OffStarImage(style)
-                        .foregroundStyle(.yellow)
-                }
-                .valueLabelStyle { style in
-                    ValueLabel(style)
-                        .font(.fiori(forTextStyle: .headline))
-                        .foregroundStyle(.brown)
-                }
-                .reviewCountLabelStyle { style in
-                    ReviewCountLabel(style)
-                        .font(.fiori(forTextStyle: .headline))
-                        .foregroundStyle(.brown)
-                }
-                .informationView(isPresented: self.$showsHintMessage, description: AttributedString("hint message"))
         }
     }
 
@@ -293,8 +335,12 @@ struct RatingControlFormViewExample: View {
     func toggleShowSheet() {
         self.showBottomSheet.toggle()
     }
+    
+    func hideKeyboard() {
+        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+    }
 }
 
 #Preview {
-    RatingControlExample()
+    RatingControlFormViewExample()
 }

--- a/Apps/Examples/Examples/FioriSwiftUICore/FormViews/TextFieldFormViewExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/FormViews/TextFieldFormViewExample.swift
@@ -40,6 +40,7 @@ struct TextFieldFormViewExample: View {
     @State var showAINotice: Bool = false
     @State var showBottomSheet: Bool = false
     @State var isLoading: Bool = false
+    @State var showingOptions = false
 
     @State var text = ""
     
@@ -59,82 +60,107 @@ struct TextFieldFormViewExample: View {
 
     var body: some View {
         VStack {
-            Text("TextFieldFormViewExample")
-            List {
-                Toggle("Shows Hint Text", isOn: self.$showsHintText)
-                    .padding(.leading, 16)
-                    .padding(.trailing, 16)
-                Toggle("Shows Error Message", isOn: self.$showsErrorMessage)
-                    .padding(.leading, 16)
-                    .padding(.trailing, 16)
-                Toggle("Shows Char Count", isOn: self.$showsCharCount)
-                    .padding(.leading, 16)
-                    .padding(.trailing, 16)
-                Toggle("Allows Beyond Limit", isOn: self.$allowsBeyondLimit)
-                    .padding(.leading, 16)
-                    .padding(.trailing, 16)
-                Toggle("Hides Read-Only Hint", isOn: self.$hidesReadonlyHint)
-                    .padding(.leading, 16)
-                    .padding(.trailing, 16)
-                Toggle("Shows Action", isOn: self.$showsAction)
-                    .padding(.leading, 16)
-                    .padding(.trailing, 16)
-                Toggle("Mandatory Field", isOn: self.$isRequired)
-                    .padding(.leading, 16)
-                    .padding(.trailing, 16)
-                Toggle("Secure Mode", isOn: self.$isSecureEnabled)
-                    .padding(.leading, 16)
-                    .padding(.trailing, 16)
-                Toggle("AI Notice", isOn: self.$showAINotice)
-                    .padding(.leading, 16)
-                    .padding(.trailing, 16)
-                Toggle("Show SkeletonLoading", isOn: self.$isLoading)
-                    .padding(.leading, 16)
-                    .padding(.trailing, 16)
-                Button("Dismiss Keyboard") {
-                    hideKeyboard()
-                }
-                .padding(.leading, 16)
-                .padding(.trailing, 16)
-
-                Text("Default TextFieldForm")
-                    .italic()
-                TextFieldFormView(title: self.key1, text: self.$valueText1, isSecureEnabled: self.isSecureEnabled, placeholder: "TextFieldFormView", errorMessage: self.getErrorMessage(), maxTextLength: self.getMaxTextLength(), hintText: self.getHintText(), isCharCountEnabled: self.showsCharCount, allowsBeyondLimit: self.allowsBeyondLimit, isRequired: self.isRequired, actionIcon: self.getActionIcon(), action: self.getAction1(), actionIconAccessibilityLabel: self.getActionIconAccessibilityLabel())
-                    .aiNoticeView(isPresented: self.$showAINotice)
-
-                Text("Existing Text")
-                    .italic()
-                TextFieldFormView(title: self.key2, text: self.$valueText2, isSecureEnabled: self.isSecureEnabled, placeholder: "TextFieldFormView", errorMessage: self.getErrorMessage(), maxTextLength: self.getMaxTextLength(), hintText: self.getHintText(), isCharCountEnabled: self.showsCharCount, allowsBeyondLimit: self.allowsBeyondLimit, isRequired: self.isRequired, actionIcon: self.getActionIcon(), action: self.getAction2(), actionIconAccessibilityLabel: self.getActionIconAccessibilityLabel())
-                    .aiNoticeView(isPresented: self.$showAINotice, icon: Image(fioriName: "fiori.ai"), description: "AI Notice with icon. ", actionLabel: "View more details", viewMoreAction: self.toggleShowSheet)
-                    .sheet(isPresented: self.$showBottomSheet) {
-                        Text("detail information")
-                            .presentationDetents([.height(250), .medium])
-                            .presentationDragIndicator(.visible)
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 16) {
+                    Button("Dismiss Keyboard") {
+                        hideKeyboard()
                     }
+                    .padding(.leading, 16)
+                    .padding(.trailing, 16)
+                    Text("Default TextFieldForm")
+                        .italic()
+                    TextFieldFormView(title: self.key1, text: self.$valueText1, isSecureEnabled: self.isSecureEnabled, placeholder: "TextFieldFormView", errorMessage: self.getErrorMessage(), maxTextLength: self.getMaxTextLength(), hintText: self.getHintText(), isCharCountEnabled: self.showsCharCount, allowsBeyondLimit: self.allowsBeyondLimit, isRequired: self.isRequired, actionIcon: self.getActionIcon(), action: self.getAction1(), actionIconAccessibilityLabel: self.getActionIconAccessibilityLabel())
+                        .aiNoticeView(isPresented: self.$showAINotice)
 
-                Text("Empty Text")
-                    .italic()
-                TextFieldFormView(title: self.key3, text: self.$valueText3, isSecureEnabled: self.isSecureEnabled, placeholder: "Please enter something", errorMessage: self.getErrorMessage(), maxTextLength: self.getMaxTextLength(), hintText: self.getHintText(), isCharCountEnabled: self.showsCharCount, allowsBeyondLimit: self.allowsBeyondLimit, isRequired: self.isRequired, actionIcon: self.getActionIcon(), action: self.getAction3(), actionIconAccessibilityLabel: self.getActionIconAccessibilityLabel())
-                    .aiNoticeView(isPresented: self.$showAINotice, icon: Image(fioriName: "fiori.ai"), description: "AI Notice with icon, long long long long long long message. ", actionLabel: "View more link", viewMoreAction: self.openURL)
+                    Text("Existing Text")
+                        .italic()
+                    TextFieldFormView(title: self.key2, text: self.$valueText2, isSecureEnabled: self.isSecureEnabled, placeholder: "TextFieldFormView", errorMessage: self.getErrorMessage(), maxTextLength: self.getMaxTextLength(), hintText: self.getHintText(), isCharCountEnabled: self.showsCharCount, allowsBeyondLimit: self.allowsBeyondLimit, isRequired: self.isRequired, actionIcon: self.getActionIcon(), action: self.getAction2(), actionIconAccessibilityLabel: self.getActionIconAccessibilityLabel())
+                        .aiNoticeView(isPresented: self.$showAINotice, icon: Image(fioriName: "fiori.ai"), description: "AI Notice with icon. ", actionLabel: "View more details", viewMoreAction: self.toggleShowSheet)
+                        .sheet(isPresented: self.$showBottomSheet) {
+                            Text("detail information")
+                                .presentationDetents([.height(250), .medium])
+                                .presentationDragIndicator(.visible)
+                        }
 
-                Text("Disabled")
-                TextFieldFormView(title: "Disabled Cell", text: self.$disabledText, isSecureEnabled: self.isSecureEnabled, placeholder: "Disabled", controlState: .disabled, isRequired: self.isRequired, actionIcon: self.getActionIcon(), action: self.getAction4())
-                    .aiNoticeView(isPresented: self.$showAINotice, icon: Image(fioriName: "fiori.ai"), description: "AI Notice message. ", actionLabel: "View more link", viewMoreAction: self.openURL)
-                    .disabled(true)
+                    Text("Empty Text")
+                        .italic()
+                    TextFieldFormView(title: self.key3, text: self.$valueText3, isSecureEnabled: self.isSecureEnabled, placeholder: "Please enter something", errorMessage: self.getErrorMessage(), maxTextLength: self.getMaxTextLength(), hintText: self.getHintText(), isCharCountEnabled: self.showsCharCount, allowsBeyondLimit: self.allowsBeyondLimit, isRequired: self.isRequired, actionIcon: self.getActionIcon(), action: self.getAction3(), actionIconAccessibilityLabel: self.getActionIconAccessibilityLabel())
+                        .aiNoticeView(isPresented: self.$showAINotice, icon: Image(fioriName: "fiori.ai"), description: "AI Notice with icon, long long long long long long message. ", actionLabel: "View more link", viewMoreAction: self.openURL)
 
-                Text("Read-Only")
-                TextFieldFormView(title: "Read-Only Cell", text: self.$readOnlyText, isSecureEnabled: self.isSecureEnabled, placeholder: "Read-Only", controlState: .readOnly, hidesReadOnlyHint: self.hidesReadonlyHint, isRequired: self.isRequired, actionIcon: self.getActionIcon(), action: self.getAction4())
-                    .aiNoticeView(isPresented: self.$showAINotice, icon: Image(systemName: "wand.and.sparkles"), description: self.customizeNoticeMsg, actionLabel: self.customizeNoticeActionLabel, viewMoreAction: self.openURL)
-                    .iconStyle(content: { config in
-                        config.icon.foregroundStyle(Color.purple)
-                    })
-                
-                TextFieldFormView(title: "", text: self.$valueText3, isSecureEnabled: self.isSecureEnabled, placeholder: "", controlState: .normal, hidesReadOnlyHint: self.hidesReadonlyHint, isRequired: self.isRequired, actionIcon: self.getActionIcon(), action: self.getAction4())
+                    Text("Disabled")
+                    TextFieldFormView(title: "Disabled Cell", text: self.$disabledText, isSecureEnabled: self.isSecureEnabled, placeholder: "Disabled", controlState: .disabled, isRequired: self.isRequired, actionIcon: self.getActionIcon(), action: self.getAction4())
+                        .aiNoticeView(isPresented: self.$showAINotice, icon: Image(fioriName: "fiori.ai"), description: "AI Notice message. ", actionLabel: "View more link", viewMoreAction: self.openURL)
+                        .disabled(true)
+
+                    Text("Read-Only")
+                    TextFieldFormView(title: "Read-Only Cell", text: self.$readOnlyText, isSecureEnabled: self.isSecureEnabled, placeholder: "Read-Only", controlState: .readOnly, hidesReadOnlyHint: self.hidesReadonlyHint, isRequired: self.isRequired, actionIcon: self.getActionIcon(), action: self.getAction4())
+                        .aiNoticeView(isPresented: self.$showAINotice, icon: Image(systemName: "wand.and.sparkles"), description: self.customizeNoticeMsg, actionLabel: self.customizeNoticeActionLabel, viewMoreAction: self.openURL)
+                        .iconStyle(content: { config in
+                            config.icon.foregroundStyle(Color.purple)
+                        })
+                    
+                    TextFieldFormView(title: "", text: self.$valueText3, isSecureEnabled: self.isSecureEnabled, placeholder: "", controlState: .normal, hidesReadOnlyHint: self.hidesReadonlyHint, isRequired: self.isRequired, actionIcon: self.getActionIcon(), action: self.getAction4())
+                }
+                .padding(.horizontal, 16)
             }
             .environment(\.isLoading, self.isLoading)
             #if !os(visionOS)
                 .scrollDismissesKeyboard(.immediately)
             #endif
+                .navigationBarTitleDisplayMode(.inline)
+                .navigationTitle("Examples")
+                .toolbar {
+                    FioriButton(title: "Options") { _ in
+                        self.showingOptions = true
+                    }
+                }
+                .sheet(isPresented: self.$showingOptions) {
+                    NavigationStack {
+                        List {
+                            Toggle("Shows Hint Text", isOn: self.$showsHintText)
+                                .padding(.leading, 16)
+                                .padding(.trailing, 16)
+                            Toggle("Shows Error Message", isOn: self.$showsErrorMessage)
+                                .padding(.leading, 16)
+                                .padding(.trailing, 16)
+                            Toggle("Shows Char Count", isOn: self.$showsCharCount)
+                                .padding(.leading, 16)
+                                .padding(.trailing, 16)
+                            Toggle("Allows Beyond Limit", isOn: self.$allowsBeyondLimit)
+                                .padding(.leading, 16)
+                                .padding(.trailing, 16)
+                            Toggle("Hides Read-Only Hint", isOn: self.$hidesReadonlyHint)
+                                .padding(.leading, 16)
+                                .padding(.trailing, 16)
+                            Toggle("Shows Action", isOn: self.$showsAction)
+                                .padding(.leading, 16)
+                                .padding(.trailing, 16)
+                            Toggle("Mandatory Field", isOn: self.$isRequired)
+                                .padding(.leading, 16)
+                                .padding(.trailing, 16)
+                            Toggle("Secure Mode", isOn: self.$isSecureEnabled)
+                                .padding(.leading, 16)
+                                .padding(.trailing, 16)
+                            Toggle("AI Notice", isOn: self.$showAINotice)
+                                .padding(.leading, 16)
+                                .padding(.trailing, 16)
+                            Toggle("Show SkeletonLoading", isOn: self.$isLoading)
+                                .padding(.leading, 16)
+                                .padding(.trailing, 16)
+                        }
+                        .navigationTitle("Options")
+                        .navigationBarTitleDisplayMode(.inline)
+                        .toolbar {
+                            ToolbarItem(placement: .navigationBarTrailing) {
+                                Button("Done") {
+                                    self.showingOptions = false
+                                }
+                            }
+                        }
+                    }
+                    .presentationDetents([.medium, .large])
+                    .presentationDragIndicator(.visible)
+                }
         }
     }
 

--- a/Apps/Examples/Examples/FioriSwiftUICore/FormViews/TitleFormViewExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/FormViews/TitleFormViewExample.swift
@@ -21,59 +21,96 @@ struct TitleFormViewExample: View {
     @State var showsCharCount = false
     @State var allowsBeyondLimit = false
     @State var hidesReadonlyHint = false
+    @State var showingOptions = false
+    @State var isLoading = false
     
     @State var text = ""
     
     var body: some View {
         VStack {
-            Text("TitleFormViewExample")
-            Form {
-                Toggle("Shows Hint Text", isOn: self.$showsHintText)
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 16) {
+                    Button("Dismiss Keyboard") {
+                        self.hideKeyboard()
+                    }
                     .padding(.leading, 16)
                     .padding(.trailing, 16)
-                Toggle("Shows Error Message", isOn: self.$showsErrorMessage)
-                    .padding(.leading, 16)
-                    .padding(.trailing, 16)
-                Toggle("Shows Char Count", isOn: self.$showsCharCount)
-                    .padding(.leading, 16)
-                    .padding(.trailing, 16)
-                Toggle("Allows Beyond Limit", isOn: self.$allowsBeyondLimit)
-                    .padding(.leading, 16)
-                    .padding(.trailing, 16)
-                Toggle("Hides Read-Only Hint", isOn: self.$hidesReadonlyHint)
-                    .padding(.leading, 16)
-                    .padding(.trailing, 16)
-                
-                Text("Default TitleForm")
-                TitleFormView(text: self.$valueText1, placeholder: "TitleFormView", errorMessage: self.getErrorMessage(), maxTextLength: self.getMaxTextLength(), hintText: self.getHintText(), isCharCountEnabled: self.showsCharCount, allowsBeyondLimit: self.allowsBeyondLimit)
-                    .padding(.leading, -4)
-                    .padding(.trailing, -4)
-
-                Text("Existing Text")
-                    .italic()
-                TitleFormView(text: self.$valueText2, placeholder: "TitleFormView", errorMessage: self.getErrorMessage(), maxTextLength: self.getMaxTextLength(), hintText: self.getHintText(), isCharCountEnabled: self.showsCharCount, allowsBeyondLimit: self.allowsBeyondLimit)
-                    .padding(.leading, -4)
-                    .padding(.trailing, -4)
-
-                Text("Empty Text")
-                    .italic()
-                TitleFormView(text: self.$valueText3, placeholder: "Please enter something", errorMessage: self.getErrorMessage(), maxTextLength: self.getMaxTextLength(), hintText: self.getHintText(), isCharCountEnabled: self.showsCharCount, allowsBeyondLimit: self.allowsBeyondLimit)
-                    .padding(.leading, -4)
-                    .padding(.trailing, -4)
-
-                Text("Disabled")
-                TitleFormView(text: self.$disabledText, placeholder: "Disabled", controlState: .disabled)
-                    .padding(.leading, -4)
-                    .padding(.trailing, -4)
-
-                Text("Read-Only")
-                TitleFormView(text: self.$readOnlyText, placeholder: "Read-Only", controlState: .readOnly, hidesReadOnlyHint: self.hidesReadonlyHint)
-                    .padding(.leading, -4)
-                    .padding(.trailing, -4)
+                    
+                    Text("Default TitleForm")
+                    TitleFormView(text: self.$valueText1, placeholder: "TitleFormView", errorMessage: self.getErrorMessage(), maxTextLength: self.getMaxTextLength(), hintText: self.getHintText(), isCharCountEnabled: self.showsCharCount, allowsBeyondLimit: self.allowsBeyondLimit)
+                        .padding(.leading, -4)
+                        .padding(.trailing, -4)
+                    
+                    Text("Existing Text")
+                        .italic()
+                    TitleFormView(text: self.$valueText2, placeholder: "TitleFormView", errorMessage: self.getErrorMessage(), maxTextLength: self.getMaxTextLength(), hintText: self.getHintText(), isCharCountEnabled: self.showsCharCount, allowsBeyondLimit: self.allowsBeyondLimit)
+                        .padding(.leading, -4)
+                        .padding(.trailing, -4)
+                    
+                    Text("Empty Text")
+                        .italic()
+                    TitleFormView(text: self.$valueText3, placeholder: "Please enter something", errorMessage: self.getErrorMessage(), maxTextLength: self.getMaxTextLength(), hintText: self.getHintText(), isCharCountEnabled: self.showsCharCount, allowsBeyondLimit: self.allowsBeyondLimit)
+                        .padding(.leading, -4)
+                        .padding(.trailing, -4)
+                    
+                    Text("Disabled")
+                    TitleFormView(text: self.$disabledText, placeholder: "Disabled", controlState: .disabled)
+                        .padding(.leading, -4)
+                        .padding(.trailing, -4)
+                    
+                    Text("Read-Only")
+                    TitleFormView(text: self.$readOnlyText, placeholder: "Read-Only", controlState: .readOnly, hidesReadOnlyHint: self.hidesReadonlyHint)
+                        .padding(.leading, -4)
+                        .padding(.trailing, -4)
+                }
+                .padding(.horizontal, 16)
             }
+            .environment(\.isLoading, self.isLoading)
             #if !os(visionOS)
-            .scrollDismissesKeyboard(.immediately)
+                .scrollDismissesKeyboard(.immediately)
             #endif
+                .navigationBarTitleDisplayMode(.inline)
+                .navigationTitle("Examples")
+                .toolbar {
+                    FioriButton(title: "Options") { _ in
+                        self.showingOptions = true
+                    }
+                }
+        }
+        .sheet(isPresented: self.$showingOptions) {
+            NavigationStack {
+                List {
+                    Toggle("Shows Hint Text", isOn: self.$showsHintText)
+                        .padding(.leading, 16)
+                        .padding(.trailing, 16)
+                    Toggle("Shows Error Message", isOn: self.$showsErrorMessage)
+                        .padding(.leading, 16)
+                        .padding(.trailing, 16)
+                    Toggle("Shows Char Count", isOn: self.$showsCharCount)
+                        .padding(.leading, 16)
+                        .padding(.trailing, 16)
+                    Toggle("Allows Beyond Limit", isOn: self.$allowsBeyondLimit)
+                        .padding(.leading, 16)
+                        .padding(.trailing, 16)
+                    Toggle("Hides Read-Only Hint", isOn: self.$hidesReadonlyHint)
+                        .padding(.leading, 16)
+                        .padding(.trailing, 16)
+                    Toggle("Show Skeleton Loading", isOn: self.$isLoading)
+                        .padding(.leading, 16)
+                        .padding(.trailing, 16)
+                }
+                .navigationTitle("Options")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        Button("Done") {
+                            self.showingOptions = false
+                        }
+                    }
+                }
+            }
+            .presentationDetents([.medium, .large])
+            .presentationDragIndicator(.visible)
         }
     }
     
@@ -91,6 +128,10 @@ struct TitleFormViewExample: View {
     
     func getCharCountEnabled() -> Bool? {
         self.showsCharCount ? true : nil
+    }
+    
+    func hideKeyboard() {
+        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
     }
 }
 


### PR DESCRIPTION
Refactor example code in 
TextFieldFormViewExample, TitleFormViewExample, RatingControlFormViewExample, FilterFormViewExamples, CurrencyInputExampleView
All the test configuration options are moved into main navigation bar button


https://github.com/user-attachments/assets/4d7f3223-d0b3-455c-bc36-42b999942e71

