### PR TITLE
feat: 🎸 corner customization support for note and filter form

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/FormViews/FilterFormViewExamples.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/FormViews/FilterFormViewExamples.swift
@@ -155,6 +155,7 @@ struct FilterFormViewExamples: View {
             }, options: self.sortValueOptions, isEnabled: self.isEnabled, allowsMultipleSelection: true, allowsEmptySelection: true, value: self.$sortFilterEmptyTitleSelectionValue, buttonSize: .flexible)
                 .filterFormOptionMinTouchHeight(50)
                 .filterFormOptionCornerRadius(16)
+                .filterFormOptionShape(.capsule)
                 .filterFormOptionTitleSpacing(4)
                 .filterFormOptionPadding(EdgeInsets(top: 4, leading: 9, bottom: 4, trailing: 9))
                 .filterFormOptionAttributes([

--- a/Apps/Examples/Examples/FioriSwiftUICore/FormViews/NoteFormViewExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/FormViews/NoteFormViewExample.swift
@@ -76,6 +76,7 @@ struct NoteFormViewExample: View {
                 Text("NoteFormView AI loading Effect with no existing text").italic()
                 NoteFormView(text: self.$valueText3, placeholder: "NoteFormView Placeholder for Skeleton loading - two lines", controlState: .normal)
                     .environment(\.isAILoading, self.isLoading)
+                    .noteFormViewCornerRadius(16)
             }
             #if !os(visionOS)
             .scrollDismissesKeyboard(.immediately)

--- a/Sources/FioriSwiftUICore/Views/CustomBuilder/FilterFormOptionsEnvironments.swift
+++ b/Sources/FioriSwiftUICore/Views/CustomBuilder/FilterFormOptionsEnvironments.swift
@@ -13,6 +13,14 @@ public enum FilterFormOptionState {
     case disabledSelected
 }
 
+/// A enum describing the shape of a filter form option
+public enum FilterFormOptionShape: Equatable {
+    /// Rounded rectangle with a specific corner radius
+    case roundedRectangle(CGFloat)
+    /// Capsule shape (fully rounded ends)
+    case capsule
+}
+
 struct FilterFormOptionAttributes: EnvironmentKey {
     public static let defaultValue: [FilterFormOptionState: [NSAttributedString.Key: Any]] = [:]
 }
@@ -27,6 +35,10 @@ struct FilterFormOptionMinTouchHeight: EnvironmentKey {
 
 struct FilterFormOptionCornerRadius: EnvironmentKey {
     public static let defaultValue: CGFloat = 16.0
+}
+
+struct FilterFormOptionShapeKey: EnvironmentKey {
+    public static let defaultValue: FilterFormOptionShape? = nil
 }
 
 struct FilterFormOptionPadding: EnvironmentKey {
@@ -70,6 +82,13 @@ public extension EnvironmentValues {
         set { self[FilterFormOptionCornerRadius.self] = newValue }
     }
     
+    /// Shape for filter form option. When set, this takes priority over `filterFormOptionCornerRadius`.
+    /// Supports `.roundedRectangle(cornerRadius)` or `.capsule`.
+    var filterFormOptionShape: FilterFormOptionShape? {
+        get { self[FilterFormOptionShapeKey.self] }
+        set { self[FilterFormOptionShapeKey.self] = newValue }
+    }
+    
     /// Padding for filter form option.
     var filterFormOptionPadding: EdgeInsets {
         get { self[FilterFormOptionPadding.self] }
@@ -92,6 +111,14 @@ public extension EnvironmentValues {
     var filterFormOptionsLineSpacing: CGFloat {
         get { self[FilterFormOptionsLineSpacing.self] }
         set { self[FilterFormOptionsLineSpacing.self] = newValue }
+    }
+    
+    /// Resolved shape for filter form option. If `filterFormOptionShape` is set, use it; otherwise fall back to `filterFormOptionCornerRadius`.
+    internal var resolvedFilterFormOptionShape: FilterFormOptionShape {
+        if let shape = self.filterFormOptionShape {
+            return shape
+        }
+        return .roundedRectangle(self.filterFormOptionCornerRadius)
     }
 }
 
@@ -146,6 +173,21 @@ public extension View {
     /// - Returns: A view with specified corner radius.
     func filterFormOptionCornerRadius(_ cornerRadius: CGFloat) -> some View {
         environment(\.filterFormOptionCornerRadius, cornerRadius)
+    }
+    
+    /// Set shape for filter form option. When set, this takes priority over `filterFormOptionCornerRadius`.
+    /// Supports `.roundedRectangle(cornerRadius)` or `.capsule`.
+    /// ```swift
+    /// FilterFormView(...)
+    ///     .filterFormOptionShape(.capsule)
+    ///
+    /// FilterFormView(...)
+    ///     .filterFormOptionShape(.roundedRectangle(16))
+    /// ```
+    /// - Parameter shape: The shape for filter form option.
+    /// - Returns: A view with specified shape.
+    func filterFormOptionShape(_ shape: FilterFormOptionShape) -> some View {
+        environment(\.filterFormOptionShape, shape)
     }
     
     /// Set padding for filter form option. Default is EdgeInsets(top: 4, leading: 4, bottom: 4, trailing: 4).

--- a/Sources/FioriSwiftUICore/_FioriStyles/FilterFormViewStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/FilterFormViewStyle.fiori.swift
@@ -15,7 +15,7 @@ public struct FilterFormViewBaseStyle: FilterFormViewStyle {
     @Environment(\.filterFormOptionsItemSpacing) var filterFormOptionsItemSpacing
     @Environment(\.filterFormOptionsLineSpacing) var filterFormOptionsLineSpacing
     @Environment(\.filterFormOptionMinTouchHeight) var filterFormOptionMinTouchHeight
-    @Environment(\.filterFormOptionCornerRadius) var filterFormOptionCornerRadius
+    @Environment(\.resolvedFilterFormOptionShape) var resolvedFilterFormOptionShape
     @Environment(\.filterFormOptionPadding) var filterFormOptionPadding
     @Environment(\.filterFormOptionTitleSpacing) var filterFormOptionTitleSpacing
     @Environment(\.filterFormViewButtonSize) var customizedButtonSize
@@ -137,10 +137,13 @@ public struct FilterFormViewBaseStyle: FilterFormViewStyle {
                 .frame(minHeight: self.filterFormOptionMinHeight)
                 .frame(maxWidth: .infinity) // set maxWidth with .infinity can make the view use the proposal size
                 .background(self.optionsAttributesColor(isSelected, isEnabled: configuration.isEnabled, key: .backgroundColor))
-                .clipShape(RoundedRectangle(cornerRadius: self.filterFormOptionCornerRadius))
+                .optionClipShape(self.resolvedFilterFormOptionShape)
                 .overlay {
-                    RoundedRectangle(cornerRadius: self.filterFormOptionCornerRadius)
-                        .stroke(self.optionsAttributesColor(isSelected, isEnabled: configuration.isEnabled, key: .strokeColor), lineWidth: self.optionsStrokeWidth(isSelected, isEnabled: configuration.isEnabled))
+                    self.optionStrokeOverlay(
+                        shape: self.resolvedFilterFormOptionShape,
+                        color: self.optionsAttributesColor(isSelected, isEnabled: configuration.isEnabled, key: .strokeColor),
+                        lineWidth: self.optionsStrokeWidth(isSelected, isEnabled: configuration.isEnabled)
+                    )
                 }
                 .frame(minHeight: self.filterFormOptionMinTouchHeight)
                 .contentShape(Rectangle())
@@ -158,6 +161,18 @@ public struct FilterFormViewBaseStyle: FilterFormViewStyle {
         }
         .sizeReader { size in
             self.optionsContainerWidth = size.width
+        }
+    }
+    
+    @ViewBuilder
+    func optionStrokeOverlay(shape: FilterFormOptionShape, color: Color, lineWidth: CGFloat) -> some View {
+        switch shape {
+        case .roundedRectangle(let cornerRadius):
+            RoundedRectangle(cornerRadius: cornerRadius)
+                .stroke(color, lineWidth: lineWidth)
+        case .capsule:
+            Capsule()
+                .stroke(color, lineWidth: lineWidth)
         }
     }
     
@@ -240,6 +255,20 @@ public struct FilterFormViewBaseStyle: FilterFormViewStyle {
             configuration.value.append(index)
         }
         configuration.onValueChange?(configuration.value)
+    }
+}
+
+// MARK: - Shape Helper
+
+private extension View {
+    @ViewBuilder
+    func optionClipShape(_ shape: FilterFormOptionShape) -> some View {
+        switch shape {
+        case .roundedRectangle(let cornerRadius):
+            self.clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+        case .capsule:
+            self.clipShape(Capsule())
+        }
     }
 }
 

--- a/Sources/FioriSwiftUICore/_FioriStyles/NoteFormViewStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/NoteFormViewStyle.fiori.swift
@@ -78,6 +78,7 @@ extension NoteFormViewFioriStyle {
         @FocusState var isFocused: Bool
         @Environment(\.isLoading) var isLoading
         @Environment(\.isCustomizedBorder) var isCustomizedBorder
+        @Environment(\.noteFormViewCornerRadius) var noteFormViewCornerRadius
         @ViewBuilder
         func makeBody(_ configuration: NoteFormViewConfiguration) -> some View {
             NoteFormView(configuration)
@@ -96,11 +97,11 @@ extension NoteFormViewFioriStyle {
                         .frame(minHeight: self.getMinHeight(configuration))
                         .frame(maxHeight: self.getMaxHeight(configuration))
                         .background(self.getBackgroundColor(configuration))
-                        .cornerRadius(8)
+                        .cornerRadius(self.noteFormViewCornerRadius)
                         .overlay(
                             Group {
                                 if !self.isCustomizedBorder {
-                                    RoundedRectangle(cornerRadius: 8)
+                                    RoundedRectangle(cornerRadius: self.noteFormViewCornerRadius)
                                         .stroke(self.getBorderColor(configuration), lineWidth: self.getBorderWidth(configuration))
                                 }
                             }
@@ -210,5 +211,32 @@ extension NoteFormViewFioriStyle {
         func makeBody(_ configuration: FormViewConfiguration) -> some View {
             FormView(configuration)
         }
+    }
+}
+
+// MARK: - NoteFormView Corner Radius
+
+struct NoteFormViewCornerRadiusKey: EnvironmentKey {
+    static let defaultValue: CGFloat = 8.0
+}
+
+public extension EnvironmentValues {
+    /// Corner radius for NoteFormView. Default is 8.
+    var noteFormViewCornerRadius: CGFloat {
+        get { self[NoteFormViewCornerRadiusKey.self] }
+        set { self[NoteFormViewCornerRadiusKey.self] = newValue }
+    }
+}
+
+public extension View {
+    /// Set corner radius for NoteFormView. Default is 8.
+    /// ```swift
+    /// NoteFormView(text: $text, placeholder: "Enter text")
+    ///     .noteFormViewCornerRadius(16)
+    /// ```
+    /// - Parameter cornerRadius: Corner radius for NoteFormView.
+    /// - Returns: A view with specified corner radius.
+    func noteFormViewCornerRadius(_ cornerRadius: CGFloat) -> some View {
+        environment(\.noteFormViewCornerRadius, cornerRadius)
     }
 }

--- a/Sources/FioriSwiftUICore/_FioriStyles/NoteFormViewStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/NoteFormViewStyle.fiori.swift
@@ -97,7 +97,7 @@ extension NoteFormViewFioriStyle {
                         .frame(minHeight: self.getMinHeight(configuration))
                         .frame(maxHeight: self.getMaxHeight(configuration))
                         .background(self.getBackgroundColor(configuration))
-                        .cornerRadius(self.noteFormViewCornerRadius)
+                        .clipShape(RoundedRectangle(cornerRadius: self.noteFormViewCornerRadius))
                         .overlay(
                             Group {
                                 if !self.isCustomizedBorder {


### PR DESCRIPTION
|before|after|
|-|-|
|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-16 at 14 18 31" src="https://github.com/user-attachments/assets/4ac5fb3f-fdb0-4970-a517-f4d975cafc26" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-16 at 14 15 45" src="https://github.com/user-attachments/assets/5779f648-0117-4ba1-af44-fa62f82c2394" />|
|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-16 at 14 18 38" src="https://github.com/user-attachments/assets/62f206dc-6ec2-4480-a6d6-1dfc37b69922" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-16 at 14 00 49" src="https://github.com/user-attachments/assets/c5c801da-131f-457d-bb07-aa10049f249f" />|
