### PR TITLE
fix: 🐛 [IOSSDKBUG-1006] Tap on a date to clear selected range in CalendarView (#1416)

### DIFF
--- a/Sources/FioriSwiftUICore/_FioriStyles/CalendarViewStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/CalendarViewStyle.fiori.swift
@@ -211,21 +211,10 @@ public struct CalendarViewBaseStyle: CalendarViewStyle {
                 configuration.model.selectedDates = [date]
             }
         } else {
-            let calendar = Calendar.autoupdatingCurrent
             if configuration.model.calendarStyle == .rangeSelection {
-                if let checkRange = configuration.model.selectedRange {
-                    if calendar.compare(date, to: checkRange.upperBound, toGranularity: .day) != .orderedDescending,
-                       calendar.compare(date, to: checkRange.lowerBound, toGranularity: .day) != .orderedAscending
-                    {
-                        let bounds = [checkRange.lowerBound, date].sorted()
-                        if let first = bounds.first, let last = bounds.last {
-                            configuration.model.selectedRange = first ... last
-                        }
-                        configuration.model.selectedDate = nil
-                    } else {
-                        configuration.model.selectedRange = nil
-                        configuration.model.selectedDate = date
-                    }
+                if configuration.model.selectedRange != nil {
+                    configuration.model.selectedRange = nil
+                    configuration.model.selectedDate = date
                 } else if let boundDate = configuration.model.selectedDate {
                     let bounds = [boundDate, date].sorted()
                     if let first = bounds.first, let last = bounds.last {

--- a/Tests/FioriSwiftUITests/FioriSwiftUICore/CalendarViewTests.swift
+++ b/Tests/FioriSwiftUITests/FioriSwiftUICore/CalendarViewTests.swift
@@ -135,9 +135,10 @@ final class CalendarViewTests: XCTestCase {
         XCTAssertTrue(Calendar.current.compare(model.selectedRange?.lowerBound ?? .now, to: self.fm.date(from: "2025 10 12")!, toGranularity: .day) == .orderedSame)
         XCTAssertTrue(Calendar.current.compare(model.selectedRange?.upperBound ?? .now, to: self.fm.date(from: "2025 10 15")!, toGranularity: .day) == .orderedSame)
         style.handleDayViewTapGesture(self.fm.date(from: "2025 10 14")!, state: .multiSelectedEnd, configuration: configuration)
-        XCTAssertTrue(Calendar.current.compare(model.selectedRange?.upperBound ?? .now, to: self.fm.date(from: "2025 10 14")!, toGranularity: .day) == .orderedSame)
-        style.handleDayViewTapGesture(self.fm.date(from: "2025 10 15")!, state: .normal, configuration: configuration)
         XCTAssertNil(model.selectedRange)
+        style.handleDayViewTapGesture(self.fm.date(from: "2025 10 15")!, state: .normal, configuration: configuration)
+        XCTAssertTrue(Calendar.current.compare(model.selectedRange?.upperBound ?? .now, to: self.fm.date(from: "2025 10 15")!, toGranularity: .day) == .orderedSame)
+        XCTAssertTrue(Calendar.current.compare(model.selectedRange?.lowerBound ?? .now, to: self.fm.date(from: "2025 10 14")!, toGranularity: .day) == .orderedSame)
     }
     
     var configuration: CalendarViewConfiguration {


### PR DESCRIPTION
To keep alignment with UI5 and Android