### PR TITLE
fix: 🐛 [IOSSDKBUG-1184] [acc] disable focus in loading state

### DIFF
--- a/Sources/FioriSwiftUICore/Utils/SkeletonLoading.swift
+++ b/Sources/FioriSwiftUICore/Utils/SkeletonLoading.swift
@@ -150,6 +150,15 @@ struct ShimmerViewModifier: ViewModifier {
     }
 
     func body(content: Content) -> some View {
+        if #available(watchOS 10.0, *) {
+            shimmerContent(content: content)
+                .focusEffectDisabled(self.isLoading)
+        } else {
+            self.shimmerContent(content: content)
+        }
+    }
+    
+    func shimmerContent(content: Content) -> some View {
         content
             .foregroundColor(self.redactedForegroundColor)
             .redacted(reason: self.isLoading ? .placeholder : [])


### PR DESCRIPTION
When skeleton loading is progress, keyboard control should not be able to focus on it.
<img width="50%" height="257" alt="Screenshot 2025-11-11 at 16 49 08" src="https://github.com/user-attachments/assets/8b544487-5ab2-48e6-9b36-e0341a1397ae" />
