### PR TITLE
fix: 🐛 CancellableResettableForm not compile on visionOS 1.0

### DIFF
--- a/Sources/FioriSwiftUICore/Components/CancellableResettableForm.swift
+++ b/Sources/FioriSwiftUICore/Components/CancellableResettableForm.swift
@@ -53,7 +53,7 @@ struct CancellableResettableDialogNavigationForm<Title: View, CancelAction: View
                         .listRowBackground(Color.clear)
                     #endif
                         .ifApply(self.calculateScrollView) {
-                            if #available(iOS 18, *) {
+                            if #available(iOS 18, visionOS 2, *) {
                                 return $0.onScrollGeometryChange(for: [Double].self) { geo in
                                     [geo.contentSize.height,
                                      geo.contentInsets.top]


### PR DESCRIPTION
Reported by Seraj, for a failed job when building xcframework binary on rel-25.11

 /Users/admin/hyperspace-mobile-oslo/_work/1/s/cloud-sdk-ios-fiori/Sources/FioriSwiftUICore/Components/CancellableResettableForm.swift:57:43: error: 'onScrollGeometryChange(for:of:action:)' is only available in visionOS 2.0 or newer
[14:45:54]: ▸ return $0.onScrollGeometryChange(for: [Double].self) { geo in
