### PR TITLE
fix: 🐛 [IOSSDKBUG-1818] [iOS] Tags of ObjectItem doesn't support line limit

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/ObjectHeader/ObjectHeaderDeveloperExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/ObjectHeader/ObjectHeaderDeveloperExample.swift
@@ -44,22 +44,31 @@ struct ObjectHeaderDeveloperExample: ListDataProtocol {
         
         switch (indexPath.section, indexPath.row) {
         case (0, 0):
-            let oh = ObjectHeader(title: "Transformer Overheating",
-                                  subtitle: "Three Phase Pad Mounted Transformer (533423)",
-                                  tags: ["I am selected", "PM01", "103-Repair", "tag 4", "tag 5", "tag 6", "Tag 9898232323", "Tagoweioaifoewif"],
-                                  footnote: "1000 - Hamburg, MECHANIK",
-                                  descriptionText: "Customer noticed that the transformer started",
-                                  status: TextOrIcon.text("High"),
-                                  substatus: TextOrIcon.text("Scheduled"),
-                                  detailContent: {
-                                      HeaderChart(title: {
-                                          Text("Temperature")
-                                      }, subtitle: {
-                                          Text("20 min ago")
-                                      }, chart: {
-                                          ChartView(chartModel)
-                                      })
+            let oh = ObjectHeader(title: { Text("Transformer Overheating") },
+                                  subtitle: { Text("Three Phase Pad Mounted Transformer (533423)") },
+                                  tags: {
+                                      Tag("I am selected")
+                                      Tag("PM01")
+                                      Tag("PM01")
+                                      Tag("103-Repair")
+                                      Tag("tag 4")
+                                      Tag("tag 5")
+                                      Tag("tag 6")
+                                      Tag("tag 9898232323")
+                                      Tag("Tagoweioaifoewif")
+                                  },
+                                  footnote: { Text("1000 - Hamburg, MECHANIK") },
+                                  descriptionText: { Text("Customer noticed that the transformer started") },
+                                  status: { TextOrIconView(TextOrIcon.text("High")) },
+                                  substatus: { TextOrIconView(TextOrIcon.text("Scheduled")) },
+                                  detailContent: { HeaderChart(title: {
+                                      Text("Temperature")
+                                  }, subtitle: {
+                                      Text("20 min ago")
+                                  }, chart: {
+                                      ChartView(chartModel)
                                   })
+                                  }).tagLineLimit(1)
             
             return AnyView(oh)
             
@@ -147,7 +156,7 @@ struct ObjectHeaderDeveloperExample: ListDataProtocol {
                 Tag("Tag9")
                 
                 Tag("Tag10")
-            }
+            }.tagLineLimit(2)
             
             return AnyView(tags)
             

--- a/Apps/Examples/Examples/FioriSwiftUICore/ObjectHeader/ObjectHeaderDeveloperExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/ObjectHeader/ObjectHeaderDeveloperExample.swift
@@ -68,7 +68,7 @@ struct ObjectHeaderDeveloperExample: ListDataProtocol {
                                   }, chart: {
                                       ChartView(chartModel)
                                   })
-                                  }).tagLineLimit(1)
+                                  }).tagsLineLimit(1)
             
             return AnyView(oh)
             
@@ -156,7 +156,7 @@ struct ObjectHeaderDeveloperExample: ListDataProtocol {
                 Tag("Tag9")
                 
                 Tag("Tag10")
-            }.tagLineLimit(2)
+            }.tagsLineLimit(2)
             
             return AnyView(tags)
             

