### PR TITLE
fix: 🐛[IOSSDKBUG-1126] [acc] Remove the fixed width and height from the Activity button

### DIFF
--- a/Sources/FioriSwiftUICore/Experimental/ActivityItems/ActivityButton+View.swift
+++ b/Sources/FioriSwiftUICore/Experimental/ActivityItems/ActivityButton+View.swift
@@ -20,7 +20,7 @@ public struct ActivityButtonView: View {
                 .font(.fiori(forTextStyle: .body).weight(.light))
                 .imageScale(.large)
                 .foregroundColor(.preferredColor(.tintColor))
-                .frame(width: 44, height: 44, alignment: .center)
+                .frame(idealWidth: 44, idealHeight: 44, alignment: .center)
         }
         .buttonStyle(BorderlessButtonStyle())
     }


### PR DESCRIPTION
Replace width and height with idealWidth and idealHeight.
<img width="1640" height="2360" alt="Simulator Screenshot - iPad (A16) - 2026-01-19 at 14 30 37" src="https://github.com/user-attachments/assets/97ffcbbf-5661-4379-883f-a5e0c455862e" />
