### PR TITLE
fix: 🐛 [1703] placeholder missed when form view is focused (rel-26.1)

### DIFF
--- a/Sources/FioriSwiftUICore/_FioriStyles/PlaceholderTextEditorStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/PlaceholderTextEditorStyle.fiori.swift
@@ -21,7 +21,7 @@ public struct PlaceholderTextEditorBaseStyle: PlaceholderTextEditorStyle {
                         self.isKeyboardShown = true
                     }
                 }
-            if configuration.text.isEmpty, !self.isFocused, !configuration.placeholder.isEmpty {
+            if configuration.text.isEmpty, !configuration.placeholder.isEmpty {
                 configuration.placeholder.body
                     .zIndex(1)
                     .onTapGesture {
@@ -59,7 +59,7 @@ extension PlaceholderTextEditorFioriStyle {
         func makeBody(_ configuration: PlaceholderConfiguration) -> some View {
             Placeholder(configuration)
                 .padding(.top, 8)
-                .padding(.leading, 8)
+                .padding(.horizontal, 13)
         }
     }
 }


### PR DESCRIPTION
Ref: #1522
New Style:
<img width="50%" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-02-05 at 17 20 57" src="https://github.com/user-attachments/assets/4b73bcb6-778f-41b1-9b69-fabaef1b59fe" />
