### PR TITLE
fix: 🐛 onScrollGeometryChange available for visionOS 2.0 above

### DIFF
--- a/Sources/FioriSwiftUICore/Experimental/Popover/View+Extension.swift
+++ b/Sources/FioriSwiftUICore/Experimental/Popover/View+Extension.swift
@@ -46,7 +46,7 @@ extension View {
     }
     
     func fioriScrollOffsetReader(_ offset: @escaping (CGPoint) -> Void) -> some View {
-        if #available(iOS 18.0, *) {
+        if #available(iOS 18.0, visionOS 2.0, *) {
             onScrollGeometryChange(for: CGPoint.self) { geometry in
                 geometry.contentOffset
             } action: { _, newValue in


### PR DESCRIPTION
Before the fix:
/github/cloud-sdk-ios-fiori/Sources/FioriSwiftUICore/Experimental/Popover/View+Extension.swift:50:13: error: 'onScrollGeometryChange(for:of:action:)' is only available in visionOS 2.0 or newer
            onScrollGeometryChange(for: CGPoint.self) { geometry in
            ^
