### PR TITLE
fix: 🐛 [IOSSDKBUG-1755] customization support for feedback (rel-26.1)

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/AIUserFeedback/AIUserFeedbackExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/AIUserFeedback/AIUserFeedbackExample.swift
@@ -28,6 +28,7 @@ struct AIUserFeedbackExample: View {
     @State var displayContentError = false
     @State var customizedErrorView = false
     @State var isSubmitResultSuccess = true
+    @State var customizedFeedbackTitles = false
     
     var body: some View {
         List {
@@ -78,6 +79,7 @@ struct AIUserFeedbackExample: View {
             Toggle("Customized Error View", isOn: self.$customizedErrorView)
             Toggle("Mock Submit Result(On: Success, Off: Fail)", isOn: self.$isSubmitResultSuccess)
             Toggle("Disable Multiple Vote", isOn: self.$disableMultipleVote)
+            Toggle("Custom feedback title", isOn: self.$customizedFeedbackTitles)
 
             Picker("Vote State(Not work for push)", selection: self.$voteStateIndex) {
                 ForEach(0 ..< self.voteStates.count, id: \.self) { index in
@@ -161,6 +163,34 @@ struct AIUserFeedbackExample: View {
                                   }
                               }, voteState: self.$voteState,
                               submitButtonState: self.$submitButtonState)
+            .illustratedMessageTitleStyle {
+                if self.customizedFeedbackTitles {
+                    Text("This is a customized illustrated message title")
+                } else {
+                    $0.title
+                }
+            }
+            .illustratedMessageDescriptionStyle {
+                if self.customizedFeedbackTitles {
+                    Text("This is a customized illustrated message description")
+                } else {
+                    $0.description
+                }
+            }
+            .filterFormViewTitleStyle {
+                if self.customizedFeedbackTitles {
+                    Text("This is a customized filter form view title")
+                } else {
+                    $0.title
+                }
+            }
+            .keyValueFormViewTitleStyle {
+                if self.customizedFeedbackTitles {
+                    Text("This is a customized key value form view title")
+                } else {
+                    $0.title
+                }
+            }
     }
     
     @ViewBuilder

--- a/Apps/Examples/Examples/FioriSwiftUICore/WritingAssistant/WritingAssistantExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/WritingAssistant/WritingAssistantExample.swift
@@ -34,7 +34,9 @@ struct WritingAssistantExample: View {
     @State var showWAAuthAlert = false
     @State var waAllowed = false
     @State var showWAPanel = false
+    @State var customizeFeedbackTitles = false
     @State private var alertCompletion: ((Bool) -> Void)? = nil
+    @State private var filterFormViewButtonSize: FilterButtonSize = .fixed
 
     @FocusState var isFocused: Bool
     
@@ -91,7 +93,13 @@ struct WritingAssistantExample: View {
                 .onChange(of: self.showWAPanel) { _, _ in
                     self.isFocused = false
                 }
-            
+            Toggle("Customize feedback view titles", isOn: self.$customizeFeedbackTitles)
+            Picker("Buttons size of filter form view in feedback", selection: self.$filterFormViewButtonSize) {
+                Text("Fixed").tag(FilterButtonSize.fixed)
+                Text("Flexible").tag(FilterButtonSize.flexible)
+                Text("Flexible by max chip").tag(FilterButtonSize.flexibleByMaxChip)
+            }
+
             NoteFormView(text: self.$text, placeholder: "NoteFormView1", errorMessage: "", hintText: AttributedString("Hint Text"), isCharCountEnabled: true, allowsBeyondLimit: false)
                 .environment(\.isLoading, self.isLoading)
                 .environment(\.isAILoading, self.isLoading)
@@ -135,6 +143,29 @@ struct WritingAssistantExample: View {
             
             Spacer()
         }
+        .illustratedMessageTitleStyle {
+            if self.customizeFeedbackTitles {
+                Text("This is a customized title for illustrated message in feedback")
+            } else {
+                $0.title
+            }
+        }
+        .illustratedMessageDescriptionStyle {
+            if self.customizeFeedbackTitles {
+                Text("This is a customized description for illustrated message in feedback")
+            } else {
+                $0.description
+            }
+        }
+        .filterFormViewTitleStyle {
+            if self.customizeFeedbackTitles {
+                Text("This is a customized title for filter form view in feedback.")
+            } else {
+                $0.title
+            }
+        }
+        .waFeedbackNavigationTitle(self.customizeFeedbackTitles ? "Customized Title" : "Feedback")
+        .filterFormViewButtonSize(self.filterFormViewButtonSize)
         .padding()
         .alert("W.A. Authorization", isPresented: self.$showWAAuthAlert) {
             Button("No", role: .destructive) {

--- a/Sources/FioriSwiftUICore/AIWritingAssistant/WAFeedback.swift
+++ b/Sources/FioriSwiftUICore/AIWritingAssistant/WAFeedback.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct WAFeedback: View {
     @State var feedbackSelection: [Int] = []
     @EnvironmentObject var context: WritingAssistantContext
+    @Environment(\.waFeedbackNavigationBarTitle) private var navigationBarTitle
     @Environment(\.dismiss) private var dismiss
     @State var showError = false
     @State var voteState: AIUserFeedbackVoteState = .downVote
@@ -12,9 +13,9 @@ struct WAFeedback: View {
     }
 
     var body: some View {
-        AIUserFeedback(title: { Title(title: "What didn’t you like about this version?") },
-                       description: { Text("Please rate your experience to help us improve.") },
-                       navigationTitle: "Feedback",
+        AIUserFeedback(title: { Title(title: AttributedString("What didn’t you like about this version?".localizedFioriString())) },
+                       description: { Text(AttributedString("Please rate your experience to help us improve.".localizedFioriString())) },
+                       navigationTitle: self.navigationBarTitle,
                        filterFormView: self.filterFormView,
                        keyValueFormView: nil,
                        displayMode: .push,

--- a/Sources/FioriSwiftUICore/AIWritingAssistant/WAUtils.swift
+++ b/Sources/FioriSwiftUICore/AIWritingAssistant/WAUtils.swift
@@ -99,6 +99,10 @@ struct WAShowPanelKey: EnvironmentKey {
     static let defaultValue: Binding<Bool> = .constant(false)
 }
 
+struct WAFeedbackNavigationBarTitleKey: EnvironmentKey {
+    static var defaultValue: AttributedString = .init("Feedback".localizedFioriString())
+}
+
 extension EnvironmentValues {
     var waHelperAction: Binding<WAHelperAction> {
         get { self[WAHelperActionKey.self] }
@@ -118,6 +122,11 @@ extension EnvironmentValues {
     var waShowPanel: Binding<Bool> {
         get { self[WAShowPanelKey.self] }
         set { self[WAShowPanelKey.self] = newValue }
+    }
+    
+    var waFeedbackNavigationBarTitle: AttributedString {
+        get { self[WAFeedbackNavigationBarTitleKey.self] }
+        set { self[WAFeedbackNavigationBarTitleKey.self] = newValue }
     }
 }
 
@@ -148,5 +157,12 @@ public extension View {
     /// - Returns: A view with the writing assistant panel or not.
     func waShowPanel(_ show: Binding<Bool>) -> some View {
         self.environment(\.waShowPanel, show)
+    }
+    
+    /// Customize the title string for the navigation bar title in feedback view.
+    /// - Parameter title: String value for the navigation bar.
+    /// - Returns: New view with customized navigation bar title for feedback in writing assistant component.
+    func waFeedbackNavigationTitle(_ title: String) -> some View {
+        self.environment(\.waFeedbackNavigationBarTitle, AttributedString(title))
     }
 }

--- a/Sources/FioriSwiftUICore/_FioriStyles/AIUserFeedbackStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/AIUserFeedbackStyle.fiori.swift
@@ -2,6 +2,8 @@ import FioriThemeManager
 import Foundation
 import SwiftUI
 
+// swiftlint:disable file_length
+
 /// AIUserFeedback display mode
 public enum AIUserFeedbackDisplayMode {
     /// AIUserFeedback is pushed in from a navigation stack.
@@ -39,11 +41,14 @@ public enum AIUserFeedbackVoteState {
 public struct AIUserFeedbackBaseStyle: AIUserFeedbackStyle {
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
     @Environment(\.dismiss) private var dismiss
-    
     @State var shouldShowFeedbackDetail = false
     @State var submitRequestFailed = false
     @Environment(\.isSubmitRequestFailed) var isSubmitRequestFailed
     @Environment(\.disableMultipleVoteForAIUserFeedback) var disableMultipleVoteForAIUserFeedback
+    @Environment(\.filterFormViewTitleStyle) private var filterFormViewTitleStyle
+    @Environment(\.keyValueFormViewTitleStyle) private var keyValueFormViewTitleStyle
+    @Environment(\.illustratedMessageTitleStyle) private var illustratedMessageTitleStyle
+    @Environment(\.illustratedMessageDescriptionStyle) private var illustratedMessageDescriptionStyle
     @State var inlineFeedbackIsPresented: Bool = false
     
     /// Indicates if the submit button has been shown.
@@ -158,6 +163,7 @@ public struct AIUserFeedbackBaseStyle: AIUserFeedbackStyle {
             ScrollView {
                 if self.isShowFailedView() {
                     self.defaultErrorView(configuration)
+                        .frame(maxWidth: .infinity)
                         .padding(.top, 20)
                         .padding(.bottom, 16)
                         .fixedSize(horizontal: false, vertical: true)
@@ -175,7 +181,10 @@ public struct AIUserFeedbackBaseStyle: AIUserFeedbackStyle {
                     VStack {
                         VStack {
                             self.illustratedMessage(configuration)
-                            
+                                .titleStyle(self.illustratedMessageTitleStyle)
+                                .descriptionStyle(self.illustratedMessageDescriptionStyle)
+                                .typeErased
+                                .frame(maxWidth: .infinity)
                             if self.shouldShowFeedbackDetail {
                                 self.feedbackDetailView(configuration)
                             }
@@ -265,10 +274,14 @@ public struct AIUserFeedbackBaseStyle: AIUserFeedbackStyle {
     func feedbackDetailView(_ configuration: AIUserFeedbackConfiguration) -> some View {
         if configuration.filterFormView != nil {
             configuration.filterFormView
+                .titleStyle(self.filterFormViewTitleStyle)
+                .typeErased
                 .padding(.bottom, 15)
         }
         if configuration.keyValueFormView != nil {
             configuration.keyValueFormView
+                .titleStyle(self.keyValueFormViewTitleStyle)
+                .typeErased
         }
     }
     
@@ -575,5 +588,121 @@ public extension View {
     /// - Returns: A new view with multiple vote is disabled or not in `AIUserFeedback`.
     func disableMultipleVoteForAIUserFeedback(_ disabled: Bool) -> some View {
         self.environment(\.disableMultipleVoteForAIUserFeedback, disabled)
+    }
+}
+
+public extension View {
+    /// :nodoc:
+    func illustratedMessageTitleStyle(_ style: some TitleStyle) -> some View {
+        self.transformEnvironment(\.illustratedMessageTitleStyleStack) { stack in
+            stack.append(style)
+        }
+    }
+    
+    /// :nodoc:
+    func illustratedMessageTitleStyle(@ViewBuilder content: @escaping (TitleConfiguration) -> some View) -> some View {
+        self.transformEnvironment(\.illustratedMessageTitleStyleStack) { stack in
+            let style = AnyTitleStyle(content)
+            stack.append(style)
+        }
+    }
+    
+    /// :nodoc:
+    func illustratedMessageDescriptionStyle(_ style: some DescriptionStyle) -> some View {
+        self.transformEnvironment(\.illustratedMessageDescriptionStyleStack) { stack in
+            stack.append(style)
+        }
+    }
+    
+    /// :nodoc:
+    func illustratedMessageDescriptionStyle(@ViewBuilder content: @escaping (DescriptionConfiguration) -> some View) -> some View {
+        self.transformEnvironment(\.illustratedMessageDescriptionStyleStack) { stack in
+            let style = AnyDescriptionStyle(content)
+            stack.append(style)
+        }
+    }
+    
+    /// :nodoc:
+    func filterFormViewTitleStyle(_ style: some TitleStyle) -> some View {
+        self.transformEnvironment(\.filterFormViewTitleStyleStack) { stack in
+            stack.append(style)
+        }
+    }
+    
+    /// :nodoc:
+    func filterFormViewTitleStyle(@ViewBuilder content: @escaping (TitleConfiguration) -> some View) -> some View {
+        self.transformEnvironment(\.filterFormViewTitleStyleStack) { stack in
+            let style = AnyTitleStyle(content)
+            stack.append(style)
+        }
+    }
+    
+    /// :nodoc:
+    func keyValueFormViewTitleStyle(_ style: some TitleStyle) -> some View {
+        self.transformEnvironment(\.keyValueFormViewTitleStyleStack) { stack in
+            stack.append(style)
+        }
+    }
+    
+    /// :nodoc:
+    func keyValueFormViewTitleStyle(@ViewBuilder content: @escaping (TitleConfiguration) -> some View) -> some View {
+        self.transformEnvironment(\.keyValueFormViewTitleStyleStack) { stack in
+            let style = AnyTitleStyle(content)
+            stack.append(style)
+        }
+    }
+}
+
+struct IllustratedMessageTitleStyleStackKey: EnvironmentKey {
+    static let defaultValue: [any TitleStyle] = []
+}
+
+struct IllustratedMessageDescriptionStyleStackKey: EnvironmentKey {
+    static let defaultValue: [any DescriptionStyle] = []
+}
+
+struct FilterFormViewTitleStyleStackKey: EnvironmentKey {
+    static let defaultValue: [any TitleStyle] = []
+}
+
+struct KeyValueFormViewTitleStyleStackKey: EnvironmentKey {
+    static let defaultValue: [any TitleStyle] = []
+}
+
+extension EnvironmentValues {
+    var illustratedMessageTitleStyle: any TitleStyle {
+        self.illustratedMessageTitleStyleStack.last ?? .base
+    }
+
+    var illustratedMessageTitleStyleStack: [any TitleStyle] {
+        get { self[IllustratedMessageTitleStyleStackKey.self] }
+        set { self[IllustratedMessageTitleStyleStackKey.self] = newValue }
+    }
+    
+    var illustratedMessageDescriptionStyle: any DescriptionStyle {
+        self.illustratedMessageDescriptionStyleStack.last ?? .base
+    }
+
+    var illustratedMessageDescriptionStyleStack: [any DescriptionStyle] {
+        get { self[IllustratedMessageDescriptionStyleStackKey.self] }
+        set { self[IllustratedMessageDescriptionStyleStackKey.self] = newValue }
+    }
+    
+    var filterFormViewTitleStyle: any TitleStyle {
+        self.filterFormViewTitleStyleStack.last ?? .base
+    }
+
+    var filterFormViewTitleStyleStack: [any TitleStyle] {
+        get { self[FilterFormViewTitleStyleStackKey.self] }
+        set { self[FilterFormViewTitleStyleStackKey.self] = newValue }
+    }
+    
+    var keyValueFormViewTitleStyle: any TitleStyle {
+        self.keyValueFormViewTitleStyleStack.last ?? .base
+    }
+    
+    var keyValueFormViewTitleStyleStack: [any TitleStyle] {
+        get { self[KeyValueFormViewTitleStyleStackKey.self] }
+        set { self[KeyValueFormViewTitleStyleStackKey.self] = newValue }
     }
 }

--- a/Sources/FioriSwiftUICore/_FioriStyles/FilterFormViewStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/FilterFormViewStyle.fiori.swift
@@ -18,6 +18,7 @@ public struct FilterFormViewBaseStyle: FilterFormViewStyle {
     @Environment(\.filterFormOptionCornerRadius) var filterFormOptionCornerRadius
     @Environment(\.filterFormOptionPadding) var filterFormOptionPadding
     @Environment(\.filterFormOptionTitleSpacing) var filterFormOptionTitleSpacing
+    @Environment(\.filterFormViewButtonSize) var customizedButtonSize
     
     private var filterFormOptionDefaultAttributes: [FilterFormOptionState: [NSAttributedString.Key: Any]] = [
         .enabledUnselected: [
@@ -96,9 +97,17 @@ public struct FilterFormViewBaseStyle: FilterFormViewStyle {
             }
     }
     
+    func buttonSize(_ configuration: FilterFormViewConfiguration) -> FilterButtonSize {
+        if let customizedButtonSize {
+            customizedButtonSize
+        } else {
+            configuration.buttonSize
+        }
+    }
+    
     @ViewBuilder
     func FilterFormViewLayoutView(_ configuration: FilterFormViewConfiguration, dynamicTypeSize: DynamicTypeSize, horizontalSizeClass: UserInterfaceSizeClass?) -> some View {
-        FilterFormViewLayout(buttonSize: configuration.buttonSize, dynamicTypeSize: dynamicTypeSize, horizontalSizeClass: horizontalSizeClass, filterFormOptionsItemSpacing: self.filterFormOptionsItemSpacing, filterFormOptionsLineSpacing: self.filterFormOptionsLineSpacing) {
+        FilterFormViewLayout(buttonSize: self.buttonSize(configuration), dynamicTypeSize: dynamicTypeSize, horizontalSizeClass: horizontalSizeClass, filterFormOptionsItemSpacing: self.filterFormOptionsItemSpacing, filterFormOptionsLineSpacing: self.filterFormOptionsLineSpacing) {
             ForEach(configuration.options.indices, id: \.self) { index in
                 let isSelected = configuration.value.contains(index)
                 let option = configuration.options[index]
@@ -246,11 +255,14 @@ extension FilterFormViewFioriStyle {
 
     struct TitleFioriStyle: TitleStyle {
         let filterFormViewConfiguration: FilterFormViewConfiguration
+        @Environment(\.filterFormViewTitleStyle) private var filterFormViewTitleStyle
 
         func makeBody(_ configuration: TitleConfiguration) -> some View {
             Title(configuration)
+                .titleStyle(self.filterFormViewTitleStyle)
                 .font(.fiori(forTextStyle: .subheadline, weight: .semibold))
                 .foregroundStyle(Color.preferredColor(self.filterFormViewConfiguration.isEnabled ? .primaryLabel : .quaternaryLabel))
+                .typeErased
         }
     }
 
@@ -377,5 +389,25 @@ private struct FilterFormViewLayout: Layout {
             let pt = CGPoint(x: itemRect.origin.x + bounds.origin.x, y: itemRect.origin.y + bounds.origin.y)
             subview.place(at: pt, proposal: ProposedViewSize(itemRect.size))
         }
+    }
+}
+
+struct FilterFormViewButtonSizeKey: EnvironmentKey {
+    static var defaultValue: FilterButtonSize? = nil
+}
+
+extension EnvironmentValues {
+    var filterFormViewButtonSize: FilterButtonSize? {
+        get { self[FilterFormViewButtonSizeKey.self] }
+        set { self[FilterFormViewButtonSizeKey.self] = newValue }
+    }
+}
+
+public extension View {
+    /// Button size customization in `FilterFormView`
+    /// - Parameter buttonSize: Button size by `FilterButtonSize`
+    /// - Returns: New view with customized button size in `FilterFormView`
+    func filterFormViewButtonSize(_ buttonSize: FilterButtonSize) -> some View {
+        self.environment(\.filterFormViewButtonSize, buttonSize)
     }
 }


### PR DESCRIPTION
Ref: #1610 
Cause there are multiple titles and description components used in Feedback, so some new APIs introduced to support styles customization.
|AIUserFeedback|Writing Assistant|
|-|-|
|<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-03-17 at 16 29 11" src="https://github.com/user-attachments/assets/ed5919ea-6a49-40bc-8a94-f63013d38540" />|<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-03-17 at 16 32 40" src="https://github.com/user-attachments/assets/3c6b0a99-6751-4c8c-afa3-b222288c8b32" />|
