### PR TITLE
fix: photo captured via camera exceeds 10MB (#1340)

### DIFF
--- a/Sources/FioriSwiftUICore/Attachment/CameraView.swift
+++ b/Sources/FioriSwiftUICore/Attachment/CameraView.swift
@@ -12,7 +12,7 @@ public struct CameraView: UIViewControllerRepresentable {
         let camera = UIImagePickerController()
         camera.sourceType = .camera
         camera.mediaTypes = [UTType.image.identifier, UTType.movie.identifier]
-        camera.allowsEditing = false
+        camera.allowsEditing = true
         camera.delegate = context.coordinator
         return camera
     }
@@ -34,7 +34,7 @@ public struct CameraView: UIViewControllerRepresentable {
             if (info[.mediaType] as? String) == UTType.movie.identifier {
                 self.parent.onSaveVideo?(info[.mediaURL] as? URL)
             } else {
-                self.parent.onSaveImage(info[UIImagePickerController.InfoKey.originalImage] as? UIImage)
+                self.parent.onSaveImage(info[UIImagePickerController.InfoKey.editedImage] as? UIImage)
             }
             self.parent.presentationMode.wrappedValue.dismiss()
         }


### PR DESCRIPTION
cherry pick [IOSSDKBUG-1235](https://jira.tools.sap/browse/IOSSDKBUG-1235) [fix PR](https://github.com/SAP/cloud-sdk-ios-fiori/pull/1340) to rel-25.8

from Sam Zhang: "Our PM wishes a patch to our production version, which is based on 25.8.2"