### PR TITLE
fix: 🐛 hidden buttons are partial visible in cardfooter[jira:0]

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/FioriButton/CardFullWidthSingleButtonExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/FioriButton/CardFullWidthSingleButtonExample.swift
@@ -17,6 +17,7 @@ class CardFullWidthSingleButtonItem: Identifiable, ObservableObject {
 struct CardFullWidthSingleButtonExample: View {
     @State private var buttonTitle = "Check in"
     @Environment(\.dismiss) private var dismiss
+    @State private var isGridView = false
     
     @State private var _dataSource: [CardFullWidthSingleButtonItem] = [
         CardFullWidthSingleButtonItem(title: "1", loadingState: .unspecified, id: UUID()),
@@ -29,12 +30,14 @@ struct CardFullWidthSingleButtonExample: View {
     var profileHeader: some View {
         ProfileHeader(detailImage: {
             Image("rw").resizable()
+                .accessibilityLabel("Photo")
         }, title: {
             Text("Harry Ford")
         }, subtitle: {
             Text("The boy wizard, the boy wizard")
         }, description: {
             Text("This is a description.")
+                .accessibilityAddTraits(.isSummaryElement)
         }) {
             HStack {
                 Spacer()
@@ -45,6 +48,7 @@ struct CardFullWidthSingleButtonExample: View {
                         .imageScale(.large)
                         .fontWeight(.light)
                 }
+                .accessibilityLabel("Message")
                 Spacer()
                 
                 Button {
@@ -54,6 +58,7 @@ struct CardFullWidthSingleButtonExample: View {
                         .imageScale(.large)
                         .fontWeight(.light)
                 }
+                .accessibilityLabel("Email")
                 Spacer()
                 
                 Button {
@@ -63,6 +68,7 @@ struct CardFullWidthSingleButtonExample: View {
                         .imageScale(.large)
                         .fontWeight(.light)
                 }
+                .accessibilityLabel("Phone Call")
                 Spacer()
                 
                 Button {
@@ -72,6 +78,7 @@ struct CardFullWidthSingleButtonExample: View {
                         .imageScale(.large)
                         .fontWeight(.light)
                 }
+                .accessibilityLabel("Video")
                 Spacer()
                 
                 Button {
@@ -81,78 +88,104 @@ struct CardFullWidthSingleButtonExample: View {
                         .imageScale(.large)
                         .fontWeight(.light)
                 }
+                .accessibilityLabel("Hint")
                 Spacer()
             }
         }
     }
     
     var body: some View {
-        Section {
-            Divider()
-            HStack {
-                Text("My Schedule")
-                    .font(.fiori(forTextStyle: .subheadline))
-                    .foregroundStyle(Color.preferredColor(.secondaryLabel))
-                Spacer()
-                Button {
-                    print("see all")
-                } label: {
-                    Text("See all (\(self._dataSource.count))")
-                        .font(.fiori(forTextStyle: .subheadline, weight: .semibold))
-                        .foregroundStyle(Color.preferredColor(.tintColor))
+        List {
+            Section {
+                Divider()
+                HStack {
+                    Text("My Schedule")
+                        .font(.fiori(forTextStyle: .subheadline))
+                        .foregroundStyle(Color.preferredColor(.secondaryLabel))
+                        .accessibilityAddTraits(.isHeader)
+                    Spacer()
+                    Button {
+                        withAnimation {
+                            self.isGridView.toggle()
+                        }
+                    } label: {
+                        Text(self.isGridView ? "Show Horizontal" : "See all (\(self._dataSource.count))")
+                            .font(.fiori(forTextStyle: .subheadline, weight: .semibold))
+                            .foregroundStyle(Color.preferredColor(.tintColor))
+                    }
                 }
-            }
-            .padding(EdgeInsets(top: 5, leading: 20, bottom: 5, trailing: 20))
-            
-            ScrollView(.horizontal) {
-                HStack(spacing: 8, content: {
-                    ForEach(0 ..< self._dataSource.count, id: \.self) { index in
-                        let item = self._dataSource[index]
-                        HStack {
-                            Card {
-                                Text("Schedule\(item.title)")
-                            } subtitle: {
-                                Text("Subtitle")
-                            } detailImage: {
-                                Image("ProfilePic")
-                                    .resizable()
-                                    .frame(width: 45, height: 45)
-                                    .clipShape(RoundedRectangle(cornerRadius: 10))
-                            } headerAction: {
-                                FioriIcon.shopping.cart
-                            } row1: {
-                                Text("Body text could be really long description that requires wrapping, with suggested 2 lines from Fiori Design Guideline perspective to make the UI concise. SDK default setting of numberOfLines for body is 6. Application Developer can override it with : cell.body.numOfLines = preferredNumberOfLines.")
-                                    .lineLimit(2)
-                            } action: {
-                                FioriButton(action: { _ in
-                                    self.updateDataSource(id: item.id)
-                                }, label: { _ in
-                                    Text(self.titleStr(item.loadingState))
-                                })
-                                .fioriButtonStyle(FioriPrimaryButtonStyle(.infinity, loadingState: item.loadingState))
-                                .disabled(item.loadingState != .unspecified)
+                .padding(EdgeInsets(top: 5, leading: 20, bottom: 5, trailing: 20))
+                
+                if self.isGridView {
+                    let columns = Array(repeating: GridItem(.flexible(), spacing: 8), count: 2)
+                    LazyVGrid(columns: columns, spacing: 10) {
+                        ForEach(self._dataSource) { item in
+                            self.cardView(for: item)
+                                .frame(maxWidth: .infinity)
+                        }
+                    }
+                    .padding(.horizontal, 16)
+                } else {
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 8) {
+                            ForEach(0 ..< self._dataSource.count, id: \.self) { index in
+                                let item = self._dataSource[index]
+                                self.cardView(for: item)
+                                    .frame(maxWidth: 300)
+                                    .accessibility(sortPriority: Double(self._dataSource.count - index))
                             }
-                            .frame(width: 300, height: 192)
-                            .background(Color.white)
                         }
                         .clipShape(RoundedRectangle(cornerRadius: 16))
                         .shadow(color: .preferredColor(.cardShadow), radius: 16) //
                         .padding(EdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8))
                     }
-                })
-                .padding(EdgeInsets(top: 0, leading: 10, bottom: 0, trailing: 10))
+                }
+                Spacer()
+            } header: {
+                self.profileHeader
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.preferredColor(.secondaryGroupedBackground))
             }
-            Spacer()
-        } header: {
-            self.profileHeader
-                .frame(maxWidth: .infinity)
-                .padding()
-                .background(Color.preferredColor(.secondaryGroupedBackground))
+            .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
+            .listRowSeparator(.hidden)
         }
+        .listStyle(.grouped)
         .navigationTitle("Object Card - Full Width  Single Button")
         .navigationBarTitleDisplayMode(.inline)
     }
     
+    @ViewBuilder
+    func cardView(for item: CardFullWidthSingleButtonItem) -> some View {
+        Card {
+            Text("Schedule \(item.title)")
+        } subtitle: {
+            Text("Subtitle")
+        } detailImage: {
+            Image("ProfilePic")
+                .resizable()
+                .frame(width: 45, height: 45)
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+        } headerAction: {
+            FioriIcon.shopping.cart
+        } row1: {
+            Text("Body text could be really long description that requires wrapping, with suggested 2 lines from Fiori Design Guideline perspective to make the UI concise. SDK default setting of numberOfLines for body is 6. Application Developer can override it with : cell.body.numOfLines = preferredNumberOfLines.")
+                .lineLimit(2)
+        } action: {
+            FioriButton(action: { _ in
+                self.updateDataSource(id: item.id)
+            }, label: { _ in
+                Text(self.titleStr(item.loadingState))
+                    .multilineTextAlignment(.center)
+            })
+            .fioriButtonStyle(FioriPrimaryButtonStyle(.infinity, loadingState: item.loadingState))
+            .disabled(item.loadingState != .unspecified)
+        }
+        .frame(width: 300)
+        .fixedSize(horizontal: false, vertical: true)
+        .background(Color.white)
+    }
+
     func updateDataSource(id: UUID) {
         for i in 0 ..< self._dataSource.count {
             let item = self._dataSource[i]

--- a/Sources/FioriSwiftUICore/_FioriStyles/CardFooterStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/CardFooterStyle.fiori.swift
@@ -91,14 +91,14 @@ private struct CardFooterLayout: Layout {
         cache.clear()
         
         let subViewSizes = subviews.reversed().map {
-            $0.sizeThatFits(.unspecified)
+            $0.sizeThatFits(proposal)
         }
         
         self.calculateLayout(proposalWidth: proposal.width, subViewSizes: subViewSizes, layoutMode: layoutMode, cache: &cache)
     }
 
     /**
-     case 1: totol is 5 buttons, 3 buttons (tertiary, secondary, primary), overflow menu with 2 buttons, overflow menu with 1 button
+     case 1: total is 5 buttons, 3 buttons (tertiary, secondary, primary), overflow menu with 2 buttons, overflow menu with 1 button
      case 2: total is 3 buttons, 2 buttons (only two of tertiary, secondary and primary exist), overflow menu with 1 button
      case 3: total is 1 button, 1 button, only one of tertiary, secondary or primary exist
      
@@ -196,8 +196,6 @@ private struct CardFooterLayout: Layout {
         /// set up frames for each subview
         
         let y = maxHeight / 2
-        // Move the hidden buttons out of visible area
-        let hideRect = CGRect(x: finalWidth + 0.3, y: y, width: 0.3, height: 0.3)
         var frames = [CGRect]()
         
         var x: CGFloat = 0
@@ -207,11 +205,15 @@ private struct CardFooterLayout: Layout {
                 x += btWidth + (i > 0 ? theSpacing : 0)
                 frames.append(CGRect(origin: CGPoint(x: finalWidth - x + btWidth / 2, y: y), size: CGSize(width: btWidth, height: maxHeight)))
             } else if i < numButtons { // rest button to hide
+                // Move the hidden buttons out of visible area
+                let hideRect = CGRect(x: finalWidth + subViewNoOflSizes[i].width / 2 + 1, y: y, width: 1, height: 1)
                 frames.append(hideRect)
             } else { // overflow
                 if numToHide > 0, i == numButtons + numToHide - 1 { // last one to show overflow
                     frames.append(CGRect(x: overflowSize.width / 2, y: y, width: min(self.maxButtonWidth, overflowSize.width), height: overflowSize.height))
                 } else { // hide the other overflow
+                    // Move the hidden buttons out of visible area
+                    let hideRect = CGRect(x: finalWidth + overflowSize.width / 2 + 1, y: y, width: 1, height: 1)
                     frames.append(hideRect)
                 }
             }
@@ -297,7 +299,7 @@ public struct CardFooterBaseStyle: CardFooterStyle {
     }
     
     /**
-        case 1: totol is 5 buttons, 3 buttons (tertiary, secondary, primary), overflow menu with 2 buttons, overflow menu with 1 button
+        case 1: total is 5 buttons, 3 buttons (tertiary, secondary, primary), overflow menu with 2 buttons, overflow menu with 1 button
         case 2: total is 3 buttons, 2 buttons (only two of tertiary, secondary and primary exist), overflow menu with 1 button
         case 3: total is 1 button, 1 button, only one of tertiary, secondary or primary exist
      */

--- a/Sources/FioriSwiftUICore/_FioriStyles/ProfileHeaderStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/ProfileHeaderStyle.fiori.swift
@@ -116,6 +116,7 @@ public struct ProfileHeaderBaseStyle: ProfileHeaderStyle {
                         }
                 }
             })
+            .frame(maxWidth: .infinity)
         }
     }
     
@@ -155,6 +156,7 @@ public struct ProfileHeaderBaseStyle: ProfileHeaderStyle {
             self.detailImage(configuration)
             VStack(alignment: .leading, spacing: 8 * oppositeValue) {
                 configuration.title
+                    .fixedSize(horizontal: false, vertical: true)
                     .sizeReader(size: { size in
                         if size.different(with: self.titleSize) {
                             self.titleSize = size
@@ -162,22 +164,29 @@ public struct ProfileHeaderBaseStyle: ProfileHeaderStyle {
                     })
                 ZStack {
                     self.subtitle(configuration)
+                        .fixedSize(horizontal: false, vertical: true)
                         .opacity(oppositeValue)
                         .padding(.top, self.subtitlePadding(configuration))
                 }
                 .clipped()
                 .padding(.top, -8 * validTransitionValue)
             }
+            .frame(maxWidth: .infinity)
+
             Spacer()
             if !configuration.description.isEmpty, validTransitionValue < 1 {
                 configuration.description
+                    .fixedSize(horizontal: false, vertical: true)
                     .opacity(oppositeValue)
+                    .frame(maxWidth: .infinity)
                 Spacer()
             }
             if !configuration.detailContent.isEmpty {
                 configuration.detailContent
+                    .frame(maxWidth: .infinity)
             }
         }
+        .padding(.horizontal)
     }
 
     private func titlePadding(_ configuration: ProfileHeaderConfiguration) -> CGFloat {


### PR DESCRIPTION
Cherrypick from main

Before:
<img width="643" height="1318" alt="Screenshot 2026-01-08 at 5 24 37 PM" src="https://github.com/user-attachments/assets/11da198b-b7fe-4af1-b233-c4d19808e181" />

After:
<img width="643" height="1318" alt="Screenshot 2026-01-09 at 9 32 03 AM" src="https://github.com/user-attachments/assets/a05995a7-4d1c-47f8-a673-688096aff4b3" />
