### PR TITLE
fix: card footer layout issue [IOSSDKBUG-1674]

### DIFF
--- a/Sources/FioriSwiftUICore/_FioriStyles/CardFooterStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/CardFooterStyle.fiori.swift
@@ -91,7 +91,7 @@ private struct CardFooterLayout: Layout {
         cache.clear()
         
         let subViewSizes = subviews.reversed().map {
-            $0.sizeThatFits(proposal)
+            $0.sizeThatFits(.unspecified)
         }
         
         self.calculateLayout(proposalWidth: proposal.width, subViewSizes: subViewSizes, layoutMode: layoutMode, cache: &cache)


### PR DESCRIPTION
Before:
<img width="452" height="934" alt="Screenshot 2026-01-29 at 6 36 40 PM" src="https://github.com/user-attachments/assets/726fbe53-349d-47e9-8661-a9f9888d44b8" />

After:
<img width="447" height="914" alt="Screenshot 2026-01-29 at 6 38 34 PM" src="https://github.com/user-attachments/assets/72ded1e4-196e-44e3-ba21-42cabc560f46" />
