### PR TITLE
fix: 🐛 Card Focus with button [jira: IOSSDKBUG-898]; cherrypick

### DIFF
--- a/Sources/FioriSwiftUICore/_FioriStyles/CardFooterStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/CardFooterStyle.fiori.swift
@@ -197,7 +197,7 @@ private struct CardFooterLayout: Layout {
         
         let y = maxHeight / 2
         // Move the hidden buttons out of visible area
-        let hideRect = CGRect(x: -2000, y: y, width: 0, height: 0)
+        let hideRect = CGRect(x: finalWidth + 0.3, y: y, width: 0.3, height: 0.3)
         var frames = [CGRect]()
         
         var x: CGFloat = 0
@@ -292,6 +292,7 @@ public struct CardFooterBaseStyle: CardFooterStyle {
                 configuration.action
             }
         }
+        .clipped()
     }
     
     /**


### PR DESCRIPTION
<img width="1159" height="646" alt="Screenshot 2025-10-17 at 4 41 46 PM" src="https://github.com/user-attachments/assets/f2721950-b8eb-4171-89c5-314ce6725945" />
<img width="594" height="1211" alt="Screenshot 2025-10-17 at 4 41 40 PM" src="https://github.com/user-attachments/assets/57736382-c735-4baf-a50d-9111896dced8" />
