### PR TITLE
fix: 🐛 [jira-0] card footer buttons are disordered

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/FioriButton/CardFixedWidthButtonsExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/FioriButton/CardFixedWidthButtonsExample.swift
@@ -123,16 +123,21 @@ struct CardFixedWidthButtonsExample: View {
                                     }, image: { _ in
                                         EmptyView()
                                     }, imagePosition: .leading, imageTitleSpacing: 8.0)
-                                        .fioriButtonStyle(FioriPrimaryButtonStyle(loadingState: item.loadingState))
+                                        .fioriButtonStyle(FioriPrimaryButtonStyle(.infinity, loadingState: item.loadingState))
                                         .disabled(item.loadingState != .unspecified)
                                 } secondaryAction: {
                                     FioriButton(isSelectionPersistent: false, title: "Decline", action: { _ in
                                         print("tap Decline")
                                     })
-                                    .fioriButtonStyle(FioriSecondaryButtonStyle(colorStyle: .negative))
+                                    .fioriButtonStyle(FioriSecondaryButtonStyle(colorStyle: .negative, maxWidth: 118))
+                                } tertiaryAction: {
+                                    FioriButton(isSelectionPersistent: false, title: "tertiary", action: { _ in
+                                        print("tap tertiary")
+                                    })
+                                    .fioriButtonStyle(FioriTertiaryButtonStyle(colorStyle: .negative, maxWidth: 118))
                                 }
                                 .frame(width: 300)
-                                .frame(minHeight: 192)
+                                .fixedSize(horizontal: false, vertical: true)
                                 .background(Color.white)
                                 .accessibility(sortPriority: Double(self._dataSource.count - index))
                             }

--- a/Apps/Examples/Examples/FioriSwiftUICore/FioriButton/CardTwoButtonsChangeToOneExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/FioriButton/CardTwoButtonsChangeToOneExample.swift
@@ -134,7 +134,7 @@ struct CardTwoButtonsChangeToOneExample: View {
                                     }
                                 }
                                 .frame(width: 300)
-                                .frame(minHeight: 192)
+                                .fixedSize(horizontal: false, vertical: true)
                                 .background(Color.white)
                                 .accessibility(sortPriority: Double(self._dataSource.count - index))
                             }

--- a/Sources/FioriSwiftUICore/_FioriStyles/CardFooterStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/CardFooterStyle.fiori.swift
@@ -107,9 +107,11 @@ private struct CardFooterLayout: Layout {
      */
     func calculateLayout(proposalWidth: CGFloat?, subViewSizes: [CGSize], layoutMode: LayoutMode, cache: inout CacheData) {
         let subViewNoOflSizes: [CGSize]
+        var hideSecondMenu = false
         switch subViewSizes.count {
         case 5:
             subViewNoOflSizes = Array(subViewSizes.dropLast(2))
+            hideSecondMenu = true
         case 3:
             subViewNoOflSizes = Array(subViewSizes.dropLast(1))
         default:
@@ -162,9 +164,10 @@ private struct CardFooterLayout: Layout {
                 }
                 maxHeight = max(maxHeight, subViewNoOflSizes[i].height)
                 numToShow = i + 1
-                
                 /// Failed to fit numToShow buttons
-                if requiredFinalWidth + (numToShow < numButtons ? min(self.maxButtonWidth, overflowSize.width) + theSpacing : 0) > finalWidth {
+                if hideSecondMenu ||
+                    requiredFinalWidth + (numToShow < numButtons ? min(self.maxButtonWidth, overflowSize.width) + theSpacing : 0) > finalWidth
+                {
                     if numToShow > 1 {
                         numToShow -= 1
                     }
@@ -197,7 +200,7 @@ private struct CardFooterLayout: Layout {
         
         let y = maxHeight / 2
         // Move the hidden buttons out of visible area
-        let hideRect = CGRect(x: finalWidth + 0.3, y: y, width: 0.3, height: 0.3)
+        var hideRect = CGRect(x: finalWidth + 0.3, y: y, width: 0.3, height: 0.3)
         var frames = [CGRect]()
         
         var x: CGFloat = 0
@@ -207,11 +210,13 @@ private struct CardFooterLayout: Layout {
                 x += btWidth + (i > 0 ? theSpacing : 0)
                 frames.append(CGRect(origin: CGPoint(x: finalWidth - x + btWidth / 2, y: y), size: CGSize(width: btWidth, height: maxHeight)))
             } else if i < numButtons { // rest button to hide
+                hideRect.origin.x = frames.map(\.maxX).max() ?? finalWidth
                 frames.append(hideRect)
             } else { // overflow
                 if numToHide > 0, i == numButtons + numToHide - 1 { // last one to show overflow
                     frames.append(CGRect(x: overflowSize.width / 2, y: y, width: min(self.maxButtonWidth, overflowSize.width), height: overflowSize.height))
                 } else { // hide the other overflow
+                    hideRect.origin.x = frames.map(\.maxX).max() ?? finalWidth
                     frames.append(hideRect)
                 }
             }


### PR DESCRIPTION
Dev results:

**Before**:
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-01-09 at 16 41 25" src="https://github.com/user-attachments/assets/ee8ddc07-1aa7-4a52-b6fc-062072d74a19" />
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-01-09 at 16 40 50" src="https://github.com/user-attachments/assets/a062f8c6-874c-4402-9cec-56f81948349b" />


**After**:
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-01-09 at 17 24 43" src="https://github.com/user-attachments/assets/fa62f157-479f-4930-b95f-a0de05ecdb6d" />
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-01-09 at 11 23 08" src="https://github.com/user-attachments/assets/cb1b5539-075d-451c-9808-38fc488a3de0" />
