### PR TITLE
fix: 🐛 keep the original picker item order(IOSSDKBUG-1647)

### DIFF
--- a/Sources/FioriSwiftUICore/_FioriStyles/ListPickerDestinationStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/ListPickerDestinationStyle.fiori.swift
@@ -889,19 +889,7 @@ struct ListPickerDestinationContent<Data: RandomAccessCollection, ID: Hashable, 
     }
         
     @ViewBuilder func generateSection(by serialData: [Data.Element]) -> some View {
-        // Only reorder for single selection mode to show selected item first
-        // For multiple selection mode, the order of items should not be changed based on current design
-        let reorderedData: [Data.Element] = {
-            if self.isSingleSelection, let selectedIndex = serialData.firstIndex(where: { self.isItemSelected($0[keyPath: self.id]) }) {
-                var reordered = serialData
-                let selectedItem = reordered.remove(at: selectedIndex)
-                reordered.insert(selectedItem, at: 0)
-                return reordered
-            }
-            return serialData
-        }()
-        
-        ForEach(reorderedData, id: self.id) { element in
+        ForEach(serialData, id: self.id) { element in
             Group {
                 let id_value = element[keyPath: id]
                 if let children, let childrenData = element[keyPath: children] {


### PR DESCRIPTION
Reverted the change in https://github.com/SAP/cloud-sdk-ios-fiori/pull/1470 , due to IOSSDKBUG-1647 .
Will do the new feature request "moving selected item to the top" in another PR which needs to keep the original behavior.