### PR TITLE
fix: 🐛 [1658]hide Selected section during search in ListPicker

### DIFF
--- a/Sources/FioriSwiftUICore/_FioriStyles/ListPickerDestinationStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/ListPickerDestinationStyle.fiori.swift
@@ -746,7 +746,7 @@ struct ListPickerDestinationContent<Data: RandomAccessCollection, ID: Hashable, 
         if self.isSingleSelection {
             return self.isListContentOutOfView && !self.disableEntriesSection
         } else {
-            return self.isTopLevel && !self.disableEntriesSection && self.destinationConfiguration != nil
+            return self.isTopLevel && !self.disableEntriesSection && self.destinationConfiguration != nil && self.searchText.isEmpty
         }
     }
     


### PR DESCRIPTION
Summary                                                                                                                                                                                                                                                                      
  - When allowsMultipleSelection is enabled and many items are selected, the "Selected" section occupies too much space, pushing search   
  results (in the "All" section) out of the visible area    
  - Fix: automatically hide the "Selected" section when the user is actively searching, so filtered results are immediately visible  without scrolling                                                                                                                       
  
  Changes                                                                                                                                 
                                                            
  - Sources/FioriSwiftUICore/_FioriStyles/ListPickerDestinationStyle.fiori.swift                                                          
  - Added && self.searchText.isEmpty condition to showSelectedSection for the multiple-selection branch
                                                                                                                                          
  Behavior  
| State | Selected Section | All Section |
| :--- | :--- | :--- |
| No search text | Visible (normal) | Below selected |
| Searching | Hidden | Full visible area |
| Clear search | Reappears with selections intact | Normal position |