### PR TITLE
fix: 🐛 [IOSSDKBUG-1165] [acc] width issue in Checkout Indicator Modal Example

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/CheckoutIndicator/CheckoutIndicatorModalExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/CheckoutIndicator/CheckoutIndicatorModalExample.swift
@@ -36,7 +36,7 @@ struct ModalView: View {
             }
             .pickerStyle(.segmented)
             .padding(.top, 20)
-            .frame(maxWidth: 300)
+            .frame(maxWidth: 400)
 
             Button("Dismiss Modal") {
                 self.dismiss()


### PR DESCRIPTION
Change the width of the "Picker" within the "Checkout Indicator Modal" example so that the button label is fully visible and readable after activation, preventing any truncation.

<img width="772" height="1005" alt="Screenshot 2025-11-07 at 07 49 18" src="https://github.com/user-attachments/assets/780253d0-0b51-41bf-bcff-9c6bd277379f" />
