### PR TITLE
fix: 🐛 [IOSSDKBUG-1837][iOS] Date formatter issues in TimelinePreview and enhance TimelineNodeType

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/Timeline/TimelinePreviewExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/Timeline/TimelinePreviewExample.swift
@@ -31,10 +31,10 @@ struct TimelinePreviewItemModelImplementation: TimelinePreviewItemModel {
 struct TimelinePreviewExample: View {
     @State private var items0: [TimelinePreviewItemModelImplementation] = [
         TimelinePreviewItemModelImplementation(title: "Open", icon: Image(systemName: "a.square"), timelineNode: TimelineNodeType.inProgress, due: ISO8601DateFormatter().date(from: "2025-09-21T12:00:00Z")!),
-        TimelinePreviewItemModelImplementation(title: "Before start", timelineNode: TimelineNodeType.start, due: ISO8601DateFormatter().date(from: "2025-07-23T12:00:00Z")!),
-        TimelinePreviewItemModelImplementation(title: "Start", timelineNode: TimelineNodeType.open, due: ISO8601DateFormatter().date(from: "2025-08-16T12:00:00Z")!),
-        TimelinePreviewItemModelImplementation(title: "Open", timelineNode: TimelineNodeType.inProgress, due: ISO8601DateFormatter().date(from: "2025-08-15T12:00:00Z")!),
-        TimelinePreviewItemModelImplementation(title: "Open", timelineNode: TimelineNodeType.open, due: ISO8601DateFormatter().date(from: "2025-09-27T12:00:00Z")!)
+        TimelinePreviewItemModelImplementation(title: "Delete", timelineNode: TimelineNodeType.delete, due: ISO8601DateFormatter().date(from: "2025-07-23T12:00:00Z")!, dateFormat: "MMM dd yyyy"),
+        TimelinePreviewItemModelImplementation(title: "Add", timelineNode: TimelineNodeType.add, due: ISO8601DateFormatter().date(from: "2025-06-16T12:00:00Z")!, dateFormat: "MMM-dd-yyyy"),
+        TimelinePreviewItemModelImplementation(title: "Open", timelineNode: TimelineNodeType.inProgress, due: ISO8601DateFormatter().date(from: "2027-08-15T12:00:00Z")!),
+        TimelinePreviewItemModelImplementation(title: "Open", timelineNode: TimelineNodeType.open, due: Date())
     ]
     @State private var items1: [TimelinePreviewItemModelImplementation] = [
         TimelinePreviewItemModelImplementation(title: "Open", timelineNode: TimelineNodeType.inProgress, due: ISO8601DateFormatter().date(from: "2024-09-21T12:00:00Z")!),
@@ -60,7 +60,7 @@ struct TimelinePreviewExample: View {
             Text("TimelinePreview: Future").listRowSeparator(.hidden)
             TimelinePreview(optionalTitle: { Text("Timeline") }, items: .constant(self.items0.map { $0 as any TimelinePreviewItemModel })).listRowSeparator(.hidden)
             Text("TimelinePreview: Present").listRowSeparator(.hidden)
-            TimelinePreview(optionalTitle: { Text("Timeline") }, items: .constant(self.items1.map { $0 as any TimelinePreviewItemModel })).listRowSeparator(.hidden)
+            TimelinePreview(optionalTitle: { Text("Timeline") }, items: .constant(self.items1.map { $0 as any TimelinePreviewItemModel })).timelinePreviewSortOrder(.descending).listRowSeparator(.hidden)
             Text("TimelinePreview: Past").listRowSeparator(.hidden)
             TimelinePreview(optionalTitle: { Text("Timeline") }, items: .constant(self.items2.map { $0 as any TimelinePreviewItemModel })).listRowSeparator(.hidden)
             Text("TimelinePreview: No Header").listRowSeparator(.hidden)

--- a/Sources/FioriSwiftUICore/Components/TimelinePreviewItemProtocol.swift
+++ b/Sources/FioriSwiftUICore/Components/TimelinePreviewItemProtocol.swift
@@ -53,6 +53,7 @@ private struct TimelinePreviewSortOrderKey: EnvironmentKey {
 }
 
 public extension EnvironmentValues {
+    /// The sort order for items displayed in a `TimelinePreview`.
     var timelinePreviewSortOrder: TimelinePreviewSortOrder {
         get { self[TimelinePreviewSortOrderKey.self] }
         set { self[TimelinePreviewSortOrderKey.self] = newValue }

--- a/Sources/FioriSwiftUICore/Components/TimelinePreviewItemProtocol.swift
+++ b/Sources/FioriSwiftUICore/Components/TimelinePreviewItemProtocol.swift
@@ -13,12 +13,15 @@ public protocol TimelinePreviewItemModel: Identifiable {
     var isCurrent: Bool? { get set }
 }
 
-/// Extension to provide a default date formatter for the `TimelinePreviewItemModel`.
-extension TimelinePreviewItemModel {
-    var formatter: DateFormatter {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "MMMM dd yyyy"
-        return formatter
+public extension TimelinePreviewItemModel {
+    /// A default date formatter used when `formatter` is `nil`.
+    var resolvedFormatter: DateFormatter {
+        if let formatter {
+            return formatter
+        }
+        let f = DateFormatter()
+        f.dateFormat = "MMMM dd yyyy"
+        return f
     }
 }
 
@@ -26,7 +29,39 @@ extension TimelinePreviewItemModel {
 public extension TimelinePreviewItem {
     /// Initialize a `TimelinePreviewItem` from a `TimelinePreviewItemModel`.
     init(model: any TimelinePreviewItemModel) {
-        // Initialize the `TimelinePreviewItem` with values
-        self.init(title: AttributedString(model.title), icon: model.icon, timelineNode: model.timelineNode, timestamp: AttributedString(model.formatter.string(from: model.due)), isFuture: model.isFuture ?? false, nodeType: model.timelineNode)
+        self.init(
+            title: AttributedString(model.title),
+            icon: model.icon,
+            timelineNode: model.timelineNode,
+            timestamp: AttributedString(model.resolvedFormatter.string(from: model.due)),
+            isFuture: model.isFuture ?? false,
+            nodeType: model.timelineNode
+        )
+    }
+}
+
+/// Controls the sort order of items in a `TimelinePreview`.
+public enum TimelinePreviewSortOrder {
+    /// Ascending by due date (earliest first). Default.
+    case ascending
+    /// Descending by due date (latest first).
+    case descending
+}
+
+private struct TimelinePreviewSortOrderKey: EnvironmentKey {
+    static let defaultValue: TimelinePreviewSortOrder = .ascending
+}
+
+public extension EnvironmentValues {
+    var timelinePreviewSortOrder: TimelinePreviewSortOrder {
+        get { self[TimelinePreviewSortOrderKey.self] }
+        set { self[TimelinePreviewSortOrderKey.self] = newValue }
+    }
+}
+
+public extension View {
+    /// Sets the sort order for items displayed in a `TimelinePreview`.
+    func timelinePreviewSortOrder(_ order: TimelinePreviewSortOrder) -> some View {
+        environment(\.timelinePreviewSortOrder, order)
     }
 }

--- a/Sources/FioriSwiftUICore/Views/TimelineNodeView.swift
+++ b/Sources/FioriSwiftUICore/Views/TimelineNodeView.swift
@@ -14,15 +14,19 @@ public struct TimelineNodeView: View {
     public var body: some View {
         switch self.nodeType {
         case .beforeStart, .beforeEnd:
-            Image(systemName: "diamond")
+            Image(fioriName: "fiori.tag")
         case .start, .end:
-            Image(systemName: "diamond.fill")
+            Image(fioriName: "fiori.rhombus.milestone.2")
         case .open:
-            Image(systemName: "circle")
+            Image(fioriName: "fiori.circle.task")
         case .inProgress:
             Image(systemName: "ellipsis.circle.fill")
         case .complete:
-            Image(systemName: "checkmark.circle.fill")
+            Image(fioriName: "fiori.sys.enter.2")
+        case .add:
+            Image(fioriName: "fiori.add")
+        case .delete:
+            Image(fioriName: "fiori.delete.fill")
         }
     }
 }
@@ -43,4 +47,8 @@ public enum TimelineNodeType {
     case beforeEnd
     /// timeline event end
     case end
+    /// timeline event add
+    case add
+    /// timeline event delete
+    case delete
 }

--- a/Sources/FioriSwiftUICore/_FioriStyles/TimelinePreviewStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/TimelinePreviewStyle.fiori.swift
@@ -74,6 +74,7 @@ struct BuildHeader: View {
 struct BuildTimelinePreviewItem: View {
     let configuration: TimelinePreviewConfiguration
     let displayItems: Int
+    @Environment(\.timelinePreviewSortOrder) private var sortOrder
 
     var body: some View {
         HStack(alignment: .timelinePreviewAlignmentGuide, spacing: 4) {
@@ -81,10 +82,10 @@ struct BuildTimelinePreviewItem: View {
             let totalCount = filteredItems.count
             
             ForEach(Array(filteredItems.enumerated()), id: \.element.id) { index, item in
-                let dateString = item.formatter.string(from: item.due)
+                let dateString = item.resolvedFormatter.string(from: item.due)
                 let timestampFormat = NSLocalizedString("Today, %@", tableName: "FioriSwiftUICore", bundle: Bundle.accessor, comment: "")
                 let timestampString = String(format: timestampFormat, dateString)
-                let isToday = Date.compareTwoDates(first: item.due, second: Date()) == .orderedSame
+                let isToday = Calendar.current.isDateInToday(item.due)
                 let dateAttributedString = AttributedString(isToday ? timestampString : dateString)
                 let a11yTime = isToday ? NSLocalizedString("Today", tableName: "FioriSwiftUICore", bundle: Bundle.accessor, comment: "") : dateString
                 let isFuture = item.isFuture ?? false
@@ -131,10 +132,16 @@ struct BuildTimelinePreviewItem: View {
             mutableItem.isCurrent = Date.compareTwoDates(first: mutableItem.due, second: Date()) == .orderedSame
             return mutableItem
         }
-        // sort the data by due and filter data by display item count
-        let filteredItems = Array(updatedItems.sorted(by: { $0.due < $1.due }).prefix(self.displayItems))
         
-        return filteredItems
+        // sort by due date according to the environment sort order, then limit to displayItems
+        let sorted: [any TimelinePreviewItemModel]
+        switch self.sortOrder {
+        case .ascending:
+            sorted = updatedItems.sorted(by: { $0.due < $1.due })
+        case .descending:
+            sorted = updatedItems.sorted(by: { $0.due > $1.due })
+        }
+        return Array(sorted.prefix(self.displayItems))
     }
 }
 


### PR DESCRIPTION
Fixed these four bugs:
1. The custom date format doesn't work and always shows "MMMM d yyyy"
2. When the date is current, it still shows "April 13 2026 ", not "Today" 
3. The TimelineNodeType doesn't support add and delete icon (how the add and delete icon looks like is shown in below expected outcome)
4. The sort order of timeline Items is always time-ascending and can not change to time-descending
Dev result:
<img width="1640" height="2360" alt="Simulator Screenshot - iPad (A16) - 2026-04-22 at 15 26 46" src="https://github.com/user-attachments/assets/541d0327-83d9-4cd1-9609-75ead53b0015" />
