### PR TITLE
fix: 🐛 [1936] keep focus in text editor when wa panel dismissed

### DIFF
--- a/Sources/FioriSwiftUICore/AIWritingAssistant/WATextInput.swift
+++ b/Sources/FioriSwiftUICore/AIWritingAssistant/WATextInput.swift
@@ -366,7 +366,7 @@ struct WATextInputModifier: ViewModifier {
             if !self.context.isInWAFlow {
                 textView.inputView = nil
                 textView.isEditable = true
-                textView.resignFirstResponder()
+                textView.becomeFirstResponder()
                 return
             }
             if useWAPanel {
@@ -386,7 +386,7 @@ struct WATextInputModifier: ViewModifier {
         } else if let textField = self.context.waTextInput as? UITextField {
             if !self.context.isInWAFlow {
                 textField.inputView = nil
-                textField.resignFirstResponder()
+                textField.becomeFirstResponder()
                 return
             }
             if useWAPanel {


### PR DESCRIPTION
# Fix: Keep Focus in Text Editor When WA Panel Is Dismissed

### Bug Fix

🐛 Resolved an issue where the text editor lost focus when the Writing Assistant (WA) panel was dismissed. Previously, `resignFirstResponder()` was incorrectly called when switching the keyboard back to the normal input state outside of the WA flow, causing the editor to lose focus. This has been replaced with `becomeFirstResponder()` to retain focus.

### Changes

* `Sources/FioriSwiftUICore/AIWritingAssistant/WATextInput.swift`: Replaced `resignFirstResponder()` with `becomeFirstResponder()` in the `switchKeyboard(useWAPanel:)` method for both `UITextView` and `UITextField` when the WA flow is not active, ensuring the text input retains focus after the WA panel is dismissed.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.51`

- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Correlation ID: `6fe7e383-0fc9-41b8-86cc-e35dcd59a0d9`
- LLM: `anthropic--claude-4.6-sonnet`
- File Content Strategy: Full file content
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.opened`
</details>
