### PR TITLE
fix: 🐛 [JIRA:0] Add default padding to ActivityItems

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/ActivityItem/ActivityItemsExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/ActivityItem/ActivityItemsExample.swift
@@ -99,6 +99,7 @@ struct ActivityItemsExample: View {
                             .frame(width: 44, height: 44)
                     }
                     .buttonStyle(BorderlessButtonStyle())
+                    .padding(.horizontal, 12)
                     
                     Button {
                         print("click heart")
@@ -110,6 +111,7 @@ struct ActivityItemsExample: View {
                             .frame(width: 44, height: 44)
                     }
                     .buttonStyle(BorderlessButtonStyle())
+                    .padding(.horizontal, 12)
                     
                     Button {
                         print("click info.circle")
@@ -121,6 +123,7 @@ struct ActivityItemsExample: View {
                             .frame(width: 44, height: 44)
                     }
                     .buttonStyle(BorderlessButtonStyle())
+                    .padding(.horizontal, 12)
                     
                     Button {
                         print("click book")
@@ -132,6 +135,7 @@ struct ActivityItemsExample: View {
                             .frame(width: 44, height: 44)
                     }
                     .buttonStyle(BorderlessButtonStyle())
+                    .padding(.horizontal, 12)
                 }
             } header: {
                 Text("Custom items")

--- a/Sources/FioriSwiftUICore/Views/ActivityItems/ActivityItemsBuilder.swift
+++ b/Sources/FioriSwiftUICore/Views/ActivityItems/ActivityItemsBuilder.swift
@@ -19,6 +19,7 @@ struct ActivityItemsListStack: ActivityItemsList {
                 element.icon
                     .imageScale(.large)
                     .frame(idealWidth: 44, idealHeight: 44, alignment: .center)
+                    .padding(.horizontal, 8)
             }
             .buttonStyle(BorderlessButtonStyle())
             .accessibilityElement(children: .combine)


### PR DESCRIPTION
1. Add default padding(8) to ActivityItems
2. Update the custom ActivityItems example to prevent icon overlap

Before:
<img width="1640" height="2360" alt="Simulator Screenshot - iPad (A16) - 2026-02-26 at 15 14 26" src="https://github.com/user-attachments/assets/624a7417-1c6d-4045-b9ad-5b39aaaf001e" />

After:
<img width="1640" height="2360" alt="Simulator Screenshot - iPad (A16) - 2026-02-26 at 15 11 27" src="https://github.com/user-attachments/assets/8ed721c9-8dd6-4b19-9b04-33420b0347c6" />
