### PR TITLE
fix: 🐛 [IOSSDKBUG-1274] [acc] Add an optionLineLimit property to FilterFormView for AIUserFeedback

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/AIUserFeedback/AIUserFeedbackExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/AIUserFeedback/AIUserFeedbackExample.swift
@@ -63,6 +63,8 @@ struct AIUserFeedbackExample: View {
     @State var voteState: AIUserFeedbackVoteState = .notDetermined
     @State var voteStateIndex: Int = 0
     
+    @State var filterOptionLineLimitIndex: Int = 1
+    
     @State var isBackgroundInteractionEnabled = false
     @State var customizedVoteButton = false
     @State var displayFilterForm = true
@@ -132,6 +134,13 @@ struct AIUserFeedbackExample: View {
             .onChange(of: self.voteStateIndex) {
                 self.voteState = self.voteStates[self.voteStateIndex]
             }
+
+            Picker(selection: self.$filterOptionLineLimitIndex, label: Text("Feedback option Line Limit")) {
+                Text("1").tag(1)
+                Text("2").tag(2)
+                Text("3").tag(3)
+                Text("4").tag(4)
+            }
         }
         .disableMultipleVoteForAIUserFeedback(self.disableMultipleVote)
         .toastMessage(isPresented: self.$isToastPresented, title: "Thank you for your feedback", duration: 3)
@@ -147,7 +156,7 @@ struct AIUserFeedbackExample: View {
     
     func showFeedback(mode: AIUserFeedbackDisplayMode) -> some View {
         let valueOptions: [AttributedString] = ["Inaccuraies", "Inappropriate Content", "Security Risks", "Slow Response", "Repetitive or Wordy", "Others"]
-        let filterFormView = FilterFormView(title: "Select all that apply", isRequired: true, options: valueOptions, errorMessage: displayContentError && self.filterFormViewSelectionValue.isEmpty ? "Missing required field" : nil, isEnabled: true, allowsMultipleSelection: true, allowsEmptySelection: true, value: self.$filterFormViewSelectionValue, buttonSize: .fixed, onValueChange: { value in
+        let filterFormView = FilterFormView(title: "Select all that apply", isRequired: true, options: valueOptions, errorMessage: displayContentError && self.filterFormViewSelectionValue.isEmpty ? "Missing required field" : nil, isEnabled: true, allowsMultipleSelection: true, allowsEmptySelection: true, value: self.$filterFormViewSelectionValue, buttonSize: .fixed, optionLineLimit: self.filterOptionLineLimitIndex, onValueChange: { value in
             print("FilterFormView value change: \(value)")
         })
         let keyValueFormView = KeyValueFormView(title: "Additional feedback", text: self.$valueText, placeholder: "Write additional comments here", errorMessage: self.displayContentError && self.valueText.isEmpty ? "Missing required field" : nil, minTextEditorHeight: 88, maxTextLength: 200, hintText: AttributedString("Hint Text"), isCharCountEnabled: true, allowsBeyondLimit: false, isRequired: true)

--- a/Apps/Examples/Examples/FioriSwiftUICore/AIUserFeedback/AIUserFeedbackExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/AIUserFeedback/AIUserFeedbackExample.swift
@@ -63,7 +63,7 @@ struct AIUserFeedbackExample: View {
     @State var voteState: AIUserFeedbackVoteState = .notDetermined
     @State var voteStateIndex: Int = 0
     
-    @State var filterOptionLineLimitIndex: Int = 1
+    @State var filterOptionLineLimit: Int? = 1
     
     @State var isBackgroundInteractionEnabled = false
     @State var customizedVoteButton = false
@@ -135,11 +135,13 @@ struct AIUserFeedbackExample: View {
                 self.voteState = self.voteStates[self.voteStateIndex]
             }
 
-            Picker(selection: self.$filterOptionLineLimitIndex, label: Text("Feedback option Line Limit")) {
-                Text("1").tag(1)
-                Text("2").tag(2)
-                Text("3").tag(3)
-                Text("4").tag(4)
+            Picker(selection: self.$filterOptionLineLimit, label: Text("Feedback option Line Limit")) {
+                Text("Not Set").tag(Int?.some(0))
+                Text("No Limit").tag(Int?.none)
+                Text("1").tag(Int?.some(1))
+                Text("2").tag(Int?.some(2))
+                Text("3").tag(Int?.some(3))
+                Text("4").tag(Int?.some(4))
             }
         }
         .disableMultipleVoteForAIUserFeedback(self.disableMultipleVote)
@@ -155,10 +157,16 @@ struct AIUserFeedbackExample: View {
     }
     
     func showFeedback(mode: AIUserFeedbackDisplayMode) -> some View {
-        let valueOptions: [AttributedString] = ["Inaccuraies", "Inappropriate Content", "Security Risks", "Slow Response", "Repetitive or Wordy", "Others"]
-        let filterFormView = FilterFormView(title: "Select all that apply", isRequired: true, options: valueOptions, errorMessage: displayContentError && self.filterFormViewSelectionValue.isEmpty ? "Missing required field" : nil, isEnabled: true, allowsMultipleSelection: true, allowsEmptySelection: true, value: self.$filterFormViewSelectionValue, buttonSize: .fixed, optionLineLimit: self.filterOptionLineLimitIndex, onValueChange: { value in
+        let valueOptions: [AttributedString] = ["Inaccuraies", "Inappropriate Content peng peng peng peng peng peng peng peng peng peng peng peng", "Security Risks", "Slow Response", "Repetitive or Wordy", "Others peng peng peng peng peng peng"]
+        var filterFormView = FilterFormView(title: "Select all that apply", isRequired: true, options: valueOptions, errorMessage: displayContentError && self.filterFormViewSelectionValue.isEmpty ? "Missing required field" : nil, isEnabled: true, allowsMultipleSelection: true, allowsEmptySelection: true, value: self.$filterFormViewSelectionValue, buttonSize: .fixed, optionLineLimit: self.filterOptionLineLimit, onValueChange: { value in
             print("FilterFormView value change: \(value)")
         })
+        if self.filterOptionLineLimit == 0 {
+            filterFormView = FilterFormView(title: "Select all that apply", isRequired: true, options: valueOptions, errorMessage: self.displayContentError && self.filterFormViewSelectionValue.isEmpty ? "Missing required field" : nil, isEnabled: true, allowsMultipleSelection: true, allowsEmptySelection: true, value: self.$filterFormViewSelectionValue, buttonSize: .fixed, onValueChange: { value in
+                print("FilterFormView value change: \(value)")
+            })
+            print("Skip setting OptionLineLimit, it will use the default value.")
+        }
         let keyValueFormView = KeyValueFormView(title: "Additional feedback", text: self.$valueText, placeholder: "Write additional comments here", errorMessage: self.displayContentError && self.valueText.isEmpty ? "Missing required field" : nil, minTextEditorHeight: 88, maxTextLength: 200, hintText: AttributedString("Hint Text"), isCharCountEnabled: true, allowsBeyondLimit: false, isRequired: true)
 		
         func shouldDisableSubmit() -> Bool {

--- a/Apps/Examples/Examples/FioriSwiftUICore/AIUserFeedback/AIUserFeedbackExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/AIUserFeedback/AIUserFeedbackExample.swift
@@ -157,15 +157,15 @@ struct AIUserFeedbackExample: View {
     }
     
     func showFeedback(mode: AIUserFeedbackDisplayMode) -> some View {
-        let valueOptions: [AttributedString] = ["Inaccuraies", "Inappropriate Content peng peng peng peng peng peng peng peng peng peng peng peng", "Security Risks", "Slow Response", "Repetitive or Wordy", "Others peng peng peng peng peng peng"]
-        var filterFormView = FilterFormView(title: "Select all that apply", isRequired: true, options: valueOptions, errorMessage: displayContentError && self.filterFormViewSelectionValue.isEmpty ? "Missing required field" : nil, isEnabled: true, allowsMultipleSelection: true, allowsEmptySelection: true, value: self.$filterFormViewSelectionValue, buttonSize: .fixed, optionLineLimit: self.filterOptionLineLimit, onValueChange: { value in
+        let valueOptions: [AttributedString] = ["Inaccuraies", "Inappropriate Content", "Security Risks", "Slow Response", "Repetitive or Wordy", "Others"]
+        var filterFormView = FilterFormView(title: "Select all that apply", isRequired: true, options: valueOptions, errorMessage: displayContentError && self.filterFormViewSelectionValue.isEmpty ? "Missing required field" : nil, isEnabled: true, allowsMultipleSelection: true, allowsEmptySelection: true, value: self.$filterFormViewSelectionValue, buttonSize: .fixed, numberOfLines: self.filterOptionLineLimit, onValueChange: { value in
             print("FilterFormView value change: \(value)")
         })
         if self.filterOptionLineLimit == 0 {
             filterFormView = FilterFormView(title: "Select all that apply", isRequired: true, options: valueOptions, errorMessage: self.displayContentError && self.filterFormViewSelectionValue.isEmpty ? "Missing required field" : nil, isEnabled: true, allowsMultipleSelection: true, allowsEmptySelection: true, value: self.$filterFormViewSelectionValue, buttonSize: .fixed, onValueChange: { value in
                 print("FilterFormView value change: \(value)")
             })
-            print("Skip setting OptionLineLimit, it will use the default value.")
+            print("Skip setting numberOfLines, it will use the default value.")
         }
         let keyValueFormView = KeyValueFormView(title: "Additional feedback", text: self.$valueText, placeholder: "Write additional comments here", errorMessage: self.displayContentError && self.valueText.isEmpty ? "Missing required field" : nil, minTextEditorHeight: 88, maxTextLength: 200, hintText: AttributedString("Hint Text"), isCharCountEnabled: true, allowsBeyondLimit: false, isRequired: true)
 		

--- a/Sources/FioriSwiftUICore/_ComponentProtocols/CompositeComponentProtocols.swift
+++ b/Sources/FioriSwiftUICore/_ComponentProtocols/CompositeComponentProtocols.swift
@@ -1269,6 +1269,9 @@ protocol _FilterFormViewComponent: _TitleComponent, _MandatoryField, _OptionsCom
     // sourcery: defaultValue = true
     /// Allow chips to layout on the same line as the title
     var isSingleLine: Bool { get }
+    // sourcery: defaultValue = 1
+    /// The maximum number of lines allowed for displaying each option's text.
+    var optionLineLimit: Int { get }
     /// Implementation of value change callback.  Is invoked on changes to the `value` property.
     var onValueChange: (([Int]) -> Void)? { get }
     

--- a/Sources/FioriSwiftUICore/_ComponentProtocols/CompositeComponentProtocols.swift
+++ b/Sources/FioriSwiftUICore/_ComponentProtocols/CompositeComponentProtocols.swift
@@ -1270,8 +1270,8 @@ protocol _FilterFormViewComponent: _TitleComponent, _MandatoryField, _OptionsCom
     /// Allow chips to layout on the same line as the title
     var isSingleLine: Bool { get }
     // sourcery: defaultValue = 1
-    /// The maximum number of lines allowed for displaying each option's text. Pass `nil` to remove the line limit.
-    var optionLineLimit: Int? { get }
+    /// The maximum number of lines allowed for displaying each option's text. The default value is `1`. Pass `nil` to remove the line limit.
+    var numberOfLines: Int? { get }
     /// Implementation of value change callback.  Is invoked on changes to the `value` property.
     var onValueChange: (([Int]) -> Void)? { get }
     

--- a/Sources/FioriSwiftUICore/_ComponentProtocols/CompositeComponentProtocols.swift
+++ b/Sources/FioriSwiftUICore/_ComponentProtocols/CompositeComponentProtocols.swift
@@ -1270,8 +1270,8 @@ protocol _FilterFormViewComponent: _TitleComponent, _MandatoryField, _OptionsCom
     /// Allow chips to layout on the same line as the title
     var isSingleLine: Bool { get }
     // sourcery: defaultValue = 1
-    /// The maximum number of lines allowed for displaying each option's text.
-    var optionLineLimit: Int { get }
+    /// The maximum number of lines allowed for displaying each option's text. Pass `nil` to remove the line limit.
+    var optionLineLimit: Int? { get }
     /// Implementation of value change callback.  Is invoked on changes to the `value` property.
     var onValueChange: (([Int]) -> Void)? { get }
     

--- a/Sources/FioriSwiftUICore/_FioriStyles/FilterFormViewStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/FilterFormViewStyle.fiori.swift
@@ -119,16 +119,16 @@ public struct FilterFormViewBaseStyle: FilterFormViewStyle {
                             configuration.checkmarkImage
                         }
                         Text(option)
-                            .lineLimit(1)
+                            .lineLimit(configuration.optionLineLimit)
                     })
                     .opacity(0)
-                    
+
                     HStack(alignment: .center, spacing: self.filterFormOptionTitleSpacing, content: {
                         if isSelected, !configuration.checkmarkImage.isEmpty {
                             configuration.checkmarkImage
                         }
                         Text(option)
-                            .lineLimit(1)
+                            .lineLimit(configuration.optionLineLimit)
                     })
                 }
                 .padding(self.filterFormOptionPadding)
@@ -377,34 +377,42 @@ private struct FilterFormViewLayout: Layout {
         
         var maxWidth = 0.0
         var hasMoreLines = false
-        
-        var lastItemRect: CGRect = .zero
+
+        var rowOriginY = 0.0
+        var rowMaxHeight = 0.0
+        var rowCurrentX = 0.0
         for index in cache.columns.indices {
             var rect = cache.columns[index]
             if self.buttonSize != .flexible {
                 rect.size.width = cache.itemMaxWidth
             }
             if index == 0 {
-                totalHeight += rect.size.height
+                rect.origin = .zero
+                rowCurrentX = rect.size.width
+                rowMaxHeight = rect.size.height
+                totalHeight = rect.size.height
             } else {
-                if rect.size.width + self.filterFormOptionsItemSpacing + lastItemRect.maxX > availableWidth {
-                    rect.origin = CGPoint(x: 0, y: lastItemRect.origin.y + lastItemRect.size.height + self.filterFormOptionsLineSpacing)
-                    // when spare space is not enough, place the item to the new line
-                    totalHeight += rect.size.height
+                if rect.size.width + self.filterFormOptionsItemSpacing + rowCurrentX > availableWidth {
+                    // Not enough room — advance to the next row using the current row's max height.
+                    rowOriginY += rowMaxHeight + self.filterFormOptionsLineSpacing
+                    rect.origin = CGPoint(x: 0, y: rowOriginY)
+                    rowCurrentX = rect.size.width
+                    rowMaxHeight = rect.size.height
+                    totalHeight = rowOriginY + rect.size.height
                     hasMoreLines = true
-                    if index > 1 {
-                        totalHeight += self.filterFormOptionsLineSpacing
-                    }
                 } else {
-                    rect.origin = CGPoint(x: lastItemRect.maxX + self.filterFormOptionsItemSpacing, y: lastItemRect.minY)
+                    rect.origin = CGPoint(x: rowCurrentX + self.filterFormOptionsItemSpacing, y: rowOriginY)
+                    rowCurrentX += self.filterFormOptionsItemSpacing + rect.size.width
+                    if rect.size.height > rowMaxHeight {
+                        rowMaxHeight = rect.size.height
+                        totalHeight = rowOriginY + rowMaxHeight
+                    }
                 }
             }
-            lastItemRect = rect
             cache.columns[index] = rect
-            
-            maxWidth = rect.maxX
+            maxWidth = max(maxWidth, rect.maxX)
         }
-        
+
         return CGSize(width: hasMoreLines ? availableWidth : maxWidth, height: totalHeight)
     }
     

--- a/Sources/FioriSwiftUICore/_FioriStyles/FilterFormViewStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/FilterFormViewStyle.fiori.swift
@@ -119,7 +119,7 @@ public struct FilterFormViewBaseStyle: FilterFormViewStyle {
                             configuration.checkmarkImage
                         }
                         Text(option)
-                            .lineLimit(configuration.optionLineLimit)
+                            .lineLimit(configuration.numberOfLines)
                     })
                     .opacity(0)
 
@@ -128,7 +128,7 @@ public struct FilterFormViewBaseStyle: FilterFormViewStyle {
                             configuration.checkmarkImage
                         }
                         Text(option)
-                            .lineLimit(configuration.optionLineLimit)
+                            .lineLimit(configuration.numberOfLines)
                     })
                 }
                 .padding(self.filterFormOptionPadding)

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/FilterFormView/FilterFormView.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/FilterFormView/FilterFormView.generated.swift
@@ -20,6 +20,8 @@ public struct FilterFormView {
     let buttonSize: FilterButtonSize
     /// Allow chips to layout on the same line as the title
     let isSingleLine: Bool
+    /// The maximum number of lines allowed for displaying each option's text.
+    let optionLineLimit: Int
     /// Implementation of value change callback.  Is invoked on changes to the `value` property.
     let onValueChange: (([Int]) -> Void)?
     ///  This image view is to be displayed on selected item.
@@ -41,6 +43,7 @@ public struct FilterFormView {
                 value: Binding<[Int]>,
                 buttonSize: FilterButtonSize = .fixed,
                 isSingleLine: Bool = true,
+                optionLineLimit: Int = 1,
                 onValueChange: (([Int]) -> Void)? = nil,
                 @ViewBuilder checkmarkImage: () -> any View = { Image(systemName: "checkmark") },
                 componentIdentifier: String? = FilterFormView.identifier)
@@ -55,6 +58,7 @@ public struct FilterFormView {
         self._value = value
         self.buttonSize = buttonSize
         self.isSingleLine = isSingleLine
+        self.optionLineLimit = optionLineLimit
         self.onValueChange = onValueChange
         self.checkmarkImage = checkmarkImage()
         self.componentIdentifier = componentIdentifier ?? FilterFormView.identifier
@@ -78,12 +82,13 @@ public extension FilterFormView {
          value: Binding<[Int]>,
          buttonSize: FilterButtonSize = .fixed,
          isSingleLine: Bool = true,
+         optionLineLimit: Int = 1,
          onValueChange: (([Int]) -> Void)? = nil,
          @ViewBuilder checkmarkImage: () -> any View = { Image(systemName: "checkmark") })
     {
         self.init(title: {
             TextWithMandatoryFieldIndicator(text: title, isRequired: isRequired, mandatoryFieldIndicator: mandatoryFieldIndicator)
-        }, options: options, controlState: controlState, errorMessage: errorMessage, isEnabled: isEnabled, allowsMultipleSelection: allowsMultipleSelection, allowsEmptySelection: allowsEmptySelection, value: value, buttonSize: buttonSize, isSingleLine: isSingleLine, onValueChange: onValueChange, checkmarkImage: checkmarkImage)
+        }, options: options, controlState: controlState, errorMessage: errorMessage, isEnabled: isEnabled, allowsMultipleSelection: allowsMultipleSelection, allowsEmptySelection: allowsEmptySelection, value: value, buttonSize: buttonSize, isSingleLine: isSingleLine, optionLineLimit: optionLineLimit, onValueChange: onValueChange, checkmarkImage: checkmarkImage)
     }
 }
 
@@ -103,6 +108,7 @@ public extension FilterFormView {
         self._value = configuration.$value
         self.buttonSize = configuration.buttonSize
         self.isSingleLine = configuration.isSingleLine
+        self.optionLineLimit = configuration.optionLineLimit
         self.onValueChange = configuration.onValueChange
         self.checkmarkImage = configuration.checkmarkImage
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
@@ -115,7 +121,7 @@ extension FilterFormView: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, title: .init(self.title), options: self.options, controlState: self.controlState, errorMessage: self.errorMessage, isEnabled: self.isEnabled, allowsMultipleSelection: self.allowsMultipleSelection, allowsEmptySelection: self.allowsEmptySelection, value: self.$value, buttonSize: self.buttonSize, isSingleLine: self.isSingleLine, onValueChange: self.onValueChange, checkmarkImage: .init(self.checkmarkImage))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, title: .init(self.title), options: self.options, controlState: self.controlState, errorMessage: self.errorMessage, isEnabled: self.isEnabled, allowsMultipleSelection: self.allowsMultipleSelection, allowsEmptySelection: self.allowsEmptySelection, value: self.$value, buttonSize: self.buttonSize, isSingleLine: self.isSingleLine, optionLineLimit: self.optionLineLimit, onValueChange: self.onValueChange, checkmarkImage: .init(self.checkmarkImage))).typeErased
                 .transformEnvironment(\.filterFormViewStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -133,7 +139,7 @@ private extension FilterFormView {
     }
 
     func defaultStyle() -> some View {
-        FilterFormView(.init(componentIdentifier: self.componentIdentifier, title: .init(self.title), options: self.options, controlState: self.controlState, errorMessage: self.errorMessage, isEnabled: self.isEnabled, allowsMultipleSelection: self.allowsMultipleSelection, allowsEmptySelection: self.allowsEmptySelection, value: self.$value, buttonSize: self.buttonSize, isSingleLine: self.isSingleLine, onValueChange: self.onValueChange, checkmarkImage: .init(self.checkmarkImage)))
+        FilterFormView(.init(componentIdentifier: self.componentIdentifier, title: .init(self.title), options: self.options, controlState: self.controlState, errorMessage: self.errorMessage, isEnabled: self.isEnabled, allowsMultipleSelection: self.allowsMultipleSelection, allowsEmptySelection: self.allowsEmptySelection, value: self.$value, buttonSize: self.buttonSize, isSingleLine: self.isSingleLine, optionLineLimit: self.optionLineLimit, onValueChange: self.onValueChange, checkmarkImage: .init(self.checkmarkImage)))
             .shouldApplyDefaultStyle(false)
             .filterFormViewStyle(FilterFormViewFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/FilterFormView/FilterFormView.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/FilterFormView/FilterFormView.generated.swift
@@ -20,8 +20,8 @@ public struct FilterFormView {
     let buttonSize: FilterButtonSize
     /// Allow chips to layout on the same line as the title
     let isSingleLine: Bool
-    /// The maximum number of lines allowed for displaying each option's text.
-    let optionLineLimit: Int
+    /// The maximum number of lines allowed for displaying each option's text. Pass `nil` to remove the line limit.
+    let optionLineLimit: Int?
     /// Implementation of value change callback.  Is invoked on changes to the `value` property.
     let onValueChange: (([Int]) -> Void)?
     ///  This image view is to be displayed on selected item.
@@ -43,7 +43,7 @@ public struct FilterFormView {
                 value: Binding<[Int]>,
                 buttonSize: FilterButtonSize = .fixed,
                 isSingleLine: Bool = true,
-                optionLineLimit: Int = 1,
+                optionLineLimit: Int? = 1,
                 onValueChange: (([Int]) -> Void)? = nil,
                 @ViewBuilder checkmarkImage: () -> any View = { Image(systemName: "checkmark") },
                 componentIdentifier: String? = FilterFormView.identifier)
@@ -82,7 +82,7 @@ public extension FilterFormView {
          value: Binding<[Int]>,
          buttonSize: FilterButtonSize = .fixed,
          isSingleLine: Bool = true,
-         optionLineLimit: Int = 1,
+         optionLineLimit: Int? = 1,
          onValueChange: (([Int]) -> Void)? = nil,
          @ViewBuilder checkmarkImage: () -> any View = { Image(systemName: "checkmark") })
     {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/FilterFormView/FilterFormView.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/FilterFormView/FilterFormView.generated.swift
@@ -20,8 +20,8 @@ public struct FilterFormView {
     let buttonSize: FilterButtonSize
     /// Allow chips to layout on the same line as the title
     let isSingleLine: Bool
-    /// The maximum number of lines allowed for displaying each option's text. Pass `nil` to remove the line limit.
-    let optionLineLimit: Int?
+    /// The maximum number of lines allowed for displaying each option's text. The default value is `1`. Pass `nil` to remove the line limit.
+    let numberOfLines: Int?
     /// Implementation of value change callback.  Is invoked on changes to the `value` property.
     let onValueChange: (([Int]) -> Void)?
     ///  This image view is to be displayed on selected item.
@@ -43,7 +43,7 @@ public struct FilterFormView {
                 value: Binding<[Int]>,
                 buttonSize: FilterButtonSize = .fixed,
                 isSingleLine: Bool = true,
-                optionLineLimit: Int? = 1,
+                numberOfLines: Int? = 1,
                 onValueChange: (([Int]) -> Void)? = nil,
                 @ViewBuilder checkmarkImage: () -> any View = { Image(systemName: "checkmark") },
                 componentIdentifier: String? = FilterFormView.identifier)
@@ -58,7 +58,7 @@ public struct FilterFormView {
         self._value = value
         self.buttonSize = buttonSize
         self.isSingleLine = isSingleLine
-        self.optionLineLimit = optionLineLimit
+        self.numberOfLines = numberOfLines
         self.onValueChange = onValueChange
         self.checkmarkImage = checkmarkImage()
         self.componentIdentifier = componentIdentifier ?? FilterFormView.identifier
@@ -82,13 +82,13 @@ public extension FilterFormView {
          value: Binding<[Int]>,
          buttonSize: FilterButtonSize = .fixed,
          isSingleLine: Bool = true,
-         optionLineLimit: Int? = 1,
+         numberOfLines: Int? = 1,
          onValueChange: (([Int]) -> Void)? = nil,
          @ViewBuilder checkmarkImage: () -> any View = { Image(systemName: "checkmark") })
     {
         self.init(title: {
             TextWithMandatoryFieldIndicator(text: title, isRequired: isRequired, mandatoryFieldIndicator: mandatoryFieldIndicator)
-        }, options: options, controlState: controlState, errorMessage: errorMessage, isEnabled: isEnabled, allowsMultipleSelection: allowsMultipleSelection, allowsEmptySelection: allowsEmptySelection, value: value, buttonSize: buttonSize, isSingleLine: isSingleLine, optionLineLimit: optionLineLimit, onValueChange: onValueChange, checkmarkImage: checkmarkImage)
+        }, options: options, controlState: controlState, errorMessage: errorMessage, isEnabled: isEnabled, allowsMultipleSelection: allowsMultipleSelection, allowsEmptySelection: allowsEmptySelection, value: value, buttonSize: buttonSize, isSingleLine: isSingleLine, numberOfLines: numberOfLines, onValueChange: onValueChange, checkmarkImage: checkmarkImage)
     }
 }
 
@@ -108,7 +108,7 @@ public extension FilterFormView {
         self._value = configuration.$value
         self.buttonSize = configuration.buttonSize
         self.isSingleLine = configuration.isSingleLine
-        self.optionLineLimit = configuration.optionLineLimit
+        self.numberOfLines = configuration.numberOfLines
         self.onValueChange = configuration.onValueChange
         self.checkmarkImage = configuration.checkmarkImage
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
@@ -121,7 +121,7 @@ extension FilterFormView: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, title: .init(self.title), options: self.options, controlState: self.controlState, errorMessage: self.errorMessage, isEnabled: self.isEnabled, allowsMultipleSelection: self.allowsMultipleSelection, allowsEmptySelection: self.allowsEmptySelection, value: self.$value, buttonSize: self.buttonSize, isSingleLine: self.isSingleLine, optionLineLimit: self.optionLineLimit, onValueChange: self.onValueChange, checkmarkImage: .init(self.checkmarkImage))).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, title: .init(self.title), options: self.options, controlState: self.controlState, errorMessage: self.errorMessage, isEnabled: self.isEnabled, allowsMultipleSelection: self.allowsMultipleSelection, allowsEmptySelection: self.allowsEmptySelection, value: self.$value, buttonSize: self.buttonSize, isSingleLine: self.isSingleLine, numberOfLines: self.numberOfLines, onValueChange: self.onValueChange, checkmarkImage: .init(self.checkmarkImage))).typeErased
                 .transformEnvironment(\.filterFormViewStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -139,7 +139,7 @@ private extension FilterFormView {
     }
 
     func defaultStyle() -> some View {
-        FilterFormView(.init(componentIdentifier: self.componentIdentifier, title: .init(self.title), options: self.options, controlState: self.controlState, errorMessage: self.errorMessage, isEnabled: self.isEnabled, allowsMultipleSelection: self.allowsMultipleSelection, allowsEmptySelection: self.allowsEmptySelection, value: self.$value, buttonSize: self.buttonSize, isSingleLine: self.isSingleLine, optionLineLimit: self.optionLineLimit, onValueChange: self.onValueChange, checkmarkImage: .init(self.checkmarkImage)))
+        FilterFormView(.init(componentIdentifier: self.componentIdentifier, title: .init(self.title), options: self.options, controlState: self.controlState, errorMessage: self.errorMessage, isEnabled: self.isEnabled, allowsMultipleSelection: self.allowsMultipleSelection, allowsEmptySelection: self.allowsEmptySelection, value: self.$value, buttonSize: self.buttonSize, isSingleLine: self.isSingleLine, numberOfLines: self.numberOfLines, onValueChange: self.onValueChange, checkmarkImage: .init(self.checkmarkImage)))
             .shouldApplyDefaultStyle(false)
             .filterFormViewStyle(FilterFormViewFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/FilterFormView/FilterFormViewStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/FilterFormView/FilterFormViewStyle.generated.swift
@@ -33,6 +33,7 @@ public struct FilterFormViewConfiguration {
     @Binding public var value: [Int]
     public let buttonSize: FilterButtonSize
     public let isSingleLine: Bool
+    public let optionLineLimit: Int
     public let onValueChange: (([Int]) -> Void)?
     public let checkmarkImage: CheckmarkImage
 

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/FilterFormView/FilterFormViewStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/FilterFormView/FilterFormViewStyle.generated.swift
@@ -33,7 +33,7 @@ public struct FilterFormViewConfiguration {
     @Binding public var value: [Int]
     public let buttonSize: FilterButtonSize
     public let isSingleLine: Bool
-    public let optionLineLimit: Int?
+    public let numberOfLines: Int?
     public let onValueChange: (([Int]) -> Void)?
     public let checkmarkImage: CheckmarkImage
 

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/FilterFormView/FilterFormViewStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/FilterFormView/FilterFormViewStyle.generated.swift
@@ -33,7 +33,7 @@ public struct FilterFormViewConfiguration {
     @Binding public var value: [Int]
     public let buttonSize: FilterButtonSize
     public let isSingleLine: Bool
-    public let optionLineLimit: Int
+    public let optionLineLimit: Int?
     public let onValueChange: (([Int]) -> Void)?
     public let checkmarkImage: CheckmarkImage
 

--- a/Tests/FioriSwiftUITests/FioriSwiftUICore/AIUserFeedbackTests.swift
+++ b/Tests/FioriSwiftUITests/FioriSwiftUICore/AIUserFeedbackTests.swift
@@ -37,4 +37,57 @@ final class AIUserFeedbackTests: XCTestCase {
         valueTextBinding.wrappedValue = "additional feedback"
         XCTAssertEqual(valueText, "additional feedback")
     }
+
+    func testOptionLineLimitDefaultValue() {
+        var selectionValue: [Int] = []
+        let binding = Binding<[Int]>(get: { selectionValue }, set: { selectionValue = $0 })
+        let view = FilterFormView(
+            title: { Text("Title") },
+            options: ["Option 1", "Option 2"],
+            isEnabled: true,
+            value: binding
+        )
+        XCTAssertEqual(view.optionLineLimit, 1)
+    }
+
+    func testOptionLineLimitCustomValue() {
+        var selectionValue: [Int] = []
+        let binding = Binding<[Int]>(get: { selectionValue }, set: { selectionValue = $0 })
+        let view = FilterFormView(
+            title: { Text("Title") },
+            options: ["Option 1", "Option 2"],
+            isEnabled: true,
+            value: binding,
+            optionLineLimit: 3
+        )
+        XCTAssertEqual(view.optionLineLimit, 3)
+    }
+
+    func testConfigurationOptionLineLimit() {
+        var capturedLineLimit: Int?
+        let style = AnyFilterFormViewStyle { cfg in
+            capturedLineLimit = cfg.optionLineLimit
+            return EmptyView()
+        }
+        var selectionValue: [Int] = []
+        let binding = Binding<[Int]>(get: { selectionValue }, set: { selectionValue = $0 })
+        let cfg = FilterFormViewConfiguration(
+            componentIdentifier: FilterFormView.identifier,
+            title: .init(Text("Title")),
+            options: ["Option 1"],
+            controlState: .normal,
+            errorMessage: nil,
+            isEnabled: true,
+            allowsMultipleSelection: true,
+            allowsEmptySelection: false,
+            value: binding,
+            buttonSize: .fixed,
+            isSingleLine: true,
+            optionLineLimit: 5,
+            onValueChange: nil,
+            checkmarkImage: .init(Image(systemName: "checkmark"))
+        )
+        _ = style.makeBody(cfg)
+        XCTAssertEqual(capturedLineLimit, 5)
+    }
 }

--- a/Tests/FioriSwiftUITests/FioriSwiftUICore/AIUserFeedbackTests.swift
+++ b/Tests/FioriSwiftUITests/FioriSwiftUICore/AIUserFeedbackTests.swift
@@ -47,7 +47,7 @@ final class AIUserFeedbackTests: XCTestCase {
             isEnabled: true,
             value: binding
         )
-        XCTAssertEqual(view.optionLineLimit, 1)
+        XCTAssertEqual(view.optionLineLimit, 1 as Int?)
     }
 
     func testOptionLineLimitCustomValue() {
@@ -60,7 +60,20 @@ final class AIUserFeedbackTests: XCTestCase {
             value: binding,
             optionLineLimit: 3
         )
-        XCTAssertEqual(view.optionLineLimit, 3)
+        XCTAssertEqual(view.optionLineLimit, 3 as Int?)
+    }
+
+    func testOptionLineLimitNilValue() {
+        var selectionValue: [Int] = []
+        let binding = Binding<[Int]>(get: { selectionValue }, set: { selectionValue = $0 })
+        let view = FilterFormView(
+            title: { Text("Title") },
+            options: ["Option 1", "Option 2"],
+            isEnabled: true,
+            value: binding,
+            optionLineLimit: nil
+        )
+        XCTAssertNil(view.optionLineLimit)
     }
 
     func testConfigurationOptionLineLimit() {
@@ -88,6 +101,34 @@ final class AIUserFeedbackTests: XCTestCase {
             checkmarkImage: .init(Image(systemName: "checkmark"))
         )
         _ = style.makeBody(cfg)
-        XCTAssertEqual(capturedLineLimit, 5)
+        XCTAssertEqual(capturedLineLimit, 5 as Int?)
+    }
+
+    func testConfigurationOptionLineLimitNil() {
+        var capturedLineLimit: Int? = 999
+        let style = AnyFilterFormViewStyle { cfg in
+            capturedLineLimit = cfg.optionLineLimit
+            return EmptyView()
+        }
+        var selectionValue: [Int] = []
+        let binding = Binding<[Int]>(get: { selectionValue }, set: { selectionValue = $0 })
+        let cfg = FilterFormViewConfiguration(
+            componentIdentifier: FilterFormView.identifier,
+            title: .init(Text("Title")),
+            options: ["Option 1"],
+            controlState: .normal,
+            errorMessage: nil,
+            isEnabled: true,
+            allowsMultipleSelection: true,
+            allowsEmptySelection: false,
+            value: binding,
+            buttonSize: .fixed,
+            isSingleLine: true,
+            optionLineLimit: nil,
+            onValueChange: nil,
+            checkmarkImage: .init(Image(systemName: "checkmark"))
+        )
+        _ = style.makeBody(cfg)
+        XCTAssertNil(capturedLineLimit)
     }
 }

--- a/Tests/FioriSwiftUITests/FioriSwiftUICore/AIUserFeedbackTests.swift
+++ b/Tests/FioriSwiftUITests/FioriSwiftUICore/AIUserFeedbackTests.swift
@@ -38,7 +38,7 @@ final class AIUserFeedbackTests: XCTestCase {
         XCTAssertEqual(valueText, "additional feedback")
     }
 
-    func testOptionLineLimitDefaultValue() {
+    func testNumberOfLinesDefaultValue() {
         var selectionValue: [Int] = []
         let binding = Binding<[Int]>(get: { selectionValue }, set: { selectionValue = $0 })
         let view = FilterFormView(
@@ -47,10 +47,10 @@ final class AIUserFeedbackTests: XCTestCase {
             isEnabled: true,
             value: binding
         )
-        XCTAssertEqual(view.optionLineLimit, 1 as Int?)
+        XCTAssertEqual(view.numberOfLines, 1 as Int?)
     }
 
-    func testOptionLineLimitCustomValue() {
+    func testNumberOfLinesCustomValue() {
         var selectionValue: [Int] = []
         let binding = Binding<[Int]>(get: { selectionValue }, set: { selectionValue = $0 })
         let view = FilterFormView(
@@ -58,12 +58,12 @@ final class AIUserFeedbackTests: XCTestCase {
             options: ["Option 1", "Option 2"],
             isEnabled: true,
             value: binding,
-            optionLineLimit: 3
+            numberOfLines: 3
         )
-        XCTAssertEqual(view.optionLineLimit, 3 as Int?)
+        XCTAssertEqual(view.numberOfLines, 3 as Int?)
     }
 
-    func testOptionLineLimitNilValue() {
+    func testNumberOfLinesNilValue() {
         var selectionValue: [Int] = []
         let binding = Binding<[Int]>(get: { selectionValue }, set: { selectionValue = $0 })
         let view = FilterFormView(
@@ -71,15 +71,15 @@ final class AIUserFeedbackTests: XCTestCase {
             options: ["Option 1", "Option 2"],
             isEnabled: true,
             value: binding,
-            optionLineLimit: nil
+            numberOfLines: nil
         )
-        XCTAssertNil(view.optionLineLimit)
+        XCTAssertNil(view.numberOfLines)
     }
 
-    func testConfigurationOptionLineLimit() {
+    func testConfigurationNumberOfLines() {
         var capturedLineLimit: Int?
         let style = AnyFilterFormViewStyle { cfg in
-            capturedLineLimit = cfg.optionLineLimit
+            capturedLineLimit = cfg.numberOfLines
             return EmptyView()
         }
         var selectionValue: [Int] = []
@@ -96,7 +96,7 @@ final class AIUserFeedbackTests: XCTestCase {
             value: binding,
             buttonSize: .fixed,
             isSingleLine: true,
-            optionLineLimit: 5,
+            numberOfLines: 5,
             onValueChange: nil,
             checkmarkImage: .init(Image(systemName: "checkmark"))
         )
@@ -104,10 +104,10 @@ final class AIUserFeedbackTests: XCTestCase {
         XCTAssertEqual(capturedLineLimit, 5 as Int?)
     }
 
-    func testConfigurationOptionLineLimitNil() {
+    func testConfigurationNumberOfLinesNil() {
         var capturedLineLimit: Int? = 999
         let style = AnyFilterFormViewStyle { cfg in
-            capturedLineLimit = cfg.optionLineLimit
+            capturedLineLimit = cfg.numberOfLines
             return EmptyView()
         }
         var selectionValue: [Int] = []
@@ -124,7 +124,7 @@ final class AIUserFeedbackTests: XCTestCase {
             value: binding,
             buttonSize: .fixed,
             isSingleLine: true,
-            optionLineLimit: nil,
+            numberOfLines: nil,
             onValueChange: nil,
             checkmarkImage: .init(Image(systemName: "checkmark"))
         )


### PR DESCRIPTION
1. The FilterFormView's option line limit is hard-coded to 1; add an optionLineLimit (default value: 1) to make it configurable.
2. Update AIUserFeedbackExample to use the new property.
3. Add unit tests for the new property.

Old:
<img width="364" height="449" alt="Picture2" src="https://github.com/user-attachments/assets/84ac6ae6-4658-4b7e-a4f4-6a7cac9f754e" />

<img width="452" height="593" alt="Picture1" src="https://github.com/user-attachments/assets/19d538ec-e75e-4766-87b8-3ac2721b2818" />

New:
<img width="364" height="449" alt="Simulator Screenshot - iPad (A16) - 2026-04-23 at 10 49 56" src="https://github.com/user-attachments/assets/708024ac-7944-486a-953b-bd2a7524eec1" />

<img width="452" height="593" alt="Simulator Screenshot - iPad (A16) - 2026-04-23 at 10 52 44" src="https://github.com/user-attachments/assets/21334339-154f-4b1a-81c4-8609fe39358f" />
