### PR TITLE
fix: 🐛 [1936] keep focus in text editor when wa panel dismissed

### DIFF
--- a/Sources/FioriSwiftUICore/AIWritingAssistant/WATextInput.swift
+++ b/Sources/FioriSwiftUICore/AIWritingAssistant/WATextInput.swift
@@ -366,7 +366,7 @@ struct WATextInputModifier: ViewModifier {
             if !self.context.isInWAFlow {
                 textView.inputView = nil
                 textView.isEditable = true
-                textView.resignFirstResponder()
+                textView.becomeFirstResponder()
                 return
             }
             if useWAPanel {
@@ -386,7 +386,7 @@ struct WATextInputModifier: ViewModifier {
         } else if let textField = self.context.waTextInput as? UITextField {
             if !self.context.isInWAFlow {
                 textField.inputView = nil
-                textField.resignFirstResponder()
+                textField.becomeFirstResponder()
                 return
             }
             if useWAPanel {


### PR DESCRIPTION
# Fix: Keep Focus in Text Editor When WA Panel Is Dismissed

### Bug Fix

🐛 Fixes an issue where focus was lost in the text editor when the Writing Assistant (WA) panel was dismissed. Previously, when the WA flow was not active, `resignFirstResponder()` was called on both `UITextView` and `UITextField`, causing the keyboard to dismiss and focus to be lost. This is corrected by calling `becomeFirstResponder()` instead, ensuring the text input retains focus.

### Changes

* `Sources/FioriSwiftUICore/AIWritingAssistant/WATextInput.swift`: Replaced `resignFirstResponder()` with `becomeFirstResponder()` in the `switchKeyboard(useWAPanel:)` method for both `UITextView` and `UITextField` when the WA flow is not active, so the text editor retains focus after the WA panel is dismissed.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.51`

- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- LLM: `anthropic--claude-4.6-sonnet`
- File Content Strategy: Full file content
- Correlation ID: `5ae36dcd-3a97-4e6d-9a94-fb755c2d194a`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.opened`
</details>
