### PR TITLE
fix: 🐛 [IOSSDKBUG-1549]VoiceOver: close button announcement fix

### DIFF
--- a/Sources/FioriSwiftUICore/_FioriStyles/CloseActionStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/CloseActionStyle.fiori.swift
@@ -16,6 +16,7 @@ public struct CloseActionFioriStyle: CloseActionStyle {
     public func makeBody(_ configuration: CloseActionConfiguration) -> some View {
         CloseAction(configuration)
             .fioriButtonStyle(CloseActionStyle())
+            .accessibilityLabel(NSLocalizedString("Close", tableName: "FioriSwiftUICore", bundle: Bundle.accessor, comment: "Close"))
     }
     
     struct CloseActionStyle: FioriButtonStyle {

--- a/Sources/FioriSwiftUICore/_localization/en.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/en.lproj/FioriSwiftUICore.strings
@@ -605,3 +605,6 @@
 
 /* XBUT: Writing assistant negative feedback accessibility label */
 "Negative feedback" = "Negative feedback";
+
+/* XBUT: Close button title */
+"Close" = "Close";


### PR DESCRIPTION
The close button on VoiceOver mode should be announced as "Close"

✅ Closes: [IOSSDKBUG-1549]