### PR TITLE
fix: 🐛 [1875] adjust button size for redo and undo in W.A

### DIFF
--- a/Sources/FioriSwiftUICore/AIWritingAssistant/InternalWAForm.swift
+++ b/Sources/FioriSwiftUICore/AIWritingAssistant/InternalWAForm.swift
@@ -131,7 +131,7 @@ struct InternalWAForm: View {
                     if self.context.rewriteTextSet.count > 1, section.id == sections.first?.id {
                         self.sectionHeader()
                             .textCase(nil)
-                            .frame(height: 60)
+                            .frame(minHeight: 60)
                             .listRowInsets(EdgeInsets())
                     }
                 } footer: {

--- a/Sources/FioriSwiftUICore/_FioriStyles/WritingAssistantFormStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/WritingAssistantFormStyle.fiori.swift
@@ -138,6 +138,7 @@ struct AIWAActionButtonStyle: FioriButtonStyle {
         let isPressed = configuration.state == .highlighted || configuration.state == .selected
         let isDisabled = configuration.state == .disabled
         return configuration.label
+            .padding(.horizontal)
             .frame(maxWidth: .infinity, minHeight: 38)
             .font(Font.fiori(forTextStyle: .body, weight: .semibold))
             .foregroundColor(.preferredColor(isPressed || isDisabled ? .quaternaryLabel : .secondaryLabel))


### PR DESCRIPTION
When using a very large dynamic type size, the button title may be truncated. So remove height limitation.