### PR TITLE
fix: 🐛 [IOSSDKBUG-1222] Icons in IconStack getting overlapped

### DIFF
--- a/Sources/FioriSwiftUICore/Views/IconStack/IconBuilder.swift
+++ b/Sources/FioriSwiftUICore/Views/IconStack/IconBuilder.swift
@@ -18,16 +18,38 @@ public protocol ViewList: View, _ViewEmptyChecking {
 }
 
 /// conform View protocol for IconStack
+private struct IconSizeKey: EnvironmentKey {
+    static let defaultValue: CGFloat = 14
+}
+
+extension EnvironmentValues {
+    var iconSize: CGFloat {
+        get { self[IconSizeKey.self] }
+        set { self[IconSizeKey.self] = newValue }
+    }
+}
+
 public extension ViewList {
     var body: some View {
-        VStack(spacing: 6) {
-            ForEach(0 ..< min(numberOfIconsToShow(), count), id: \.self) { index in
-                view(at: index)
+        IconStackSizedBody(viewList: self)
+    }
+}
+
+private struct IconStackSizedBody<V: ViewList>: View {
+    let viewList: V
+    @ScaledMetric(relativeTo: .body) var scaledSize: CGFloat = 14
+
+    var body: some View {
+        VStack(alignment: .center, spacing: 6) {
+            ForEach(0 ..< min(self.viewList.numberOfIconsToShow(), self.viewList.count), id: \.self) { index in
+                self.viewList.view(at: index)
                     .lineLimit(1)
                     .minimumScaleFactor(0.1)
-                    .frame(width: 14, height: 14)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(width: self.scaledSize)
             }
         }
+        .frame(width: self.scaledSize)
     }
 }
 

--- a/Sources/FioriSwiftUICore/Views/IconStack/IconStack+View.swift
+++ b/Sources/FioriSwiftUICore/Views/IconStack/IconStack+View.swift
@@ -26,6 +26,8 @@ extension IconStack: ViewList {
                 Text(txt)
             case .icon(let icon):
                 icon
+                    .resizable()
+                    .scaledToFit()
             case .both(let txt, _):
                 Text(txt)
             }


### PR DESCRIPTION
Fixed the issue: IOSSDKBUG-1222 ACC- 260.2 (WCAG 2.2, 1.4.4, Level AA) _ SAP BTP SDK for IOS_ iPad_ Ui’s _ After applying large text setting the Ui’s getting overlapped.

Before:
<img width="342" height="194" alt="Screenshot 2026-05-19 at 16 31 45" src="https://github.com/user-attachments/assets/4be10687-94fb-424b-9add-ebe52533727c" />
After:
<img width="342" height="220" alt="Screenshot 2026-05-19 at 16 13 36" src="https://github.com/user-attachments/assets/adad9d9c-ccbf-4f69-a8d3-ddd21cf6a5a1" />
