### PR TITLE
fix: 🐛 [0]iOS 26.4: DateTime popover clipped in FilterFeedback

### DIFF
--- a/Sources/FioriSwiftUICore/Components/CancellableResettableForm.swift
+++ b/Sources/FioriSwiftUICore/Components/CancellableResettableForm.swift
@@ -11,11 +11,19 @@ struct CancellableResettableDialogNavigationForm<Title: View, CancelAction: View
     var applyAction: ApplyAction
     let calculateScrollView: Bool
     @State private var sheetContentHeight: CGFloat = 0
+    @State private var hasInitialMeasurement: Bool = false
     @State private var bottomHeight: CGFloat = 0
-    @State private var navigationBarHeight: CGFloat = 50
+    @State private var navigationBarHeight: CGFloat = {
+        if LiquidGlassHelper.usesLiquidGlassUI {
+            return UIDevice.current.userInterfaceIdiom != .phone ? 67 : 74
+        } else {
+            return UIDevice.current.userInterfaceIdiom != .phone ? 50.0 : 56.0
+        }
+    }()
+
     @State private var scrollViewHeight: CGFloat? = nil
     @State private var subScrollViewHeight: CGFloat = 0
-    @State var horizontalSizeClass: UserInterfaceSizeClass = .compact
+    @State var horizontalSizeClass: UserInterfaceSizeClass = UIDevice.current.userInterfaceIdiom != .phone ? .regular : .compact
     
     #if !os(visionOS)
         private let popoverIdealWidth = 393.0
@@ -72,13 +80,34 @@ struct CancellableResettableDialogNavigationForm<Title: View, CancelAction: View
                             }
                         }
                         .ifApply(!self.calculateScrollView) {
-                            $0.background {
-                                GeometryReader { proxy in
-                                    Color.clear
-                                        .task {
-                                            self.sheetContentHeight = proxy.size.height
+                            if #available(iOS 18, *) {
+                                return $0.onGeometryChange(for: CGFloat.self) { proxy in
+                                    proxy.size.height
+                                } action: { oldHeight, newHeight in
+                                    if !self.hasInitialMeasurement {
+                                        // On iOS 26, the first layout pass may report an inflated height
+                                        // that includes the navigation bar safe area inset. The second pass
+                                        // corrects to the true content height. We always take the smaller
+                                        // stable value when height shrinks after the first measurement.
+                                        if oldHeight == 0 || newHeight <= oldHeight {
+                                            self.sheetContentHeight = newHeight
+                                            self.hasInitialMeasurement = true
                                         }
-                                }
+                                    } else {
+                                        // After initial measurement, accept all updates directly
+                                        // (e.g., DatePicker growing taller when switching to a 6-week month)
+                                        self.sheetContentHeight = newHeight
+                                    }
+                                }.typeErased
+                            } else {
+                                return $0.background {
+                                    GeometryReader { proxy in
+                                        Color.clear
+                                            .task {
+                                                self.sheetContentHeight = proxy.size.height
+                                            }
+                                    }
+                                }.typeErased
                             }
                         }
                     VStack(spacing: 0) {
@@ -113,16 +142,7 @@ struct CancellableResettableDialogNavigationForm<Title: View, CancelAction: View
                 }.hideSharedBackground()
             }
         }
-        .frame(idealWidth: self.popoverIdealWidth, idealHeight: self.idealHeight())
-        .background {
-            GeometryReader { proxy in
-                self.navigationBar()
-                    .task {
-                        self.navigationBarHeight = proxy.size.height
-                    }
-                    .hidden()
-            }
-        }
+        .frame(idealWidth: self.popoverIdealWidth, idealHeight: self.hasIdealHeight ? self.idealHeight() : nil)
         .presentationDetents(self.presentationDetent())
         #if !os(visionOS)
             .listRowBackground(Color.preferredColor(.secondaryGroupedBackground))
@@ -153,7 +173,7 @@ struct CancellableResettableDialogNavigationForm<Title: View, CancelAction: View
             return [.height(self.sheetContentHeight + self.bottomHeight + self.navigationBarHeight)]
         }
     }
-    
+
     func idealHeight() -> CGFloat {
         if self.calculateScrollView, let scrollViewHeight {
             if self.subScrollViewHeight > 0 {
@@ -165,34 +185,23 @@ struct CancellableResettableDialogNavigationForm<Title: View, CancelAction: View
             return self.sheetContentHeight + self.bottomHeight + self.navigationBarHeight
         }
     }
-    
+
+    /// Whether the ideal height has been measured and is ready to use.
+    /// On iPad, applying an idealHeight of ~navigationBarHeight before content
+    /// is measured causes the popover to clip its content.
+    var hasIdealHeight: Bool {
+        if self.calculateScrollView {
+            return self.scrollViewHeight != nil
+        } else {
+            return self.sheetContentHeight > 0
+        }
+    }
+
     var bottomPadding: CGFloat {
         if self.horizontalSizeClass == .regular {
             return 26
         } else {
             return 0
-        }
-    }
-    
-    func navigationBar() -> some View {
-        NavigationStack {
-            EmptyView()
-                .navigationBarTitleDisplayMode(.inline)
-                .toolbar {
-                    ToolbarItem(placement: .principal) {
-                        self.title
-                    }
-                    ToolbarItem(placement: .topBarLeading) {
-                        self.cancelAction
-                            .fixedSize()
-                            .accessibilityIdentifier("Cancel")
-                    }
-                    ToolbarItem(placement: .topBarTrailing) {
-                        self.resetAction
-                            .fixedSize()
-                            .accessibilityIdentifier("Reset")
-                    }
-                }
         }
     }
 }