--- a/Apps/Examples/Examples/FioriSwiftUICore/ObjectItem/ObjectItemCustomSeparatorExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/ObjectItem/ObjectItemCustomSeparatorExample.swift
@@ -115,7 +115,17 @@ struct ObjectItemCustomSeparatorExample: View {
             Tag("Started")
                 .tagStyle(MyTagStyle())
             Tag("PM01")
-            Tag("103-Repair")
+                .tagStyle(OutlinedTagStyle())
+            Tag("103-Re")
+                .tagStyle(OutlinedTagStyle())
+            Tag("103-Re2 103-Re2 103-Re2 103-Re2 103-Re2 103-Re2 103-Re2 103-Re2 103-Re2 103-Re2 103-Re2 103-Re2")
+                .tagStyle(OutlinedTagStyle())
+            Tag("103-Re")
+            Tag("103-Re4")
+            Tag("103-Re5")
+            Tag("103-Repair6")
+            Tag("103-Re7")
+            Tag("103-Repair8")
         }),
         
         ObjectItem(title: {
@@ -212,6 +222,12 @@ struct ObjectItemCustomSeparatorExample: View {
                             item.alignmentGuide(.listRowSeparatorLeading) { _ in
                                 50
                             }
+                        }
+                        .tagLineLimit(3)
+                        .moreTag { count in
+                            Text("+\(count) more")
+                                .font(.fiori(forTextStyle: .footnote))
+                                .foregroundStyle(Color.blue)
                         }
                 }
             } header: {

--- a/Apps/Examples/Examples/FioriSwiftUICore/ObjectItem/ObjectItemCustomSeparatorExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/ObjectItem/ObjectItemCustomSeparatorExample.swift
@@ -223,7 +223,7 @@ struct ObjectItemCustomSeparatorExample: View {
                                 50
                             }
                         }
