### PR TITLE
test: 💍 testCalendarModel failed on 12/31/2025

### DIFF
--- a/Tests/FioriSwiftUITests/FioriSwiftUICore/CalendarViewTests.swift
+++ b/Tests/FioriSwiftUITests/FioriSwiftUICore/CalendarViewTests.swift
@@ -40,7 +40,7 @@ final class CalendarViewTests: XCTestCase {
         XCTAssertNil(model.selectedRange)
         XCTAssertEqual(model.monthViewHeight, 300)
         XCTAssertEqual(model.currentMonthOriginHeight, 0)
-        XCTAssertEqual(model.title, "Sep \(2025)")
+        XCTAssertEqual(model.title, "Sep \(year)")
         XCTAssertFalse(model.isDragging)
         XCTAssertTrue(model.isExpanded)
         XCTAssertTrue(model.showsOutOfMonthDates)


### PR DESCRIPTION
Since the github build machine is already changed to 1/1/2026, testCalendarModel failed
Fixed the hardcoded value "2025"