### PR TITLE
fix: 🐛 [1929] update attachments alignment to topLeading

### DIFF
--- a/Sources/FioriSwiftUICore/_FioriStyles/AttachmentGroupStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/AttachmentGroupStyle.fiori.swift
@@ -17,7 +17,7 @@ public struct AttachmentGroupBaseStyle: AttachmentGroupStyle {
                 .accessibilityHint(configuration.controlState == .readOnly ? "ready only".localizedFioriString() : "actions available".localizedFioriString())
                 .padding(.bottom, AttachmentConstants.extraTitleBottomPadding)
             
-            LazyVGrid(columns: Array(repeating: GridItem(.adaptive(minimum: AttachmentConstants.thumbnailWidth), alignment: .top), count: 1), spacing: AttachmentConstants.cellVerticalSpacing) {
+            LazyVGrid(columns: Array(repeating: GridItem(.adaptive(minimum: AttachmentConstants.thumbnailWidth), alignment: .topLeading), count: 1), spacing: AttachmentConstants.cellVerticalSpacing) {
                 if configuration.controlState != .readOnly {
                     if let maxCount = configuration.maxCount {
                         if maxCount > configuration.attachments.count {

--- a/Sources/FioriSwiftUICore/_FioriStyles/AttachmentGroupStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/AttachmentGroupStyle.fiori.swift
@@ -14,7 +14,7 @@ public struct AttachmentGroupBaseStyle: AttachmentGroupStyle {
             configuration.title
                 .id("Attachment:Title:\(configuration.title)")
                 .accessibilityIdentifier("Attachment:Title:\(configuration.title)")
-                .accessibilityHint(configuration.controlState == .readOnly ? "ready only".localizedFioriString() : "actions available".localizedFioriString())
+                .accessibilityHint(configuration.controlState == .readOnly ? "read only".localizedFioriString() : "actions available".localizedFioriString())
                 .padding(.bottom, AttachmentConstants.extraTitleBottomPadding)
             
             LazyVGrid(columns: Array(repeating: GridItem(.adaptive(minimum: AttachmentConstants.thumbnailWidth), alignment: .topLeading), count: 1), spacing: AttachmentConstants.cellVerticalSpacing) {


### PR DESCRIPTION
|before|after|
|-|-|
|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-30 at 10 42 05" src="https://github.com/user-attachments/assets/409fe1f2-3e58-46ff-8e49-d0e72d8a2ec3" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-30 at 10 33 28" src="https://github.com/user-attachments/assets/a7995f6e-12ee-42d1-84a8-1bbab3fe16f7" />|