### PR TITLE
fix: 🐛 remove the demo case for the deprecated Sidebar API

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/SideBar/EditableSideBarExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/SideBar/EditableSideBarExample.swift
@@ -12,38 +12,27 @@ public struct SideBarExample: View {
     public var body: some View {
         List {
             NavigationLink {
-                OutdatedSideBarExample()
+                EditableSideBarExample(allowEdit: false)
             } label: {
-                Text("Outdated Sidebar")
+                Text("Readonly Sidebar")
             }
             NavigationLink {
-                List {
-                    NavigationLink {
-                        EditableSideBarExample(allowEdit: false)
-                    } label: {
-                        Text("Readonly Sidebar")
-                    }
-                    NavigationLink {
-                        EditableSideBarExample()
-                    } label: {
-                        Text("Editable Sidebar")
-                    }
-                    NavigationLink {
-                        EditableSideBarExample(isCustom: true)
-                    } label: {
-                        Text("Customized Sidebar")
-                    }
-                    NavigationLink {
-                        EditableSideBarExample(isPartialCustom: true)
-                    } label: {
-                        Text("Customized Sidebar-2")
-                    }
-                }
-                .navigationBarHidden(false)
+                EditableSideBarExample()
             } label: {
-                Text("Sidebar")
+                Text("Editable Sidebar")
+            }
+            NavigationLink {
+                EditableSideBarExample(isCustom: true)
+            } label: {
+                Text("Customized Sidebar")
+            }
+            NavigationLink {
+                EditableSideBarExample(isPartialCustom: true)
+            } label: {
+                Text("Customized Sidebar-2")
             }
         }
+        .navigationBarHidden(false)
     }
 }
 


### PR DESCRIPTION
This PR handles the removal of the demo case for the deprecated Sidebar API in the Example App.

The following AY11 issues were resolved with above fix:
[IOSSDKBUG-1049](https://jira.tools.sap/browse/IOSSDKBUG-1049)
[IOSSDKBUG-1050](https://jira.tools.sap/browse/IOSSDKBUG-1050)
[IOSSDKBUG-1053](https://jira.tools.sap/browse/IOSSDKBUG-1053)
[IOSSDKBUG-1054](https://jira.tools.sap/browse/IOSSDKBUG-1054)
[IOSSDKBUG-1057](https://jira.tools.sap/browse/IOSSDKBUG-1057)
[IOSSDKBUG-1058](https://jira.tools.sap/browse/IOSSDKBUG-1058)
[IOSSDKBUG-1076](https://jira.tools.sap/browse/IOSSDKBUG-1076)
