### PR TITLE
fix: 🐛 add missed customEventView for calendar week mode

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/Calendar/CalendarProtocolWeekViewExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/Calendar/CalendarProtocolWeekViewExample.swift
@@ -39,8 +39,15 @@ struct CalendarProtocolWeekViewExample: View {
         CalendarWeekView(calendarStyle: .month, weekInfo: info, startDate: self.fm.date(from: "2025 01 01")!, endDate: self.fm.date(from: "2025 12 31")!, showsOutOfMonthDates: true, selectedDate: self.selectedDate, dayTappedCallback: { date, state in
             print("Tap on a date:\(date), with state:\(state)")
             self.selectedDate = date
-        }, customEventView: { _ in
-            Rectangle()
+        }, customEventView: { date in
+            if date == self.fm.date(from: "2025 10 26")! {
+                Circle().fill(Color.indigo)
+                    .frame(width: 10, height: 10)
+            } else if date == self.fm.date(from: "2025 10 27")! {
+                Rectangle()
+            } else {
+                Color.clear
+            }
         })
         .environment(\.showsWeekNumbers, true)
         .environment(\.hasEventIndicator, true)

--- a/Sources/FioriSwiftUICore/_FioriStyles/CalendarViewStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/CalendarViewStyle.fiori.swift
@@ -39,13 +39,13 @@ public struct CalendarViewBaseStyle: CalendarViewStyle {
                                 let info = configuration.model.weeks[index]
                                 CalendarWeekView(calendarStyle: configuration.model.calendarStyle, weekInfo: info, startDate: configuration.model.startDate, endDate: configuration.model.endDate, selectedDate: configuration.model.selectedDate, disabledDates: configuration.model.disabledDates, dayTappedCallback: { date, dayViewState in
                                     self.handleDayViewTapGesture(date, state: dayViewState, configuration: configuration)
-                                })
-                                .frame(width: self.availableWidth - paddingOffset * 2)
-                                .fioriSizeReader { size in
-                                    DispatchQueue.main.async {
-                                        self.weekViewHeight = size.height
+                                }, customEventView: configuration.customEventView)
+                                    .frame(width: self.availableWidth - paddingOffset * 2)
+                                    .fioriSizeReader { size in
+                                        DispatchQueue.main.async {
+                                            self.weekViewHeight = size.height
+                                        }
                                     }
-                                }
                             }
                         }
                         .scrollTargetLayout()


### PR DESCRIPTION
# Fix: Add Missing `customEventView` for Calendar Week Mode

### Bug Fix

🐛 Resolved an issue where the `customEventView` parameter was not being passed through to `CalendarWeekView` when the calendar is in week (or expandable/collapsed) mode, causing custom event indicators to be silently ignored.

### Changes

* `Sources/FioriSwiftUICore/_FioriStyles/CalendarViewStyle.fiori.swift`: Fixed the `CalendarWeekView` initialization within the week/expandable scroll view to correctly pass `configuration.customEventView` as the `customEventView` argument. Previously, the closing brace placement caused the parameter to be omitted entirely.

* `Apps/Examples/Examples/FioriSwiftUICore/Calendar/CalendarProtocolWeekViewExample.swift`: Updated the example to demonstrate date-specific custom event views — rendering an `indigo` circle for October 26, a `Rectangle` for October 27, and a transparent `Color.clear` for all other dates — replacing the previous placeholder that applied a `Rectangle` to every date indiscriminately.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.23`

- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- LLM: `anthropic--claude-4.6-sonnet`
- Event Trigger: `pull_request.opened`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- File Content Strategy: Full file content
- Correlation ID: `61b8ec38-d4fc-4323-b965-19119a830c0e`
</details>
