### PR TITLE
fix: 🐛 [1673] profile header transparent and touch area issue

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/ProfileHeader/ProfileHeaderAnimatableExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/ProfileHeader/ProfileHeaderAnimatableExample.swift
@@ -15,13 +15,16 @@ struct ProfileHeaderAnimatableExample: View {
             HStack(spacing: 30) {
                 Button(action: {}, label: {
                     Image(systemName: "mail")
+                        .frame(minWidth: 44, minHeight: 44)
                 })
                 Button(action: {}, label: {
                     Image(systemName: "message")
+                        .frame(minWidth: 44, minHeight: 44)
                 })
                 
                 Button(action: {}, label: {
                     Image(systemName: "phone")
+                        .frame(minWidth: 44, minHeight: 44)
                 })
             }
         }
@@ -29,24 +32,30 @@ struct ProfileHeaderAnimatableExample: View {
     }
     
     var body: some View {
-        ScrollView {
-            LazyVStack(alignment: .center, pinnedViews: [.sectionHeaders], content: {
-                Section {
-                    ForEach(0 ..< 30) { item in
-                        Text("List Item \(item)")
-                            .frame(maxWidth: .infinity)
-                            .padding()
-                            .background(.gray)
-                            .cornerRadius(10)
-                    }
-                } header: {
-                    self.profileHeader
-                        .frame(maxWidth: .infinity)
-                        .padding()
-                        .background(Color.preferredColor(.secondaryGroupedBackground))
-                }
-            })
+        if #available(iOS 26, *) {
+            list.scrollEdgeEffectStyle(.hard, for: .top)
+        } else {
+            self.list
         }
+    }
+    
+    var list: some View {
+        List {
+            Section {
+                ForEach(0 ..< 30) { item in
+                    Text("List Item \(item)")
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding()
+                        .cornerRadius(10)
+                }
+            } header: {
+                self.profileHeader
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.preferredColor(.primaryBackground))
+            }
+        }
+        .listStyle(.plain)
         .navigationTitle("Animatable Header")
     }
 }

--- a/Apps/Examples/Examples/FioriSwiftUICore/ProfileHeader/ProfileHeaderStaticExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/ProfileHeader/ProfileHeaderStaticExample.swift
@@ -13,13 +13,16 @@ struct ProfileHeaderStaticExample: View {
             HStack(spacing: 30) {
                 Button(action: {}, label: {
                     Image(systemName: "mail")
+                        .frame(minWidth: 44, minHeight: 44)
                 })
                 Button(action: {}, label: {
                     Image(systemName: "message")
+                        .frame(minWidth: 44, minHeight: 44)
                 })
                 
                 Button(action: {}, label: {
                     Image(systemName: "phone")
+                        .frame(minWidth: 44, minHeight: 44)
                 })
             }
         }
@@ -53,24 +56,30 @@ struct ProfileHeaderStaticExample: View {
     }
     
     var body: some View {
-        ScrollView {
-            LazyVStack(alignment: .center, pinnedViews: [.sectionHeaders], content: {
-                Section {
-                    ForEach(0 ..< 30) { item in
-                        Text("List Item \(item)")
-                            .frame(maxWidth: .infinity)
-                            .padding()
-                            .background(.gray)
-                            .cornerRadius(10)
-                    }
-                } header: {
-                    self.profileHeader
-                        .frame(maxWidth: .infinity)
-                        .padding()
-                        .background(Color.preferredColor(.secondaryGroupedBackground))
-                }
-            })
+        if #available(iOS 26, *) {
+            list.scrollEdgeEffectStyle(.hard, for: .top)
+        } else {
+            self.list
         }
+    }
+    
+    var list: some View {
+        List {
+            Section {
+                ForEach(0 ..< 30) { item in
+                    Text("List Item \(item)")
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding()
+                        .cornerRadius(10)
+                }
+            } header: {
+                self.profileHeader
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.preferredColor(.primaryBackground))
+            }
+        }
+        .listStyle(.plain)
         .navigationTitle("Static Header")
     }
 }


### PR DESCRIPTION
# Fix Profile Header Transparency and Touch Area Issues

### 🐛 Bug Fix

Resolved transparency and touch area issues in the ProfileHeader component by migrating from ScrollView to List and enforcing minimum touch targets.

### Changes

* **`ProfileHeaderAnimatableExample.swift`**: 
  - Added minimum touch area constraints (44x44 pt) to all action buttons in the profile header to meet accessibility guidelines
  - Migrated from `ScrollView` with `LazyVStack` to `List` with proper section headers to fix transparency issues
  - Added explicit background color (`.primaryBackground`) to header section to prevent transparency
  - Implemented iOS 26+ `.scrollEdgeEffectStyle(.hard, for: .top)` modifier for improved scroll behavior
  - Updated list item alignment and removed redundant background styling

* **`ProfileHeaderStaticExample.swift`**: 
  - Applied identical fixes as the animatable example to maintain consistency
  - Added minimum touch area constraints (44x44 pt) to all action buttons
  - Migrated from `ScrollView` with `LazyVStack` to `List` with section headers
  - Added explicit background color to header section
  - Implemented iOS 26+ scroll edge effect styling
  - Applied `.listStyle(.plain)` for consistent appearance

- [ ] 🔄 Regenerate and Update Summary

