### PR TITLE
fix: 🐛 [IOSSDKBUG-1070] ACC- 253.1 (WCAG 2.2, 3.3.2, Level A) _ SAP BTP SDK for IOS_ iPad_ Button _ After activating button Ui get disappeared.

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/SortFilter/SortFilterExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/SortFilter/SortFilterExample.swift
@@ -79,6 +79,7 @@ struct SortFilterExample: View {
                                 }
                             }
                     }
+                    .fullConfigurationItem(itemContent: .name("All Configuration"), position: .leading)
             } else {
                 FilterFeedbackBar(items: self.$items, onUpdate: self.performSortAndFilter)
                     .fullConfigurationItem(itemContent: .name("All Configuration"), position: .leading)


### PR DESCRIPTION
dev result:
<img width="569" height="821" alt="image" src="https://github.com/user-attachments/assets/ebf53304-190b-4fb6-96d9-10ec57737ef9" />

