### PR TITLE
fix: 🐛 [IOSSDKBUG-1613] re-layout sort filter view (25.11)

### DIFF
--- a/Sources/FioriSwiftUICore/Views/SortFilter/SortFilter+Environment.swift
+++ b/Sources/FioriSwiftUICore/Views/SortFilter/SortFilter+Environment.swift
@@ -26,9 +26,18 @@ struct SortFilterBarItemFrameKey: EnvironmentKey {
     static let defaultValue: CGRect = .zero
 }
 
+struct SortFilterContentHeightKey: EnvironmentKey {
+    static let defaultValue: Binding<CGFloat> = .constant(0)
+}
+
 extension EnvironmentValues {
     var sortFilterBarItemFrame: CGRect {
         get { self[SortFilterBarItemFrameKey.self] }
         set { self[SortFilterBarItemFrameKey.self] = newValue }
+    }
+    
+    var sortFilterContentHeight: Binding<CGFloat> {
+        get { self[SortFilterContentHeightKey.self] }
+        set { self[SortFilterContentHeightKey.self] = newValue }
     }
 }

--- a/Sources/FioriSwiftUICore/_FioriStyles/SortFilterViewStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/SortFilterViewStyle.fiori.swift
@@ -14,56 +14,41 @@ import SwiftUI
 // Base Layout style
 public struct SortFilterViewBaseStyle: SortFilterViewStyle {
     @StateObject var context: SortFilterContext = .init()
-    @State var size: CGSize = .zero
     @Environment(\.dismiss) var dismiss
     @Environment(\.sortFilterBarItemFrame) var sortFilterBarItemFrame
 
     public func makeBody(_ configuration: SortFilterViewConfiguration) -> some View {
         // Add default layout here
-        CancellableResettableDialogNavigationForm {
+        CancellableResettableDialogNavigationForm(calculateScrollView: true, title: {
             configuration.title
-        } cancelAction: {
+        }, cancelAction: {
             configuration.cancelAction
                 .onSimultaneousTapGesture {
                     self.context.handleCancel?()
                     configuration.onCancel?()
                     self.dismiss()
                 }
-        } resetAction: {
+        }, resetAction: {
             configuration.resetAction
                 .onSimultaneousTapGesture {
                     self.context.handleReset?()
                     configuration.onReset?()
                 }
                 .environment(\.isEnabled, self.context.isResetButtonEnabled)
-        } applyAction: {
+        }, applyAction: {
             configuration.applyAction
                 .onSimultaneousTapGesture {
                     self.context.handleApply?()
                     configuration.onUpdate?()
                     self.dismiss()
                 }
-        } components: {
+        }, components: {
             SortFilterCFGItemContainer(items: configuration.$items, btnFrame: self.sortFilterBarItemFrame)
-                .sizeReader(size: { s in
-                    if self.size != s {
-                        self.size = s
-                    }
-                })
                 .environmentObject(self.context)
-        }
-        #if !os(visionOS)
-        .frame(minWidth: UIDevice.current.userInterfaceIdiom != .phone ? 393.0 : nil)
-        #else
-        .frame(minWidth: 480.0)
+        })
+        #if os(visionOS)
         .background(Color.clear)
         #endif
-        .frame(height: UIDevice.current.userInterfaceIdiom != .phone ? self.size.height + self.additionHeight() : nil)
-        .presentationDetents([.large])
-    }
-    
-    func additionHeight() -> CGFloat {
-        self.context.isPickerListShown ? (self.context.isSearchBarHidden ? 68 : (self.context.isKeyboardShown ? 100 : 120)) : 120
     }
 }
 


### PR DESCRIPTION
Ref: #1474 
Using relative layout instead of fixed size.

|full window|custom compact size|
|-|-|
|<img width="2752" height="2064" alt="Simulator Screenshot - iPad Pro 13-inch (M5) - 2026-01-07 at 16 58 22" src="https://github.com/user-attachments/assets/5faacd6d-8c72-47c1-a78b-3d84df21779a" />|<img width="2752" height="2064" alt="Simulator Screenshot - iPad Pro 13-inch (M5) - 2026-01-07 at 16 58 49" src="https://github.com/user-attachments/assets/a458d64a-0c32-45cf-b7f3-16fe270589e8" />|
