### PR TITLE
fix: 🐛 FioriButton does not work with .accessibilityIdentifier

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/FioriButton/FioriButtonExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/FioriButton/FioriButtonExample.swift
@@ -80,6 +80,8 @@ struct FioriButtonExample: View {
                         }
                     })
                     .disabled(!self._isEnabled)
+                    // check FioriButton should allow App to set accessibilityIdentifier for UITest
+                    .accessibilityIdentifier("button_id")
     }
 }
 

--- a/Sources/FioriSwiftUICore/Utils/SkeletonLoading.swift
+++ b/Sources/FioriSwiftUICore/Utils/SkeletonLoading.swift
@@ -154,21 +154,25 @@ struct ShimmerViewModifier: ViewModifier {
         if #available(watchOS 10.0, *) {
             shimmerContent(content: content)
                 .focusEffectDisabled(self.isLoading)
-                .accessibilityElement(children: self.isLoading ? .ignore : .contain)
+                .ifApply(self.isLoading) {
+                    $0.accessibilityElement(children: .ignore)
+                        .accessibilityLabel(self.loadingAccLabel)
+                        .accessibilityValue("")
+                        .accessibilityHint("")
+                        .accessibilityAddTraits(.isStaticText)
+                }
                 .allowsHitTesting(!self.isLoading)
-                .accessibilityLabel(self.isLoading ? self.loadingAccLabel : "")
-                .accessibilityValue(self.isLoading ? "" : "")
-                .accessibilityHint(self.isLoading ? "" : "")
-                .accessibilityAddTraits(self.isLoading ? .isStaticText : [])
                 .disabled(self.isLoading)
         } else {
             self.shimmerContent(content: content)
-                .accessibilityElement(children: self.isLoading ? .ignore : .contain)
+                .ifApply(self.isLoading) {
+                    $0.accessibilityElement(children: .ignore)
+                        .accessibilityLabel(self.loadingAccLabel)
+                        .accessibilityValue("")
+                        .accessibilityHint("")
+                        .accessibilityAddTraits(.isStaticText)
+                }
                 .allowsHitTesting(!self.isLoading)
-                .accessibilityLabel(self.isLoading ? self.loadingAccLabel : "")
-                .accessibilityValue(self.isLoading ? "" : "")
-                .accessibilityHint(self.isLoading ? "" : "")
-                .accessibilityAddTraits(self.isLoading ? .isStaticText : [])
                 .disabled(self.isLoading)
         }
     }


### PR DESCRIPTION
Without the fix,  the accessibilityIdentifier set by Application code will not be effective in FioriButton. This caused UITest failure for Applications, since UITest relies on the accessibilityIdentifier to locate the element to navigate the tests.

After the fix, the "button_id" is visible ,  by "Accessibility Inspector". Otherwise, this field is empty even if it is set to "button_id".

<img width="1124" height="1012" alt="Screenshot 2026-02-19 at 3 35 39 PM" src="https://github.com/user-attachments/assets/5abc5e4c-9ab6-4f91-bb34-d41ba8e87624" />
