### PR TITLE
fix: 🐛 [IOSSDKBUG-1891] [iOS] Extra space between the bottom of the timeline section and the dividing line

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/Timeline/TimelineItemsExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/Timeline/TimelineItemsExample.swift
@@ -20,7 +20,53 @@ struct TimelineItemsExample: View {
                         config.secondaryTimestamp.foregroundColor(.yellow)
                     })
             }
-            Section(header: Text("Timeline")) {
+            Section(header: Text("Timeline 0")) {
+                Timeline(
+                    timestamp: { Text("06/06/26") },
+                    secondaryTimestamp: { EmptyView() },
+                    timelineNode: { TimelineNodeView(.add) },
+                    icon: { EmptyView() },
+                    title: {
+                        EmptyView()
+                    },
+                    subtitle: {
+                        EmptyView()
+                    },
+                    attribute: { EmptyView() },
+                    status: { EmptyView() },
+                    substatus: { EmptyView() },
+                    subAttribute: { EmptyView() },
+                    isPast: false,
+                    isPresent: true
+                )
+                .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
+                .listRowSeparator(.hidden)
+                .modifier(CustomListRowModifier())
+            }
+            Section(header: Text("Timeline 1")) {
+                Timeline(
+                    timestamp: { Text("06/09/26") },
+                    secondaryTimestamp: { EmptyView() },
+                    timelineNode: { TimelineNodeView(.add) },
+                    icon: { TextOrIconView(TextOrIcon.icon(Image(fioriName: "fiori.browse.folder"))) },
+                    title: {
+                        Text("Expected proficiency level removed from job role")
+                    },
+                    subtitle: {
+                        Text("This is the subtitle of the timeline node")
+                    },
+                    attribute: { Text("Attribute title") },
+                    status: { Text("status") },
+                    substatus: { Text("sub status") },
+                    subAttribute: { Text("sub attribute") },
+                    isPast: false,
+                    isPresent: true
+                )
+                .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 0))
+                .listRowSeparator(.hidden)
+                .modifier(CustomListRowModifier())
+            }
+            Section(header: Text("Timeline 2")) {
                 Timeline(timestamp: "06/21/24", secondaryTimestamp: .icon(Image(systemName: "sun.max")), timelineNode: .complete, title: "Complete", subtitle: "abc", attribute: "attr", status: .text("Info"), substatus: .both("substatus", Image(systemName: "exclamationmark.circle")), subAttribute: "subAttr", isPast: true)
                     .modifier(CustomListRowModifier())
                     .secondaryTimestampStyle(content: { config in

--- a/Sources/FioriSwiftUICore/_FioriStyles/TimelineMarkerStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/TimelineMarkerStyle.fiori.swift
@@ -57,6 +57,7 @@ public struct TimelineMarkerBaseStyle: TimelineMarkerStyle {
                         configuration.title
                         Spacer()
                     }
+                    Spacer()
                     Divider()
                         .foregroundColor(Color.preferredColor(.separator).opacity(0.41))
                         .frame(height: 0.33)

--- a/Sources/FioriSwiftUICore/_FioriStyles/TimelineStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/TimelineStyle.fiori.swift
@@ -104,6 +104,7 @@ struct TimelineMainStack: View {
                 Spacer()
                 self.configuration.subAttribute
             }
+            Spacer()
             Divider()
                 .foregroundColor(Color.preferredColor(.separator).opacity(0.41))
                 .frame(height: 0.33)


### PR DESCRIPTION
Before:
<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-04-30 at 14 00 49" src="https://github.com/user-attachments/assets/ea2f9723-1fa6-42ff-8ffb-b2386e3aadb3" />

After:
<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-04-30 at 15 25 12" src="https://github.com/user-attachments/assets/58956e3a-da2e-4eb7-881d-de9127e8a90f" />
<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-04-30 at 15 02 44" src="https://github.com/user-attachments/assets/fe5177da-bc9e-4177-a806-55adfff3cfc2" />
<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-04-30 at 15 04 45" src="https://github.com/user-attachments/assets/c1b31035-350f-4ef8-a429-69faa99fe31b" />
