### PR TITLE
fix: photo captured via camera exceeds 10MB

### DIFF
--- a/Sources/FioriSwiftUICore/Attachment/CameraView.swift
+++ b/Sources/FioriSwiftUICore/Attachment/CameraView.swift
@@ -39,7 +39,7 @@ public struct CameraView: UIViewControllerRepresentable {
         let camera = UIImagePickerController()
         camera.sourceType = .camera
         camera.mediaTypes = [UTType.image.identifier, UTType.movie.identifier]
-        camera.allowsEditing = false
+        camera.allowsEditing = true
         camera.delegate = context.coordinator
         return camera
     }
@@ -86,7 +86,7 @@ public struct CameraView: UIViewControllerRepresentable {
             if (info[.mediaType] as? String) == UTType.movie.identifier {
                 self.parent.onSaveVideo?(info[.mediaURL] as? URL)
             } else {
-                self.parent.onSaveImage(info[UIImagePickerController.InfoKey.originalImage] as? UIImage)
+                self.parent.onSaveImage(info[UIImagePickerController.InfoKey.editedImage] as? UIImage)
             }
             self.parent.presentationMode.wrappedValue.dismiss()
         }


### PR DESCRIPTION
Fix [IOSSDKBUG-1235](https://jira.tools.sap/browse/IOSSDKBUG-1235): Photo captured via camera exceeds 10MB — please optimize image compression

Issue: 
Before this PR, info[UIImagePickerController.InfoKey.originalImage] was used to retrieve image. This returns large image.

Fix:
There two approaches for avoiding large images. 
1. use info[UIImagePickerController.InfoKey.editedImage] + allowsEditing = true.
2. resize captured image. 
Since we don't have a spec for resizing images captured with camera, the first approach is adopted for now. In the long run, we can start analyzing how to resize images for different Apps.
With the fix, file size is significantly reduced.

Comparison:
SwiftUICore after fix:
![after-fix](https://github.com/user-attachments/assets/b42ae77b-0951-483e-90d3-d8457aaf04e4)

JMC before fix:
![before-fix-jmc](https://github.com/user-attachments/assets/95452260-0d90-4b83-a590-390187fd7708)