--- a/Sources/FioriSwiftUICore/Views/SortFilter/FilterFeedbackBarItemSubview.swift
+++ b/Sources/FioriSwiftUICore/Views/SortFilter/FilterFeedbackBarItemSubview.swift
@@ -618,9 +618,7 @@ struct DateTimeMenuItem: View {
                 )
                 .datePickerStyle(.graphical)
                 .labelsHidden()
-                .frame(minHeight: 320)
                 .fixedSize(horizontal: false, vertical: true)
-                .clipped()
             }
         }
     }
@@ -686,7 +684,7 @@ struct DateTimeMenuItem: View {
                 })
             })
     }
-    
+
     private func padView() -> some View {
         FilterFeedbackBarItem(icon: icon(name: self.item.icon, isVisible: true), title: AttributedString(self.item.label), accessoryIcon: Image(systemName: "chevron.down"), isSelected: self.item.isChecked)
             .accessibilityFocused(self.$isBarItemFocused)


### PR DESCRIPTION
Bug Description:
  The DateTime item in FilterFeedbackBar displays with clipped/incorrectly sized popover content on iPad (iOS 26.4 simulator). The layout only corrects itself after the user interacts with the content. iPhone is unaffected.                                   
                                                                                                                                  
  Root Cause:                                                                                                                     
  On iPad, popover sizing relies on `.frame(idealHeight:)`. The idealHeight is calculated as `sheetContentHeight + bottomHeight + navigationBarHeight`, but several timing issues cause the first-frame value to be incorrect:                                     
  
  1. Delayed content height measurement: `sheetContentHeight` starts at 0 and is measured asynchronously via `GeometryReader` + `.task`. On the first frame, `idealHeight` is only ~50pt (just the navigation bar height), far too small for the `DatePicker` (~400pt), causing the popover to render clipped.                                                                                          
  2. Delayed navigation bar height measurement: The old code measured navigation bar height by creating a hidden NavigationStack and reading its geometry asynchronously via .task, which also wasn't available on the first frame. The hardcoded initial value  of 50 also didn't account for iOS 26 Liquid Glass navigation bar height changes.
  3. Incorrect bottom spacing: `horizontalSizeClass` was initialized to `.compact `unconditionally, causing the Apply button's bottom spacing on iPad to use the iPhone value (6pt instead of 16pt). Although `WindowTraitReader` corrects this later, the popover size is already determined on the first frame and does not readjust.
                                                                                                                                  
  Fix:                                                                                                                            
                                                                                              
  - When content has not yet been measured (`sheetContentHeight == 0`), pass `nil` for `idealHeight` instead of an incorrect small value, allowing SwiftUI to use intrinsic content sizing for the popover and avoiding first-frame clipping 
                      
  - Replace async navigation bar height measurement with static values based on device type and Liquid Glass state, eliminating the timing issue; remove the now-unnecessary hidden NavigationStack measurement method      
                                      
  - Upgrade content height measurement from `GeometryReader` + `.task `(one-shot) to `onGeometryChange `(iOS 18+, continuous tracking), supporting dynamic content height changes (e.g., DatePicker switching between 5-week and 6-week months) and handling iOS 26's  inflated first-pass height 
                                                                                                       
  - Initialize horizontalSizeClass based on device type to ensure correct spacing on the first frame for iPad
                                                                                                                                                                                                                         
  - Remove `.frame(minHeight: 320) `and `.clipped()` from DatePicker, which were workarounds for the insufficient popover height and  are no longer needed

before:
<img width="362" height="475" alt="Screenshot 2026-04-03 at 16 42 20" src="https://github.com/user-attachments/assets/6ea0382e-cca0-43fa-9753-3fa4e0b1a79d" /><img width="365" height="421" alt="Screenshot 2026-04-03 at 14 23 52" src="https://github.com/user-attachments/assets/d705ff5c-cf97-49e5-909e-37436e5564e5" />

after:
<img width="364" height="243" alt="Screenshot 2026-04-07 at 15 14 09" src="https://github.com/user-attachments/assets/1d10c5c9-e74c-49e9-8b74-2e034132e8ab" /><img width="364" height="515" alt="Screenshot 2026-04-07 at 15 14 20" src="https://github.com/user-attachments/assets/0566ced8-ddeb-4dca-abba-b664754913dc" />
