### PR TITLE
fix: 🐛 [IOSSDKBUG-1297] DateTimePicker: display wrong date

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/Picker/DateTimePickerExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/Picker/DateTimePickerExample.swift
@@ -4,7 +4,7 @@ import SwiftUI
 
 struct DateTimePickerExample: View {
     @State var s1: Date? = .init(timeIntervalSince1970: 0.0)
-    @State var s2: Date? = nil
+    @State var s2: Date? = Date(timeIntervalSinceNow: 60 * 60 * 24 * 7)
     @State var s3: Date? = nil
     @State var s4: Date? = nil
     @State var s5: Date? = .now

--- a/Sources/FioriSwiftUICore/_FioriStyles/DateTimePickerStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/DateTimePickerStyle.fiori.swift
@@ -40,6 +40,11 @@ public struct DateTimePickerBaseStyle: DateTimePickerStyle {
             }
             .animation(.easeInOut(duration: 0.3), value: configuration.pickerVisible)
         }
+        .onAppear {
+            if let configuredDate = configuration.selectedDate {
+                self.selectedDate = configuredDate
+            }
+        }
         .ifApply(FioriLocale.shared.locale != nil) {
             $0.environment(\.locale, FioriLocale.shared.locale!)
         }


### PR DESCRIPTION
Fix the problem that the progrprogrammatically selected date was not highlighted.

✅ Closes: IOSSDKBUG-1297