### PR TITLE
fix: 🐛 [1934] reorder voice over announcement for note form

### DIFF
--- a/Sources/FioriSwiftUICore/_FioriStyles/NoteFormViewStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/NoteFormViewStyle.fiori.swift
@@ -15,6 +15,16 @@ public struct NoteFormViewBaseStyle: NoteFormViewStyle {
                     .disabled(self.getDisabled(configuration))
             }
             .textInputInfoView(isPresented: Binding(get: { self.isInfoViewNeeded(configuration) }, set: { _ in }), description: self.getInfoString(configuration), counter: self.getCounterString(configuration))
+            .accessibilityRepresentation {
+                // text editor using content as its accessibility value which will read out at last, re-order, read it first.
+                VStack {
+                    Text(configuration.text)
+                    if !configuration.placeholder.isEmpty, configuration.text.isEmpty {
+                        configuration.placeholder
+                    }
+                    TextInputInfoView(icon: nil, description: self.getInfoString(configuration), counter: self.getCounterString(configuration))
+                }
+            }
             .accessibilityElement(children: .combine)
             .accessibilityHint(self.getAccessibilityHint(configuration, isFocused: self.isFocused))
         }


### PR DESCRIPTION
# Fix: Reorder VoiceOver Announcement for Note Form View

### Bug Fix

🐛 Fixed the VoiceOver accessibility announcement order for `NoteFormView`. Previously, the text editor used its content as the accessibility value, which was read out last. This change reorders the announcement so the content is read first, improving the accessibility experience.

### Changes

* `NoteFormViewStyle.fiori.swift`: Added an `.accessibilityRepresentation` modifier to the `NoteFormViewBaseStyle` layout. This custom representation explicitly places the text content, placeholder (when applicable), and the info/counter view in the correct reading order for VoiceOver, ensuring the text is announced before the hint and counter information.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.37`

- File Content Strategy: Full file content
- Event Trigger: `pull_request.opened`
- Correlation ID: `46143173-5dd1-40a1-8f1a-6df280b6d6ea`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- LLM: `anthropic--claude-4.6-sonnet`
</details>