-                        .tagLineLimit(3)
+                        .tagsLineLimit(3)
                         .moreTag { count in
                             Text("+\(count) more")
                                 .font(.fiori(forTextStyle: .footnote))

--- a/Sources/FioriSwiftUICore/Views/MHStack.swift
+++ b/Sources/FioriSwiftUICore/Views/MHStack.swift
@@ -17,7 +17,7 @@ public struct MHStack<T: TagViewList>: View {
     let lineSpacing: CGFloat
     
     @Environment(\.tagLimit) var tagLimit
-    @Environment(\.tagLineLimit) var tagLineLimit
+    @Environment(\.tagsLineLimit) var tagsLineLimit
     @Environment(\.moreTagBuilder) var moreTagBuilder
     
     @State private var mainViewSize = CGSize(width: -1, height: -1)
@@ -69,8 +69,8 @@ public struct MHStack<T: TagViewList>: View {
         var currentLineMaxHeight: CGFloat = 0
         var currentLine = 0
 
-        let maxLines = self.tagLineLimit ?? Int.max
-        let hasLimit = self.tagLineLimit != nil
+        let maxLines = self.tagsLineLimit ?? Int.max
+        let hasLimit = self.tagsLineLimit != nil
 
         // Use the actual measured MoreTag size
         let currentMoreTagSize = self.moreTagSize.width > 0 ? self.moreTagSize : CGSize(width: 40, height: 20)

--- a/Sources/FioriSwiftUICore/Views/MHStack.swift
+++ b/Sources/FioriSwiftUICore/Views/MHStack.swift
@@ -188,8 +188,15 @@ public struct MHStack<T: TagViewList>: View {
     }
     
     private func updateMainViewSize(width: CGFloat, height: CGFloat) {
-        DispatchQueue.main.async {
-            self.mainViewSize = CGSize(width: width, height: height)
+        let newSize = CGSize(width: width, height: height)
+        
+        if self.mainViewSize.different(with: newSize) {
+            DispatchQueue.main.async {
+                // Double-check to prevent stale states during async execution.
+                if self.mainViewSize.different(with: newSize) {
+                    self.mainViewSize = newSize
+                }
+            }
         }
     }
     
@@ -197,25 +204,25 @@ public struct MHStack<T: TagViewList>: View {
         ZStack(alignment: .topLeading) {
             ForEach(layouts, id: \.index) { layout in
                 if layout.index >= 0 {
-                    Measurable(content: {
-                        self.tags.view(at: layout.index)
-                    }) { size in
-                        self.measuredSizes[layout.index] = size
-                    }
-                    .position(x: layout.x, y: layout.y)
+                    self.tags.view(at: layout.index)
+                        .fioriSizeReader { size in
+                            if let oldSize = self.measuredSizes[layout.index] {
+                                if size.different(with: oldSize) {
+                                    self.measuredSizes[layout.index] = size
+                                }
+                            } else {
+                                self.measuredSizes[layout.index] = size
+                            }
+                        }
+                        .position(x: layout.x, y: layout.y)
                 } else {
                     self.moreTagBuilder.build(self.tagCount - layouts.filter { $0.index >= 0 }.count)
                         .fixedSize()
-                        .background(
-                            GeometryReader { geo in
-                                Color.clear
-                                    .onAppear {
-                                        if geo.size != self.moreTagSize {
-                                            self.moreTagSize = geo.size
-                                        }
-                                    }
+                        .fioriSizeReader { size in
+                            if self.moreTagSize.different(with: size) {
+                                self.moreTagSize = size
                             }
-                        )
+                        }
                         .position(x: layout.x, y: layout.y)
                 }
             }
@@ -227,32 +234,5 @@ public struct MHStack<T: TagViewList>: View {
         let index: Int
         let x, y: CGFloat
         let size: CGSize
-    }
-}
-
-// MARK: - Measurable View
-
-struct Measurable<Content: View>: View {
-    let content: Content
-    let onMeasure: (CGSize) -> Void
-    
-    init(@ViewBuilder content: () -> Content, onMeasure: @escaping (CGSize) -> Void) {
-        self.content = content()
-        self.onMeasure = onMeasure
-    }
-    
-    var body: some View {
-        self.content
-            .background(
-                GeometryReader { geo in
-                    Color.clear
-                        .preference(key: SizePreferenceKey.self, value: geo.size)
-                }
-            )
-            .onPreferenceChange(SizePreferenceKey.self) { size in
-                DispatchQueue.main.async {
-                    self.onMeasure(size)
-                }
-            }
     }
 }

--- a/Sources/FioriSwiftUICore/Views/MHStack.swift
+++ b/Sources/FioriSwiftUICore/Views/MHStack.swift
@@ -68,16 +68,16 @@ public struct MHStack<T: TagViewList>: View {
         var currentY: CGFloat = 0
         var currentLineMaxHeight: CGFloat = 0
         var currentLine = 0
-        
+
         let maxLines = self.tagLineLimit ?? Int.max
         let hasLimit = self.tagLineLimit != nil
-        
+
         // Use the actual measured MoreTag size
         let currentMoreTagSize = self.moreTagSize.width > 0 ? self.moreTagSize : CGSize(width: 40, height: 20)
-        
+
         for index in 0 ..< self.tagCount {
             let tagSize = self.measuredSizes[index] ?? CGSize(width: 60, height: 30)
-            
+
             // --- Step 1: Handle oversized tags (occupy entire line) ---
             if tagSize.width > containerWidth {
                 if currentX > 0 {
@@ -86,20 +86,20 @@ public struct MHStack<T: TagViewList>: View {
                     currentLineMaxHeight = 0
                     currentLine += 1
                 }
-                
+
                 if hasLimit, currentLine >= maxLines {
                     break
                 }
-                
+
                 layouts.append(ItemLayout(index: index, x: containerWidth / 2, y: currentY + tagSize.height / 2, size: tagSize))
-                
+
                 currentY += tagSize.height + self.lineSpacing
                 currentX = 0
                 currentLineMaxHeight = 0
                 currentLine += 1
                 continue
             }
-            
+
             // --- Step 2: Check if line break is needed ---
             if currentX > 0, (currentX + tagSize.width) > containerWidth {
                 currentX = 0
@@ -107,15 +107,15 @@ public struct MHStack<T: TagViewList>: View {
                 currentLineMaxHeight = 0
                 currentLine += 1
             }
-            
+
             // --- Step 3: Check if maximum line count is exceeded ---
             if hasLimit, currentLine >= maxLines {
                 break
             }
-            
+
             // --- Step 4: Special logic - Last line handling (reserve space for MoreTag) ---
             let isLastLine = hasLimit && (currentLine + 1 == maxLines)
-            
+
             if isLastLine {
                 // Check if MoreTag is wider than container
                 if currentMoreTagSize.width >= containerWidth {
@@ -123,18 +123,18 @@ public struct MHStack<T: TagViewList>: View {
                     layouts.append(ItemLayout(index: -1, x: currentMoreTagSize.width / 2, y: currentY + currentMoreTagSize.height / 2, size: currentMoreTagSize))
                     break
                 }
-                
+
                 // Calculate remaining available width on current line
                 // If we place the current tag, is there enough space for (spacing + MoreTag)?
                 let spaceAfterTag = containerWidth - (currentX + tagSize.width)
                 let needSpacing = currentX > 0 ? self.spacing : 0
-                
+
                 // If (remaining space) < (MoreTag width + spacing), we can't fit this tag
                 if spaceAfterTag < (currentMoreTagSize.width + needSpacing) {
                     // Don't display current tag, break.
                     break
                 }
-                
+
                 // If it fits, place it normally
                 layouts.append(ItemLayout(index: index, x: currentX + tagSize.width / 2, y: currentY + tagSize.height / 2, size: tagSize))
                 currentLineMaxHeight = max(currentLineMaxHeight, tagSize.height)
@@ -146,39 +146,45 @@ public struct MHStack<T: TagViewList>: View {
                 currentX += tagSize.width + self.spacing
             }
         }
-        
+
         // --- Step 6: Handle final placement of MoreTag ---
-        let hiddenCount = self.tagCount - layouts.filter { $0.index >= 0 }.count
+        self.handleMoreTagPlacement(layouts: &layouts, tagCount: self.tagCount, containerWidth: containerWidth, currentMoreTagSize: currentMoreTagSize, lastY: currentY)
+
+        // Calculate final height
+        let finalHeight = layouts.map { $0.y + $0.size.height / 2 }.max() ?? 0
+        self.updateMainViewSize(width: containerWidth, height: finalHeight)
+
+        return self.renderContent(layouts: layouts, moreTagSize: currentMoreTagSize)
+    }
+
+    private func handleMoreTagPlacement(layouts: inout [ItemLayout], tagCount: Int, containerWidth: CGFloat, currentMoreTagSize: CGSize, lastY: CGFloat) {
+        let visibleCount = layouts.filter { $0.index >= 0 }.count
+        let hiddenCount = tagCount - visibleCount
+
         if hiddenCount > 0 {
             let hasMoreTag = layouts.contains { $0.index == -1 }
-            
+
             if !hasMoreTag {
                 var moreX: CGFloat = 0
                 var moreY: CGFloat = 0
-                
+
                 if let lastLayout = layouts.last {
                     let lastTagRight = lastLayout.x + lastLayout.size.width / 2
                     moreX = lastTagRight + self.spacing + currentMoreTagSize.width / 2
                     moreY = lastLayout.y
                 } else {
                     moreX = currentMoreTagSize.width / 2
-                    moreY = currentY + currentMoreTagSize.height / 2
+                    moreY = lastY + currentMoreTagSize.height / 2
                 }
-                
+
                 // Boundary protection
                 if moreX + currentMoreTagSize.width / 2 > containerWidth {
                     moreX = containerWidth - currentMoreTagSize.width / 2
                 }
-                
+
                 layouts.append(ItemLayout(index: -1, x: moreX, y: moreY, size: currentMoreTagSize))
             }
         }
-        
-        // Calculate final height
-        let finalHeight = layouts.map { $0.y + $0.size.height / 2 }.max() ?? 0
-        self.updateMainViewSize(width: containerWidth, height: finalHeight)
-        
-        return self.renderContent(layouts: layouts, moreTagSize: currentMoreTagSize)
     }
     
     private func updateMainViewSize(width: CGFloat, height: CGFloat) {

--- a/Sources/FioriSwiftUICore/Views/MHStack.swift
+++ b/Sources/FioriSwiftUICore/Views/MHStack.swift
@@ -17,7 +17,12 @@ public struct MHStack<T: TagViewList>: View {
     let lineSpacing: CGFloat
     
     @Environment(\.tagLimit) var tagLimit
-    @State var mainViewSize = CGSize(width: -1, height: -1)
+    @Environment(\.tagLineLimit) var tagLineLimit
+    @Environment(\.moreTagBuilder) var moreTagBuilder
+    
+    @State private var mainViewSize = CGSize(width: -1, height: -1)
+    @State private var measuredSizes: [Int: CGSize] = [:]
+    @State private var moreTagSize: CGSize = .init(width: 40, height: 20)
     
     init(tags: T, spacing: CGFloat? = 10, lineSpacing: CGFloat? = 10) {
         self.tags = tags
@@ -53,70 +58,195 @@ public struct MHStack<T: TagViewList>: View {
     }
     
     private var tagCount: Int {
-        guard let limit = self.tagLimit else {
-            return self.tags.count
-        }
-        
-        if limit <= 1 {
-            return min(1, self.tags.count)
-        }
-        
+        guard let limit = self.tagLimit else { return self.tags.count }
         return min(limit, self.tags.count)
     }
     
     func makeBody(in containerWidth: CGFloat) -> some View {
-        var width = CGFloat.zero
-        var height = CGFloat.zero
-        var tmpMainViewSize: CGSize = .zero
-        return ZStack(alignment: .topLeading) {
-            ForEach(0 ..< self.tagCount, id: \.self) { index in
-                self.tags.view(at: index)
-                    .padding(EdgeInsets(top: 0, leading: 1, bottom: 0, trailing: self.spacing))
-                    .alignmentGuide(.leading, computeValue: { d in
-                        if index == 0 {
-                            tmpMainViewSize = .zero
-                        }
-                        
-                        if abs(width - d.width) > containerWidth {
-                            width = 0
-                            height = -(tmpMainViewSize.height + self.lineSpacing)
-                        }
-                        let result = width
-                        if index + 1 == self.tagCount {
-                            width = 0 // last item
-                        } else {
-                            width -= d.width
-                        }
-                        
-                        if abs(width) > tmpMainViewSize.width {
-                            tmpMainViewSize.width = abs(width)
-                        }
-                        
-                        if d.height + abs(height) > tmpMainViewSize.height {
-                            tmpMainViewSize.height = d.height + abs(height)
-                        }
-                    
-                        return result
-                    })
-                    .alignmentGuide(.top, computeValue: { _ in
-                        let result = height
-                        if index + 1 == self.tagCount {
-                            height = 0 // last item
-                            
-                            DispatchQueue.main.async {
-                                self.mainViewSize = tmpMainViewSize
+        var layouts: [ItemLayout] = []
+        var currentX: CGFloat = 0
+        var currentY: CGFloat = 0
+        var currentLineMaxHeight: CGFloat = 0
+        var currentLine = 0
+        
+        let maxLines = self.tagLineLimit ?? Int.max
+        let hasLimit = self.tagLineLimit != nil
+        
+        // Use the actual measured MoreTag size
+        let currentMoreTagSize = self.moreTagSize.width > 0 ? self.moreTagSize : CGSize(width: 40, height: 20)
+        
+        for index in 0 ..< self.tagCount {
+            let tagSize = self.measuredSizes[index] ?? CGSize(width: 60, height: 30)
+            
+            // --- Step 1: Handle oversized tags (occupy entire line) ---
+            if tagSize.width > containerWidth {
+                if currentX > 0 {
+                    currentX = 0
+                    currentY += currentLineMaxHeight + self.lineSpacing
+                    currentLineMaxHeight = 0
+                    currentLine += 1
+                }
+                
+                if hasLimit, currentLine >= maxLines {
+                    break
+                }
+                
+                layouts.append(ItemLayout(index: index, x: containerWidth / 2, y: currentY + tagSize.height / 2, size: tagSize))
+                
+                currentY += tagSize.height + self.lineSpacing
+                currentX = 0
+                currentLineMaxHeight = 0
+                currentLine += 1
+                continue
+            }
+            
+            // --- Step 2: Check if line break is needed ---
+            if currentX > 0, (currentX + tagSize.width) > containerWidth {
+                currentX = 0
+                currentY += currentLineMaxHeight + self.lineSpacing
+                currentLineMaxHeight = 0
+                currentLine += 1
+            }
+            
+            // --- Step 3: Check if maximum line count is exceeded ---
+            if hasLimit, currentLine >= maxLines {
+                break
+            }
+            
+            // --- Step 4: Special logic - Last line handling (reserve space for MoreTag) ---
+            let isLastLine = hasLimit && (currentLine + 1 == maxLines)
+            
+            if isLastLine {
+                // Check if MoreTag is wider than container
+                if currentMoreTagSize.width >= containerWidth {
+                    // If MoreTag is wider than container, only show MoreTag on this line
+                    layouts.append(ItemLayout(index: -1, x: currentMoreTagSize.width / 2, y: currentY + currentMoreTagSize.height / 2, size: currentMoreTagSize))
+                    break
+                }
+                
+                // Calculate remaining available width on current line
+                // If we place the current tag, is there enough space for (spacing + MoreTag)?
+                let spaceAfterTag = containerWidth - (currentX + tagSize.width)
+                let needSpacing = currentX > 0 ? self.spacing : 0
+                
+                // If (remaining space) < (MoreTag width + spacing), we can't fit this tag
+                if spaceAfterTag < (currentMoreTagSize.width + needSpacing) {
+                    // Don't display current tag, break.
+                    break
+                }
+                
+                // If it fits, place it normally
+                layouts.append(ItemLayout(index: index, x: currentX + tagSize.width / 2, y: currentY + tagSize.height / 2, size: tagSize))
+                currentLineMaxHeight = max(currentLineMaxHeight, tagSize.height)
+                currentX += tagSize.width + self.spacing
+            } else {
+                // --- Step 5: Not the last line, place normally ---
+                layouts.append(ItemLayout(index: index, x: currentX + tagSize.width / 2, y: currentY + tagSize.height / 2, size: tagSize))
+                currentLineMaxHeight = max(currentLineMaxHeight, tagSize.height)
+                currentX += tagSize.width + self.spacing
+            }
+        }
+        
+        // --- Step 6: Handle final placement of MoreTag ---
+        let hiddenCount = self.tagCount - layouts.filter { $0.index >= 0 }.count
+        if hiddenCount > 0 {
+            let hasMoreTag = layouts.contains { $0.index == -1 }
+            
+            if !hasMoreTag {
+                var moreX: CGFloat = 0
+                var moreY: CGFloat = 0
+                
+                if let lastLayout = layouts.last {
+                    let lastTagRight = lastLayout.x + lastLayout.size.width / 2
+                    moreX = lastTagRight + self.spacing + currentMoreTagSize.width / 2
+                    moreY = lastLayout.y
+                } else {
+                    moreX = currentMoreTagSize.width / 2
+                    moreY = currentY + currentMoreTagSize.height / 2
+                }
+                
+                // Boundary protection
+                if moreX + currentMoreTagSize.width / 2 > containerWidth {
+                    moreX = containerWidth - currentMoreTagSize.width / 2
+                }
+                
+                layouts.append(ItemLayout(index: -1, x: moreX, y: moreY, size: currentMoreTagSize))
+            }
+        }
+        
+        // Calculate final height
+        let finalHeight = layouts.map { $0.y + $0.size.height / 2 }.max() ?? 0
+        self.updateMainViewSize(width: containerWidth, height: finalHeight)
+        
+        return self.renderContent(layouts: layouts, moreTagSize: currentMoreTagSize)
+    }
+    
+    private func updateMainViewSize(width: CGFloat, height: CGFloat) {
+        DispatchQueue.main.async {
+            self.mainViewSize = CGSize(width: width, height: height)
+        }
+    }
+    
+    private func renderContent(layouts: [ItemLayout], moreTagSize: CGSize) -> some View {
+        ZStack(alignment: .topLeading) {
+            ForEach(layouts, id: \.index) { layout in
+                if layout.index >= 0 {
+                    Measurable(content: {
+                        self.tags.view(at: layout.index)
+                    }) { size in
+                        self.measuredSizes[layout.index] = size
+                    }
+                    .position(x: layout.x, y: layout.y)
+                } else {
+                    self.moreTagBuilder.build(self.tagCount - layouts.filter { $0.index >= 0 }.count)
+                        .fixedSize()
+                        .background(
+                            GeometryReader { geo in
+                                Color.clear
+                                    .onAppear {
+                                        if geo.size != self.moreTagSize {
+                                            self.moreTagSize = geo.size
+                                        }
+                                    }
                             }
-                        }
-                        
-                        return result
-                    })
+                        )
+                        .position(x: layout.x, y: layout.y)
+                }
             }
         }
     }
+    
+    struct ItemLayout: Identifiable {
+        let id = UUID()
+        let index: Int
+        let x, y: CGFloat
+        let size: CGSize
+    }
 }
 
-extension MHStack: _ViewEmptyChecking {
-    public var isEmpty: Bool {
-        self.tagCount == 0
+// MARK: - Measurable View
+
+struct Measurable<Content: View>: View {
+    let content: Content
+    let onMeasure: (CGSize) -> Void
+    
+    init(@ViewBuilder content: () -> Content, onMeasure: @escaping (CGSize) -> Void) {
+        self.content = content()
+        self.onMeasure = onMeasure
+    }
+    
+    var body: some View {
+        self.content
+            .background(
+                GeometryReader { geo in
+                    Color.clear
+                        .preference(key: SizePreferenceKey.self, value: geo.size)
+                }
+            )
+            .onPreferenceChange(SizePreferenceKey.self) { size in
+                DispatchQueue.main.async {
+                    self.onMeasure(size)
+                }
+            }
     }
 }

--- a/Sources/FioriSwiftUICore/_FioriStyles/TagStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/TagStyle.fiori.swift
@@ -348,6 +348,104 @@ public extension View {
     }
 }
 
+/// Environment key for limiting the number of lines for tags.
+struct TagLineLimitEnvironmentKey: EnvironmentKey {
+    static let defaultValue: Int? = nil
+}
+
+public extension EnvironmentValues {
+    /// The maximum number of lines that a Tag container can display.
+    /// If the value is nil, it uses as many lines as required.
+    /// The default is nil.
+    var tagLineLimit: Int? {
+        get { self[TagLineLimitEnvironmentKey.self] }
+        set { self[TagLineLimitEnvironmentKey.self] = newValue }
+    }
+}
+
+public extension View {
+    /// Sets the maximum number of lines that a View can display tags.
+    ///
+    /// Use `tagLineLimit(_:)` to cap the number of lines for tags.
+    ///
+    /// The line limit applies to all ``Tag`` instances within a hierarchy.
+    ///
+    /// ```swift
+    /// MHStack {
+    ///     // ... many tags
+    /// }
+    /// .tagLineLimit(3)
+    /// ```
+    ///
+    /// - Parameter number: The line limit. If `nil`, no line limit applies.
+    /// - Returns: A view that limits the number of tag lines
+    func tagLineLimit(_ number: Int?) -> some View {
+        self.environment(\.tagLineLimit, number)
+    }
+}
+
+/// Type-erased builder for creating custom "more tags" indicator views.
+/// Used to customize the appearance of the "+N more" indicator when tags are truncated.
+struct AnyMoreTagBuilder {
+    let build: (Int) -> AnyView
+    init(_ builder: @escaping (Int) -> some View) {
+        self.build = { AnyView(builder($0)) }
+    }
+}
+
+/// Environment key for customizing the "more tags" indicator builder.
+struct MoreTagBuilderKey: EnvironmentKey {
+    static let defaultValue: AnyMoreTagBuilder = AnyMoreTagBuilder { count in
+        Text(String(format: "+%d more".localizedFioriString(), count))
+            .font(.fiori(forTextStyle: .footnote))
+            .foregroundStyle(Color.preferredColor(.accentLabel10))
+    }
+}
+
+extension EnvironmentValues {
+    /// The builder used to create the "more tags" indicator view.
+    /// This view is displayed when tags are truncated due to `tagLimit` or `tagLineLimit`.
+    /// The default shows "+N more" in the Fiori footnote style.
+    var moreTagBuilder: AnyMoreTagBuilder {
+        get { self[MoreTagBuilderKey.self] }
+        set { self[MoreTagBuilderKey.self] = newValue }
+    }
+}
+
+public extension View {
+    /// Customizes the appearance of the "more tags" indicator.
+    ///
+    /// Use `moreTag(_:)` to customize how the "+N more" indicator appears
+    /// when tags are truncated due to `tagLimit` or `tagLineLimit` constraints.
+    ///
+    /// The builder closure receives the count of hidden tags as a parameter.
+    ///
+    /// ```swift
+    /// MHStack {
+    ///     ForEach(items, id: \.self) { item in
+    ///         Text(item)
+    ///     }
+    /// }
+    /// .tagLineLimit(2)
+    /// .moreTag { count in
+    ///     Text("+\(count)")
+    ///         .font(.caption)
+    ///         .foregroundColor(.red)
+    ///         .padding(4)
+    ///         .background(Color.red.opacity(0.1))
+    ///         .cornerRadius(4)
+    /// }
+    /// ```
+    ///
+    /// - Parameter builder: A closure that takes the number of hidden tags
+    ///   and returns a custom view to display as the "more" indicator.
+    /// - Returns: A view with a customized "more tags" indicator.
+    func moreTag(@ViewBuilder builder: @escaping (Int) -> some View) -> some View {
+        let anyBuilder = AnyMoreTagBuilder(builder)
+        return self.environment(\.moreTagBuilder, anyBuilder)
+    }
+}
+
 @available(*, deprecated, message: "Use `TagConfiguration` instead")
 /// The properties of a tag.
 public struct TagStyleConfiguration {

--- a/Sources/FioriSwiftUICore/_FioriStyles/TagStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/TagStyle.fiori.swift
@@ -20,7 +20,6 @@ public struct TagFioriStyle: TagStyle {
         Tag(configuration)
             .font(.fiori(forTextStyle: .footnote))
             .foregroundStyle(Color.preferredColor(.accentLabel10))
-            .lineLimit(self.tagLimit)
             .ifApply(!(self.tagStyle is OutlinedTagStyle), content: {
                 $0.background(
                     RoundedRectangle(cornerRadius: 8)
@@ -349,7 +348,7 @@ public extension View {
 }
 
 /// Environment key for limiting the number of lines for tags.
-struct TagLineLimitEnvironmentKey: EnvironmentKey {
+struct TagsLineLimitEnvironmentKey: EnvironmentKey {
     static let defaultValue: Int? = nil
 }
 
@@ -357,16 +356,16 @@ public extension EnvironmentValues {
     /// The maximum number of lines that a Tag container can display.
     /// If the value is nil, it uses as many lines as required.
     /// The default is nil.
-    var tagLineLimit: Int? {
-        get { self[TagLineLimitEnvironmentKey.self] }
-        set { self[TagLineLimitEnvironmentKey.self] = newValue }
+    var tagsLineLimit: Int? {
+        get { self[TagsLineLimitEnvironmentKey.self] }
+        set { self[TagsLineLimitEnvironmentKey.self] = newValue }
     }
 }
 
 public extension View {
     /// Sets the maximum number of lines that a View can display tags.
     ///
-    /// Use `tagLineLimit(_:)` to cap the number of lines for tags.
+    /// Use `tagsLineLimit(_:)` to cap the number of lines for tags.
     ///
     /// The line limit applies to all ``Tag`` instances within a hierarchy.
     ///
@@ -374,13 +373,13 @@ public extension View {
     /// MHStack {
     ///     // ... many tags
     /// }
-    /// .tagLineLimit(3)
+    /// .tagsLineLimit(3)
     /// ```
     ///
     /// - Parameter number: The line limit. If `nil`, no line limit applies.
     /// - Returns: A view that limits the number of tag lines
-    func tagLineLimit(_ number: Int?) -> some View {
-        self.environment(\.tagLineLimit, number)
+    func tagsLineLimit(_ number: Int?) -> some View {
+        self.environment(\.tagsLineLimit, number)
     }
 }
 
@@ -404,7 +403,7 @@ struct MoreTagBuilderKey: EnvironmentKey {
 
 extension EnvironmentValues {
     /// The builder used to create the "more tags" indicator view.
-    /// This view is displayed when tags are truncated due to `tagLimit` or `tagLineLimit`.
+    /// This view is displayed when tags are truncated due to `tagsLineLimit`.
     /// The default shows "+N more" in the Fiori footnote style.
     var moreTagBuilder: AnyMoreTagBuilder {
         get { self[MoreTagBuilderKey.self] }
@@ -416,7 +415,7 @@ public extension View {
     /// Customizes the appearance of the "more tags" indicator.
     ///
     /// Use `moreTag(_:)` to customize how the "+N more" indicator appears
-    /// when tags are truncated due to `tagLimit` or `tagLineLimit` constraints.
+    /// when tags are truncated due to `tagsLineLimit` constraints.
     ///
     /// The builder closure receives the count of hidden tags as a parameter.
     ///
@@ -426,7 +425,7 @@ public extension View {
     ///         Text(item)
     ///     }
     /// }
-    /// .tagLineLimit(2)
+    /// .tagsLineLimit(2)
     /// .moreTag { count in
     ///     Text("+\(count)")
     ///         .font(.caption)

--- a/Sources/FioriSwiftUICore/_localization/en.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/en.lproj/FioriSwiftUICore.strings
@@ -703,3 +703,6 @@
 
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "Checkout Indicator";
+
+/*XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "+%d more";


### PR DESCRIPTION
dev results:
<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-04-20 at 10 30 21" src="https://github.com/user-attachments/assets/076f23b4-83f5-4a8d-8e6d-b80e92f86471" />
<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-04-20 at 10 43 15" src="https://github.com/user-attachments/assets/7b5af42b-b4eb-4188-bba6-61587ebb3518" />
<img width="2868" height="1320" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-04-20 at 10 53 28" src="https://github.com/user-attachments/assets/c184de45-4b44-46eb-b238-6afc71893f86" />

