### PR TITLE
fix: 🐛 SPI vertical layout messed when title is empty (rel-25.11)

### DIFF
--- a/Sources/FioriSwiftUICore/Views/StepProgressIndicator/_SingleStep.swift
+++ b/Sources/FioriSwiftUICore/Views/StepProgressIndicator/_SingleStep.swift
@@ -272,13 +272,13 @@ struct InnerSingleStep<Title: View, Node: View, Line: View>: View {
                         .alignmentGuide(.stepsTopAlignment) { $0.height / 2.0 }
                     self.line.frame(maxWidth: self.lineWidth, minHeight: self.lineHeight)
                 }
+                .alignmentGuide(.stepsLeadingAlignment) { $0[HorizontalAlignment.center] }
                 Spacer().frame(width: self.horizontalSpacing)
                 self.title.lineLimit(nil)
                     .fixedSize(horizontal: false, vertical: true)
                     .alignmentGuide(.stepsTopAlignment) {
                         ($0.height - ($0[.lastTextBaseline] - $0[.firstTextBaseline])) / 2
                     }
-                    .alignmentGuide(.stepsLeadingAlignment) { $0[.leading] }
                 Spacer().frame(width: abs(self.trailing))
                 Spacer()
             }


### PR DESCRIPTION
Ref: #1446 
|before|after|
|-|-|
|<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2025-12-29 at 14 01 28" src="https://github.com/user-attachments/assets/e700317e-8c98-4389-aa58-8fd52569dcf9" />|<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2025-12-29 at 14 42 33" src="https://github.com/user-attachments/assets/8652c561-5b16-4ef5-b8f6-7b48cc1e7451" />|