### PR TITLE
fix: 🐛 [IOSSDKBUG-1548] A11y: add placeholder for text inputs

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/FormViews/TextFieldFormViewExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/FormViews/TextFieldFormViewExample.swift
@@ -99,7 +99,7 @@ struct TextFieldFormViewExample: View {
                             config.icon.foregroundStyle(Color.purple)
                         })
                     
-                    TextFieldFormView(title: "", text: self.$valueText3, isSecureEnabled: self.isSecureEnabled, placeholder: "", controlState: .normal, hidesReadOnlyHint: self.hidesReadonlyHint, isRequired: self.isRequired, actionIcon: self.getActionIcon(), action: self.getAction4())
+                    TextFieldFormView(title: "", text: self.$valueText3, isSecureEnabled: self.isSecureEnabled, placeholder: "Enter Something", controlState: .normal, hidesReadOnlyHint: self.hidesReadonlyHint, isRequired: self.isRequired, actionIcon: self.getActionIcon(), action: self.getAction4())
                 }
                 .padding(.horizontal, 16)
             }

--- a/Apps/Examples/Examples/FioriSwiftUICore/Indicator/ProcessingIndicatorExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/Indicator/ProcessingIndicatorExample.swift
@@ -31,7 +31,7 @@ struct ProcessingIndicatorExample: View {
             Button("Show/hide in container", action: {
                 self.showInContainer.toggle()
             })
-            TextFieldFormView(title: "Set label", text: self.$labelText).padding()
+            TextFieldFormView(title: "Set label", text: self.$labelText, placeholder: "Enter something").padding()
             ProcessingIndicator(optionalTitle: AttributedString(self.labelText))
             Spacer()
             if self.showInContainer {

--- a/Apps/Examples/Examples/FioriSwiftUICore/WritingAssistant/WritingAssistantExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/WritingAssistant/WritingAssistantExample.swift
@@ -93,10 +93,8 @@ struct WritingAssistantExample: View {
                 .waHelperAction(self.$helperAction)
                 .frame(height: 100)
                 .hideFeedbackFooterInWritingAssistant(self.hideFeedbackSection)
-            
-            TextFieldFormView(title: {
-                Text("TextFieldFormView Title")
-            }, text: self.$text2)
+
+            TextFieldFormView(title: "TextFieldFormView Title", text: self.$text2, placeholder: "Enter something")
                 .waTextInput(self.$text2, menus: WAMenu.availableMenus, menuHandler: { menu, value in
                     await self.fetchData(for: menu, value: value)
                 }, feedbackOptions: self.feedbackOptions, feedbackHandler: { state, values in


### PR DESCRIPTION
Adding placeholders in Examples app for all TextFieldFormCell views.

✅ Closes: IOSSDKBUG-1548