### PR TITLE
fix: 🐛 [1861]Enhanced FilterFeedbackBar's PickerItem

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/SortFilter/SortFilterExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/SortFilter/SortFilterExample.swift
@@ -13,7 +13,22 @@ struct SortFilterExample: View {
             .picker(item: .init(name: "List Many Status", value: [0], valueOptions: ["Received", "Started", "Hold", "Transfer", "Completed", "Pending Review Pending Pending Pending Pending Pending", "Accepted Medium", "Pending Medium", "Completed Medium", "Checked", "Unchecked", "Partially Checked", "Checked and Unchecked", "Checked and Partially Checked", "Unchecked and Partially Checked", "Partially Checked and Unchecked", "Checked and Unchecked and Partially Checked", "Unchecked and Partially Checked and Partially Checked", "Partially Checked and Unchecked and Partially Checked", "Checked Finally", "Unchecked Finally", "Partially Checked Finally", "Checked and Unchecked Finally", "Checked and Partially Checked Finally", "Unchecked and Partially Checked Finally", "Partially Checked and Unchecked Finally", "Checked Finally and Partially Checked Finally", "Unchecked Finally and Partially Checked Finally", "Partially Checked Finally and Partially Checked Finally", "Review", "Reviewed", "To be Reviewed", "Pending for Review", "Booked", "To be Booked", "Will Book", "Booking Canceled"], allowsMultipleSelection: true, allowsEmptySelection: true, barItemDisplayMode: .value, searchPrompt: "Search by status name", icon: "clock", itemLayout: .fixed, displayMode: .list), showsOnFilterFeedbackBar: true),
             .picker(item: .init(name: "Flexible Filter", value: [0], valueOptions: ["Received", "Started", "Hold", "Transfer", "Completed", "Pending Review Pending Pending Pending Pending Pending", "Accepted Medium", "Pending", "Completed Medium"], allowsMultipleSelection: true, allowsEmptySelection: true, barItemDisplayMode: .nameAndValue, icon: "clock", itemLayout: .flexible, displayMode: .filterFormCell), showsOnFilterFeedbackBar: true),
             .picker(item: .init(name: "Fixed Few Filter", value: [0], valueOptions: ["Received", "Started", "Hold", "Transfer", "Completed", "Pending Review Pending Pending Pending Pending Pending"], allowsMultipleSelection: false, allowsEmptySelection: true, barItemDisplayMode: .name, icon: "clock", itemLayout: .fixed, displayMode: .filterFormCell), showsOnFilterFeedbackBar: true),
-            .picker(item: .init(name: "Fixed Many Filter", value: [0], valueOptions: ["Received", "Started", "Hold", "Transfer", "Completed", "Pending Review Pending Pending Pending Pending Pending", "Accepted Medium", "Pending Medium", "Completed Medium", "Checked", "Unchecked", "Partially Checked", "Checked and Unchecked", "Checked and Partially Checked", "Unchecked and Partially Checked", "Partially Checked and Unchecked", "Checked and Unchecked and Partially Checked", "Unchecked and Partially Checked and Partially Checked", "Partially Checked and Unchecked and Partially Checked", "Checked Finally", "Unchecked Finally", "Partially Checked Finally", "Checked and Unchecked Finally", "Checked and Partially Checked Finally", "Unchecked and Partially Checked Finally", "Partially Checked and Unchecked Finally", "Checked Finally and Partially Checked Finally", "Unchecked Finally and Partially Checked Finally", "Partially Checked Finally and Partially Checked Finally", "Review", "Reviewed", "To be Reviewed", "Pending for Review", "Booked", "To be Booked", "Will Book", "Booking Canceled"], allowsMultipleSelection: false, allowsEmptySelection: true, barItemDisplayMode: .value, icon: "clock", itemLayout: .fixed, displayMode: .filterFormCell), showsOnFilterFeedbackBar: true)
+            .picker(item: .init(name: "Fixed Many Filter", value: [0], valueOptions: ["Received", "Started", "Hold", "Transfer", "Completed", "Pending Review Pending Pending Pending Pending Pending", "Accepted Medium", "Pending Medium", "Completed Medium", "Checked", "Unchecked", "Partially Checked", "Checked and Unchecked", "Checked and Partially Checked", "Unchecked and Partially Checked", "Partially Checked and Unchecked", "Checked and Unchecked and Partially Checked", "Unchecked and Partially Checked and Partially Checked", "Partially Checked and Unchecked and Partially Checked", "Checked Finally", "Unchecked Finally", "Partially Checked Finally", "Checked and Unchecked Finally", "Checked and Partially Checked Finally", "Unchecked and Partially Checked Finally", "Partially Checked and Unchecked Finally", "Checked Finally and Partially Checked Finally", "Unchecked Finally and Partially Checked Finally", "Partially Checked Finally and Partially Checked Finally", "Review", "Reviewed", "To be Reviewed", "Pending for Review", "Booked", "To be Booked", "Will Book", "Booking Canceled"], allowsMultipleSelection: false, allowsEmptySelection: true, barItemDisplayMode: .value, icon: "clock", itemLayout: .fixed, displayMode: .filterFormCell), showsOnFilterFeedbackBar: true),
+            // custom search filter
+            .picker(item: .init(name: "Product", value: [0], valueOptions: ["MacBook Pro 16\"", "iPad Air M3", "iPhone 17 Pro", "Apple Watch Ultra 3", "AirPods Pro 3"], allowsMultipleSelection: true, allowsEmptySelection: true, barItemDisplayMode: .name, displayMode: .list, configuration: SortFilterItem.PickerItemConfiguration(searchFilter: { displayText, query in displayText.localizedCaseInsensitiveContains(query) || displayText.split(separator: " ").contains { $0.localizedCaseInsensitiveContains(query) } })), showsOnFilterFeedbackBar: true),
+            // custom row content with subtitle
+            .picker(item: .init(name: "Assignee", value: [Int](), valueOptions: ["Alice Johnson", "Bob Smith", "Charlie Brown", "Diana Prince"], allowsMultipleSelection: false, allowsEmptySelection: true, barItemDisplayMode: .value, displayMode: .list, configuration: SortFilterItem.PickerItemConfiguration(rowContentProvider: { index in
+                let names = ["Alice Johnson", "Bob Smith", "Charlie Brown", "Diana Prince"]
+                let departments = ["Engineering", "Design", "Marketing", "Management"]
+                return AnyView(VStack(alignment: .leading, spacing: 2) {
+                    Text(names[index])
+                    Text(departments[index]).font(.caption).foregroundStyle(.secondary)
+                })
+            })), showsOnFilterFeedbackBar: true)
+        ],
+        [
+            // pagination: initial 20 items, more loaded on scroll
+            .picker(item: .init(id: "pagination-employee", name: "Employee", value: [Int](), valueOptions: (1 ... 20).map { "Employee \($0)" }, allowsMultipleSelection: false, allowsEmptySelection: true, barItemDisplayMode: .value, displayMode: .list, configuration: SortFilterItem.PickerItemConfiguration(hasMoreData: true)), showsOnFilterFeedbackBar: true)
         ],
         [
             .picker(item: .init(name: "Priority", value: [0], valueOptions: ["High", "Medium", "Low"], allowsMultipleSelection: false, allowsEmptySelection: true, barItemDisplayMode: .nameAndValue, icon: "filemenu.and.cursorarrow"), showsOnFilterFeedbackBar: true),
@@ -56,6 +71,13 @@ struct SortFilterExample: View {
     @State private var isCustomStyle: Bool = false
     @State private var sortFilterList: [String] = []
     @State private var sortFilterButtonLabel: String = "Sort & Filter"
+
+    // Pagination state
+    @State private var paginatedNames: [String] = (1 ... 20).map { "Employee \($0)" }
+    @State private var paginationPage: Int = 1
+    @State private var paginationHasMore: Bool = true
+    private let paginationPageSize = 20
+    private let paginationTotal = 100
 
     var body: some View {
         VStack {
@@ -109,10 +131,76 @@ struct SortFilterExample: View {
         }
         .navigationTitle("Sort & Filter")
         .onAppear {
+            self.injectPaginationCallback()
             self.performSortAndFilter()
         }
     }
-    
+
+    // MARK: - Pagination helpers
+
+    private let paginationSectionIndex = 1
+
+    private func injectPaginationCallback() {
+        // Replace the pagination section's picker with one that has the onLoadMore callback
+        self.items[self.paginationSectionIndex] = [self.buildPaginatedPicker()]
+    }
+
+    private func loadMoreEmployees() {
+        let start = self.paginationPage * self.paginationPageSize
+        let end = min(start + self.paginationPageSize, self.paginationTotal)
+        guard start < end else {
+            self.paginationHasMore = false
+            return
+        }
+
+        for i in start ..< end {
+            self.paginatedNames.append("Employee \(i + 1)")
+        }
+        self.paginationPage += 1
+        self.paginationHasMore = end < self.paginationTotal
+
+        // Preserve current selection when rebuilding
+        let currentValue: [Int]
+        if case .picker(let item, _) = self.items[self.paginationSectionIndex][0] {
+            currentValue = item.workingValue
+        } else {
+            currentValue = []
+        }
+
+        let picker: SortFilterItem = .picker(item: .init(
+            id: "pagination-employee",
+            name: "Employee",
+            value: currentValue,
+            valueOptions: self.paginatedNames,
+            allowsMultipleSelection: false,
+            allowsEmptySelection: true,
+            barItemDisplayMode: .value,
+            displayMode: .list,
+            configuration: SortFilterItem.PickerItemConfiguration(
+                onLoadMore: { self.loadMoreEmployees() },
+                hasMoreData: self.paginationHasMore
+            )
+        ), showsOnFilterFeedbackBar: true)
+        self.items[self.paginationSectionIndex] = [picker]
+    }
+
+    private func buildPaginatedPicker() -> SortFilterItem {
+        .picker(item: .init(
+            id: "pagination-employee",
+            name: "Employee",
+            value: [Int](),
+            valueOptions: self.paginatedNames,
+            allowsMultipleSelection: false,
+            allowsEmptySelection: true,
+            barItemDisplayMode: .value,
+            displayMode: .list,
+            configuration: SortFilterItem.PickerItemConfiguration(
+                onLoadMore: { self.loadMoreEmployees() },
+                hasMoreData: self.paginationHasMore
+            )
+        ), showsOnFilterFeedbackBar: true)
+    }
+
     func numberOfItems() -> Int {
         // randomly padding result to mimic impact of filtering
         for i in 0 ... Int.random(in: 0 ... 5) {

--- a/Sources/FioriSwiftUICore/DataTypes/SortFilter+DataType.swift
+++ b/Sources/FioriSwiftUICore/DataTypes/SortFilter+DataType.swift
@@ -672,6 +672,47 @@ public enum OptionListPickerItemLayoutType {
 }
 
 public extension SortFilterItem {
+    /// Configuration for advanced PickerItem capabilities.
+    /// When provided, enables features like custom search, custom row content, and pagination.
+    struct PickerItemConfiguration: Equatable {
+        /// Custom search filter closure. Receives (displayText, searchText) and returns Bool.
+        /// When nil, the default `localizedCaseInsensitiveContains` is used.
+        public var searchFilter: ((String, String) -> Bool)?
+
+        /// Type-erased closure that produces a custom row view for a given option index.
+        /// When nil, the default `Text(valueOptions[index])` is used.
+        public var rowContentProvider: ((Int) -> AnyView)?
+
+        /// Callback invoked when the list scrolls near the end of current data.
+        /// The consumer should load more data and update `valueOptions` on the PickerItem.
+        public var onLoadMore: (() -> Void)?
+
+        /// Indicates whether more data is available for pagination.
+        public var hasMoreData: Bool
+
+        /// Create a PickerItemConfiguration.
+        /// - Parameters:
+        ///   - searchFilter: Custom search filter closure receiving (displayText, searchText).
+        ///   - rowContentProvider: Type-erased closure producing a custom row view for a given option index.
+        ///   - onLoadMore: Callback invoked when the list scrolls near the end of current data.
+        ///   - hasMoreData: Indicates whether more data is available for pagination.
+        public init(
+            searchFilter: ((String, String) -> Bool)? = nil,
+            rowContentProvider: ((Int) -> AnyView)? = nil,
+            onLoadMore: (() -> Void)? = nil,
+            hasMoreData: Bool = false
+        ) {
+            self.searchFilter = searchFilter
+            self.rowContentProvider = rowContentProvider
+            self.onLoadMore = onLoadMore
+            self.hasMoreData = hasMoreData
+        }
+
+        public static func == (lhs: PickerItemConfiguration, rhs: PickerItemConfiguration) -> Bool {
+            lhs.hasMoreData == rhs.hasMoreData
+        }
+    }
+
     ///  Data structure for filter feedback, option list picker,
     struct PickerItem: Identifiable, Equatable {
         public let id: String
@@ -696,7 +737,10 @@ public extension SortFilterItem {
         var disableListContentSection: Bool = false
         var allowsDisplaySelectionCount: Bool = true
         var resetButtonConfiguration: FilterFeedbackBarResetButtonConfiguration = .init()
-        
+
+        /// Advanced configuration for custom search, row content, and pagination.
+        public var configuration: PickerItemConfiguration?
+
         var uuidValueOptions: [ValueOptionModel] = []
         var workingValueSet: Set<UUID> = []
         
@@ -765,8 +809,9 @@ public extension SortFilterItem {
         ///   - disableContentSection: A boolean value to control the display of the unselected area section.
         ///   - allowsDisplaySelectionCount: A boolean value to indicate to allow display selection count or not.
         ///   - resetButtonConfiguration: A configuration to customize the reset button.
-        public init(id: String = UUID().uuidString, name: String, title: String? = nil, value: Int, valueOptions: [String], allowsEmptySelection: Bool, barItemDisplayMode: BarItemDisplayMode = .name, searchPrompt: String? = nil, isSearchBarHidden: Bool = false, icon: String? = nil, itemLayout: OptionListPickerItemLayoutType = .fixed, displayMode: DisplayMode = .automatic, listEntriesSectionMode: ListEntriesSectionMode = .default, disableContentSection: Bool = false, allowsDisplaySelectionCount: Bool = true, resetButtonConfiguration: FilterFeedbackBarResetButtonConfiguration = FilterFeedbackBarResetButtonConfiguration()) {
-            self.init(id: id, name: name, title: title, value: [value], valueOptions: valueOptions, allowsMultipleSelection: false, allowsEmptySelection: allowsEmptySelection, barItemDisplayMode: barItemDisplayMode, searchPrompt: searchPrompt, isSearchBarHidden: isSearchBarHidden, icon: icon, itemLayout: itemLayout, displayMode: displayMode, listEntriesSectionMode: listEntriesSectionMode, disableContentSection: disableContentSection, allowsDisplaySelectionCount: allowsDisplaySelectionCount, resetButtonConfiguration: resetButtonConfiguration)
+        ///   - configuration: Advanced configuration for custom search, row content, pagination, and display/data value separation.
+        public init(id: String = UUID().uuidString, name: String, title: String? = nil, value: Int, valueOptions: [String], allowsEmptySelection: Bool, barItemDisplayMode: BarItemDisplayMode = .name, searchPrompt: String? = nil, isSearchBarHidden: Bool = false, icon: String? = nil, itemLayout: OptionListPickerItemLayoutType = .fixed, displayMode: DisplayMode = .automatic, listEntriesSectionMode: ListEntriesSectionMode = .default, disableContentSection: Bool = false, allowsDisplaySelectionCount: Bool = true, resetButtonConfiguration: FilterFeedbackBarResetButtonConfiguration = FilterFeedbackBarResetButtonConfiguration(), configuration: PickerItemConfiguration? = nil) {
+            self.init(id: id, name: name, title: title, value: [value], valueOptions: valueOptions, allowsMultipleSelection: false, allowsEmptySelection: allowsEmptySelection, barItemDisplayMode: barItemDisplayMode, searchPrompt: searchPrompt, isSearchBarHidden: isSearchBarHidden, icon: icon, itemLayout: itemLayout, displayMode: displayMode, listEntriesSectionMode: listEntriesSectionMode, disableContentSection: disableContentSection, allowsDisplaySelectionCount: allowsDisplaySelectionCount, resetButtonConfiguration: resetButtonConfiguration, configuration: configuration)
         }
         
         /// Create PickerItem for filter feedback.
@@ -789,7 +834,8 @@ public extension SortFilterItem {
         ///   - disableContentSection: A boolean value to control the display of the unselected area section.
         ///   - allowsDisplaySelectionCount: A boolean value to indicate to allow display selection count or not.
         ///   - resetButtonConfiguration: A configuration to customize the reset button.
-        public init(id: String = UUID().uuidString, name: String, title: String? = nil, value: [Int], valueOptions: [String], allowsMultipleSelection: Bool, allowsEmptySelection: Bool, barItemDisplayMode: BarItemDisplayMode = .name, searchPrompt: String? = nil, isSearchBarHidden: Bool = false, icon: String? = nil, itemLayout: OptionListPickerItemLayoutType = .fixed, displayMode: DisplayMode = .automatic, listEntriesSectionMode: ListEntriesSectionMode = .default, disableContentSection: Bool = false, allowsDisplaySelectionCount: Bool = true, resetButtonConfiguration: FilterFeedbackBarResetButtonConfiguration = FilterFeedbackBarResetButtonConfiguration()) {
+        ///   - configuration: Advanced configuration for custom search, row content, pagination, and display/data value separation.
+        public init(id: String = UUID().uuidString, name: String, title: String? = nil, value: [Int], valueOptions: [String], allowsMultipleSelection: Bool, allowsEmptySelection: Bool, barItemDisplayMode: BarItemDisplayMode = .name, searchPrompt: String? = nil, isSearchBarHidden: Bool = false, icon: String? = nil, itemLayout: OptionListPickerItemLayoutType = .fixed, displayMode: DisplayMode = .automatic, listEntriesSectionMode: ListEntriesSectionMode = .default, disableContentSection: Bool = false, allowsDisplaySelectionCount: Bool = true, resetButtonConfiguration: FilterFeedbackBarResetButtonConfiguration = FilterFeedbackBarResetButtonConfiguration(), configuration: PickerItemConfiguration? = nil) {
             self.id = id
             self.name = name
             self.title = title
@@ -797,6 +843,7 @@ public extension SortFilterItem {
             self.workingValue = value
             self.originalValue = value
             self.valueOptions = valueOptions
+            self.configuration = configuration
             self.uuidValueOptions = valueOptions.enumerated().map { index, option in
                 ValueOptionModel(index: index, value: option)
             }
@@ -936,6 +983,21 @@ public extension SortFilterItem {
         
         var isOriginal: Bool {
             self.workingValue == self.originalValue
+        }
+
+        /// Append new options to the picker without resetting selection state.
+        /// Use this for pagination scenarios where data is loaded incrementally.
+        /// - Parameters:
+        ///   - newOptions: Display texts to append.
+        ///   - hasMoreData: Whether more data is still available after this append.
+        public mutating func appendOptions(_ newOptions: [String], hasMoreData: Bool = false) {
+            let startIndex = self.valueOptions.count
+            self.valueOptions.append(contentsOf: newOptions)
+            let newModels = newOptions.enumerated().map { offset, option in
+                ValueOptionModel(index: startIndex + offset, value: option)
+            }
+            self.uuidValueOptions.append(contentsOf: newModels)
+            self.configuration?.hasMoreData = hasMoreData
         }
     }
     

--- a/Sources/FioriSwiftUICore/Views/SortFilter/FilterFeedbackBarItemSubview.swift
+++ b/Sources/FioriSwiftUICore/Views/SortFilter/FilterFeedbackBarItemSubview.swift
@@ -381,13 +381,25 @@ struct PickerMenuItem: View {
                             self.item.apply()
                             self.onUpdate()
                         } label: {
-                            Label { Text(self.item.valueOptions[idx]) } icon: { Image(fioriName: "fiori.accept") }
+                            Label {
+                                if let provider = self.item.configuration?.rowContentProvider {
+                                    provider(idx)
+                                } else {
+                                    Text(self.item.valueOptions[idx])
+                                }
+                            } icon: { Image(fioriName: "fiori.accept") }
                         }
                     } else {
-                        Button(self.item.valueOptions[idx]) {
+                        Button {
                             self.item.optionOnTap(idx)
                             self.item.apply()
                             self.onUpdate()
+                        } label: {
+                            if let provider = self.item.configuration?.rowContentProvider {
+                                provider(idx)
+                            } else {
+                                Text(self.item.valueOptions[idx])
+                            }
                         }
                     }
                 }
@@ -481,6 +493,9 @@ struct PickerMenuItem: View {
     @MainActor private func configListPickerDestination() -> some View {
         let filter: ((SortFilterItem.PickerItem.ValueOptionModel, String) -> Bool) = { f, s in
             if !s.isEmpty {
+                if let customFilter = self.item.configuration?.searchFilter {
+                    return customFilter(f.value, s)
+                }
                 return f.value.localizedCaseInsensitiveContains(s)
             } else {
                 return true
@@ -493,7 +508,27 @@ struct PickerMenuItem: View {
                 self.$item.workingValueSet.asOptionalSelection() :
                 self.$item.workingValueSet.asRequiredSelection(defaultValue: defaultSingleSelection).toOptionalBinding()
         }
-        
+
+        let rowContentBuilder: (SortFilterItem.PickerItem.ValueOptionModel) -> AnyView = { e in
+            if let provider = self.item.configuration?.rowContentProvider {
+                return AnyView(provider(e.index).destinationRowBackgroundColor(.clear))
+            } else {
+                return AnyView(Text(e.value).destinationRowBackgroundColor(.clear))
+            }
+        }
+
+        let paginationRowContent: (SortFilterItem.PickerItem.ValueOptionModel) -> AnyView = { e in
+            let baseView = rowContentBuilder(e)
+            if e.index == self.item.uuidValueOptions.count - 1,
+               self.item.configuration?.hasMoreData == true
+            {
+                return AnyView(baseView.onAppear {
+                    self.item.configuration?.onLoadMore?()
+                })
+            }
+            return baseView
+        }
+
         let listPickerDestination = self.item.allowsMultipleSelection ?
             ListPickerDestination(
                 self.item.uuidValueOptions,
@@ -504,8 +539,7 @@ struct PickerMenuItem: View {
                 searchPrompt: self.item.searchPrompt,
                 searchFilter: self.item.isSearchBarHidden == false ? filter : nil
             ) { e in
-                Text(e.value)
-                    .destinationRowBackgroundColor(.clear)
+                paginationRowContent(e)
             } :
             ListPickerDestination(
                 self.item.uuidValueOptions,
@@ -515,8 +549,7 @@ struct PickerMenuItem: View {
                 searchPrompt: self.item.searchPrompt,
                 searchFilter: self.item.isSearchBarHidden == false ? filter : nil
             ) { e in
-                Text(e.value)
-                    .destinationRowBackgroundColor(.clear)
+                paginationRowContent(e)
             }
         return listPickerDestination
             .disableEntriesSection(self.item.disableListEntriesSection)

--- a/Sources/FioriSwiftUICore/Views/SortFilter/SortFilterCFGItemContainer.swift
+++ b/Sources/FioriSwiftUICore/Views/SortFilter/SortFilterCFGItemContainer.swift
@@ -216,12 +216,23 @@ extension SortFilterCFGItemContainer: View {
     func listPickerDestination(row r: Int, column c: Int) -> some View {
         let filter: ((SortFilterItem.PickerItem.ValueOptionModel, String) -> Bool) = { f, s in
             if !s.isEmpty {
+                if let customFilter = self._items[r][c].picker.configuration?.searchFilter {
+                    return customFilter(f.value, s)
+                }
                 return f.value.localizedCaseInsensitiveContains(s)
             } else {
                 return true
             }
         }
-        
+
+        let rowContentBuilder: (SortFilterItem.PickerItem.ValueOptionModel) -> AnyView = { e in
+            if let provider = self._items[r][c].picker.configuration?.rowContentProvider {
+                return AnyView(provider(e.index))
+            } else {
+                return AnyView(Text(e.value))
+            }
+        }
+
         return ListPickerDestination(self._items[r][c].picker.uuidValueOptions,
                                      id: \.id,
                                      selections: Binding<Set<UUID>>(get: { self._items[r][c].picker.workingValueSet }, set: { self._items[r][c].picker.workingValueSet = $0 }),
@@ -229,7 +240,16 @@ extension SortFilterCFGItemContainer: View {
                                      isTrackingLiveChanges: true,
                                      searchFilter: self._items[r][c].picker.isSearchBarHidden == false ? filter : nil)
         { e in
-            Text(e.value)
+            let baseView = rowContentBuilder(e)
+            if e.index == self._items[r][c].picker.uuidValueOptions.count - 1,
+               self._items[r][c].picker.configuration?.hasMoreData == true
+            {
+                AnyView(baseView.onAppear {
+                    self._items[r][c].picker.configuration?.onLoadMore?()
+                })
+            } else {
+                baseView
+            }
         }
         .disableEntriesSection(self._items[r][c].picker.disableListEntriesSection)
         .disableContentSection(self._items[r][c].picker.disableListContentSection)
@@ -452,12 +472,24 @@ extension SortFilterCFGItemContainer: View {
                             self._items[r][c].picker.onTap(option: self._items[r][c].picker.valueOptions[idx])
                             self._items[r][c].picker.apply()
                         } label: {
-                            Label { Text(self._items[r][c].picker.valueOptions[idx]) } icon: { Image(fioriName: "fiori.accept") }
+                            Label {
+                                if let provider = self._items[r][c].picker.configuration?.rowContentProvider {
+                                    provider(idx)
+                                } else {
+                                    Text(self._items[r][c].picker.valueOptions[idx])
+                                }
+                            } icon: { Image(fioriName: "fiori.accept") }
                         }
                     } else {
-                        Button(self._items[r][c].picker.valueOptions[idx]) {
+                        Button {
                             self._items[r][c].picker.onTap(option: self._items[r][c].picker.valueOptions[idx])
                             self._items[r][c].picker.apply()
+                        } label: {
+                            if let provider = self._items[r][c].picker.configuration?.rowContentProvider {
+                                provider(idx)
+                            } else {
+                                Text(self._items[r][c].picker.valueOptions[idx])
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Enhanced FilterFeedbackBar's PickerItem to support advanced list picker scenarios including custom search, custom row content, and pagination — addressing feature gaps compared to UIKit's FUIListPicker.
                                                                                                                                          
 ### Background                                                                                                                              
  
Customers reported that the current PickerItem implementation only accepts valueOptions: [String] with hardcoded search logic, making it impossible to:                                           
  1. Customize search filtering behavior (UIKit provides FUIListPickerSearchResultsUpdating)                                              
  2. Display rich row content (UIKit provides FUIListPickerDataSource with cell delegates)                                                
  3. Support pagination / lazy loading for large datasets                                 
                                                                                                                                          
 ### Changes                                                                                                                                 
                                                                                                                                          
  New Type: SortFilterItem.PickerItemConfiguration (SortFilter+DataType.swift)                                                            
  - searchFilter: ((String, String) -> Bool)? — Custom local search filter replacing the default localizedCaseInsensitiveContains         
  - rowContentProvider: ((Int) -> AnyView)? — Custom row view for each option by index                                                    
  - onLoadMore: (() -> Void)? — Callback triggered when list scrolls to the last item 
  - hasMoreData: Bool — Controls whether pagination trigger is active                                                                     
                                                                                                                                          
  New Method: PickerItem.appendOptions(_:hasMoreData:) (SortFilter+DataType.swift)                                                        
  - Appends new options in-place without resetting selection state                                                                        
  - Designed for pagination scenarios where data is loaded incrementally                                                                  
                                                                                                                                          
  PickerItem Init Update (SortFilter+DataType.swift)                                                                                      
  - Added optional configuration: PickerItemConfiguration? = nil parameter to both existing initializers                                  
  - Fully backward-compatible — existing code compiles without changes                                                                    
                                                                                                                                          
  Rendering Layer Updates (FilterFeedbackBarItemSubview.swift, SortFilterCFGItemContainer.swift)                                          
  - List mode: uses custom searchFilter and rowContentProvider when configured; triggers onLoadMore on last row appearance                
  - Menu mode: uses custom rowContentProvider when configured                                                                             
                                                                                                                                          
  ### Example (SortFilterExample.swift)                                                                                                       
  - Added "Product" picker demonstrating custom word-based search                                                                         
  - Added "Assignee" picker demonstrating custom row content with subtitle                                                                
  - Added "Employee" picker demonstrating pagination (loads 20 items per page up to 100)