### PR TITLE
fix: 🐛 [1237] liquid glass style support for EULA bottom bar

### DIFF
--- a/Sources/FioriSwiftUICore/_FioriStyles/EULAViewStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/EULAViewStyle.fiori.swift
@@ -5,19 +5,60 @@ import SwiftUI
 // Base Layout style
 public struct EULAViewBaseStyle: EULAViewStyle {
     public func makeBody(_ configuration: EULAViewConfiguration) -> some View {
+        Group {
+            if #available(iOS 26, *) {
+                containerView(configuration)
+            } else {
+                self.legacyContainerView(configuration)
+            }
+        }
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                self.navBarLeadingView(configuration)
+                    .fixedSize()
+            }
+        }
+    }
+    
+    func containerView(_ configuration: EULAViewConfiguration) -> some View {
+        ScrollView(.vertical, showsIndicators: true) {
+            VStack {
+                configuration.title
+                    .padding(.vertical, 30)
+                configuration.bodyText
+            }
+            .padding(.horizontal, 32)
+        }
+        .toolbar {
+            ToolbarItemGroup(placement: .bottomBar) {
+                configuration.disagreeAction
+                    .fixedSize()
+                    .onSimultaneousTapGesture {
+                        configuration.didDisagree?()
+                    }
+                Spacer()
+                configuration.agreeAction
+                    .fixedSize()
+                    .onSimultaneousTapGesture {
+                        configuration.didAgree?()
+                    }
+            }
+        }
+    }
+    
+    func legacyContainerView(_ configuration: EULAViewConfiguration) -> some View {
         VStack {
             ScrollView(.vertical, showsIndicators: true) {
                 VStack {
                     configuration.title
-                        .padding(.top, 30)
-                        .padding(.bottom, 30)
-                    
+                        .padding(.vertical, 30)
                     configuration.bodyText
                 }
             }
             .padding(.top, 2)
-            .padding(.leading, 32)
-            .padding(.trailing, 32)
+            .padding(.horizontal, 32)
                         
             HStack {
                 configuration.disagreeAction
@@ -33,14 +74,6 @@ public struct EULAViewBaseStyle: EULAViewStyle {
                     }
             }
             .padding()
-        }
-        .navigationBarTitleDisplayMode(.inline)
-        .navigationBarBackButtonHidden(true)
-        .toolbar {
-            ToolbarItem(placement: .topBarLeading) {
-                self.navBarLeadingView(configuration)
-                    .fixedSize()
-            }
         }
     }
     


### PR DESCRIPTION
|before|after|
|-|-|
|<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-01-29 at 15 33 54" src="https://github.com/user-attachments/assets/bd48a730-738f-4f5e-b2ff-d4f28c0dddc6" />|<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-01-29 at 15 36 36" src="https://github.com/user-attachments/assets/638b31a0-c144-4f4a-aca8-6b707ca9891a" />|
|<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-01-29 at 15 33 59" src="https://github.com/user-attachments/assets/5861a5aa-f236-4864-8e1f-8acf21b65cfc" />|<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-01-29 at 15 36 41" src="https://github.com/user-attachments/assets/916d8589-3f92-45b6-ba1a-1117c49b2f5a" />|

