### PR TITLE
fix: 🐛 [1833]StepperView control cannot display nagetive values

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/FormCells/StepperViewExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/FormCells/StepperViewExample.swift
@@ -34,7 +34,7 @@ struct StepperViewExample: View {
                 StepperView(
                     title: { Text("Value") },
                     text: self.$normalStepValue,
-                    stepRange: 0 ... 100,
+                    stepRange: -10 ... 100,
                     description: { Text("Hint Text") }
                 )
                 .disabled(self.isDisabled)
@@ -43,7 +43,7 @@ struct StepperViewExample: View {
                     title: { Text("Value") },
                     text: self.$doubleStepValue,
                     step: 0.5,
-                    stepRange: 0.5 ... 80.5,
+                    stepRange: -2.5 ... 80.5,
                     isDecimalSupported: true,
                     description: { Text("Double Value") }
                 )

--- a/Sources/FioriSwiftUICore/_FioriStyles/StepperFieldStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/StepperFieldStyle.fiori.swift
@@ -139,9 +139,13 @@ public struct StepperFieldBaseStyle: StepperFieldStyle {
     private func filterDecimalInput(_ value: String) -> String {
         var result = ""
         var hasDecimalPoint = false
-        
+        var hasMinusSign = false
+
         for char in value {
-            if char.isNumber {
+            if char == "-", !hasMinusSign, result.isEmpty {
+                result.append(char)
+                hasMinusSign = true
+            } else if char.isNumber {
                 result.append(char)
             } else if char == ".", !hasDecimalPoint {
                 result.append(char)

--- a/Sources/FioriSwiftUICore/_FioriStyles/TextInputFieldStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/TextInputFieldStyle.fiori.swift
@@ -65,9 +65,13 @@ public struct TextInputFieldDecimalStyle: TextInputFieldStyle {
     private func updateText(value: String, configuration: TextInputFieldConfiguration) {
         var result = ""
         var hasDecimalPoint = false
-        
+        var hasMinusSign = false
+
         for char in value {
-            if char.isNumber {
+            if char == "-", !hasMinusSign, result.isEmpty {
+                result.append(char)
+                hasMinusSign = true
+            } else if char.isNumber {
                 result.append(char)
             } else if char == ".", !hasDecimalPoint {
                 result.append(char)
@@ -85,16 +89,28 @@ public struct TextInputFieldNumberStyle: TextInputFieldStyle {
             .frame(minHeight: 44)
             .keyboardType(.numberPad)
             .setOnChange(of: configuration.text, action1: { newValue in
-                let filtered = newValue.filter(\.isNumber)
+                let filtered = Self.filterIntegerInput(newValue)
                 if filtered != newValue {
                     configuration.text = filtered
                 }
             }) { _, newValue in
-                let filtered = newValue.filter(\.isNumber)
+                let filtered = Self.filterIntegerInput(newValue)
                 if filtered != newValue {
                     configuration.text = filtered
                 }
             }
+    }
+
+    private static func filterIntegerInput(_ value: String) -> String {
+        var result = ""
+        for (index, char) in value.enumerated() {
+            if char == "-", index == 0 {
+                result.append(char)
+            } else if char.isNumber {
+                result.append(char)
+            }
+        }
+        return result
     }
 }
 


### PR DESCRIPTION

1. The stepRange API accepts ClosedRange<Double>, and there are no documentation or code restrictions that require the lower bound to be >= 0.
2. The calculation logic of clampValue and adjustValue fully supports negative values.
3. The disable logic of the minus button ( > stepRange.lowerBound) also correctly supports negative lower bounds.
4. The only issue is that the input filtering layer does not consider the negative sign character "-".
