### PR TITLE
fix: 🐛 [IOSSDKBUG-1289]remove acc for close Image, keep whole

### DIFF
--- a/Sources/FioriSwiftUICore/_FioriStyles/SignatureCaptureViewStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/SignatureCaptureViewStyle.fiori.swift
@@ -389,6 +389,7 @@ extension SignatureCaptureViewFioriStyle {
             Xmark(configuration)
                 .foregroundColor(Color.preferredColor(.quaternaryLabel))
                 .font(.fiori(forTextStyle: .body))
+                .accessibilityHidden(true)
         }
     }
     


### PR DESCRIPTION
Observed Behavior:

on accessing the ‘Close’ button, screen reader is reading as ‘Signature here’ however we have no tool tip as such.

Same issue is occurring in signature inline view
Expected Behavior:  

Only the correct UI information should be read out and any additional or irrelevant announcement should be avoided,