### PR TITLE
fix: 🐛 [IOSSDKBUG-1233] [acc] Add acc label for star/star.fill icon in CardSkeletonLoading example

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/SkeletonLoading/CardSkeletonLoading.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/SkeletonLoading/CardSkeletonLoading.swift
@@ -56,9 +56,9 @@ struct CardSkeletonLoading: View {
                             .titleStyle { config in
                                 config.title.foregroundStyle(Color.preferredColor(.positiveLabel))
                             }
-                        Image(systemName: "star")
+                        Image(systemName: "star").accessibilityLabel("Favourite icon, not selected")
                         LabelItem(title: "Long long long label")
-                        Image(systemName: "star.fill")
+                        Image(systemName: "star.fill").accessibilityLabel("Favourite icon, selected")
                         LabelItem(title: "Multiple lines row1")
                     }
                 }, row2: {


### PR DESCRIPTION
<img width="669" height="969" alt="Screenshot 2025-12-24 at 09 58 07" src="https://github.com/user-attachments/assets/fdcfc6ca-bc19-404f-8d14-ef474231e659" />
<img width="674" height="989" alt="Screenshot 2025-12-24 at 09 58 19" src="https://github.com/user-attachments/assets/88fad1be-d86b-4c28-a4ff-2c3a3da28efe" />
