### PR TITLE
fix: add a test

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/Tag/TagExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/Tag/TagExample.swift
@@ -12,7 +12,8 @@ struct TagExample: View {
         "Emoji 😀",
         "Empty Label",
         "Multiline Label\nSecond Line",
-        "Custom View"
+        "Custom View",
+        "M5"
     ]
     // AttributedString for tag
     var attributedTag: AttributedString {


### PR DESCRIPTION
# Add M5 Tag Example Test Case

### Bug Fix / Test

🧪 Added a missing test case entry to the `TagExample` view to ensure the `M5` tag scenario is covered.

### Changes

* `Apps/Examples/Examples/FioriSwiftUICore/Tag/TagExample.swift`: Added `"M5"` to the list of tag examples and fixed a missing trailing comma after `"Custom View"`.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.47`

- LLM: `anthropic--claude-4.6-sonnet`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- File Content Strategy: Full file content
- Event Trigger: `pull_request.opened`
- Correlation ID: `d23a4f0c-a2b3-4c76-9c87-f0263f88d6b9`
</details>
