### PR TITLE
fix: 🐛 hidden buttons are partial visible in cardfooter[jira:0]

### DIFF
--- a/Sources/FioriSwiftUICore/_FioriStyles/CardFooterStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/CardFooterStyle.fiori.swift
@@ -196,8 +196,6 @@ private struct CardFooterLayout: Layout {
         /// set up frames for each subview
         
         let y = maxHeight / 2
-        // Move the hidden buttons out of visible area
-        let hideRect = CGRect(x: finalWidth + 0.3, y: y, width: 0.3, height: 0.3)
         var frames = [CGRect]()
         
         var x: CGFloat = 0
@@ -207,11 +205,15 @@ private struct CardFooterLayout: Layout {
                 x += btWidth + (i > 0 ? theSpacing : 0)
                 frames.append(CGRect(origin: CGPoint(x: finalWidth - x + btWidth / 2, y: y), size: CGSize(width: btWidth, height: maxHeight)))
             } else if i < numButtons { // rest button to hide
+                // Move the hidden buttons out of visible area
+                let hideRect = CGRect(x: finalWidth + subViewNoOflSizes[i].width / 2 + 1, y: y, width: 1, height: 1)
                 frames.append(hideRect)
             } else { // overflow
                 if numToHide > 0, i == numButtons + numToHide - 1 { // last one to show overflow
                     frames.append(CGRect(x: overflowSize.width / 2, y: y, width: min(self.maxButtonWidth, overflowSize.width), height: overflowSize.height))
                 } else { // hide the other overflow
+                    // Move the hidden buttons out of visible area
+                    let hideRect = CGRect(x: finalWidth + overflowSize.width / 2 + 1, y: y, width: 1, height: 1)
                     frames.append(hideRect)
                 }
             }


### PR DESCRIPTION
Before (Check out the right side of button "Check In"):
<img width="643" height="1318" alt="Screenshot 2026-01-08 at 5 24 37 PM" src="https://github.com/user-attachments/assets/730dda69-2599-460a-85bb-9541bc1f78c1" />

After:
<img width="643" height="1318" alt="Screenshot 2026-01-09 at 8 36 14 AM" src="https://github.com/user-attachments/assets/31891b50-2b15-4f1d-a1db-76ef0cc5147a" />
