### PR TITLE
fix: 🐛 [IOSSDKBUG-1741] sync show panel state on appear

### DIFF
--- a/Sources/FioriSwiftUICore/AIWritingAssistant/WATextInput.swift
+++ b/Sources/FioriSwiftUICore/AIWritingAssistant/WATextInput.swift
@@ -196,6 +196,12 @@ struct WATextInputModifier: ViewModifier {
                     }
                 #endif
             }
+            .onAppear {
+                if self.waShowPanel.wrappedValue {
+                    self.context.updateInWAFlow(true)
+                    self.startWAPanel()
+                }
+            }
             .onDisappear {
                 self.context.showCancelAlert = false
                 self.context.isPresented = false


### PR DESCRIPTION
# Sync Panel Presentation State on Appear

### Bug Fix

🐛 Fixed a synchronization issue where the AI Writing Assistant panel's `isPresented` context state was not initialized correctly when the view appeared. This caused a mismatch between the actual panel visibility and the internal `context.isPresented` state.

### Changes

* `WATextInput.swift`: Added an `.onAppear` modifier to synchronize `context.isPresented` with the current value of `waShowPanel.wrappedValue` when the view first appears, ensuring the panel state is consistent from the start.

### Jira Issues

* IOSSDKBUG-1741: Sync show panel with isPresented

- [ ] 🔄 Regenerate and Update Summary


---
📬 [Subscribe to the Hyperspace PR Bot DL](https://url.sap/451kgs) to get the latest announcements and pilot features!


<details>
<summary>PR Bot Information</summary>

**Version:** `1.18` | 📖 [Documentation](https://url.sap/dy9ocn) | 🚨 [Create Incident](https://url.sap/budnv9) | 💬 [Feedback](https://url.sap/my4dn3)

- Correlation ID: `6441f0a0-1dc2-11f1-8e4f-f72b1eb4c69f`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- LLM: `anthropic--claude-4.6-sonnet`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Event Trigger: `pull_request.opened`
</details>
