### PR TITLE
fix: 🐛 [2138] Add hidesSeparator support to all pickers

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/Picker/DateRangePickerExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/Picker/DateRangePickerExample.swift
@@ -13,6 +13,17 @@ struct DateRangePickerExample: View {
     @State private var pickerVisible3 = false
     @State private var pickerVisible4 = false
     @State private var pickerVisible5 = false
+
+    @State private var customizeSeparator = false
+    @State private var showSeparator = true
+    @State private var separatorColorIndex = 0
+    @State private var separatorLineWidth: CGFloat = 0.33
+    private let separatorColors: [(String, Color)] = [
+        ("Default", Color.preferredColor(.separatorOpaque)),
+        ("Red", .red),
+        ("Blue", .blue),
+        ("Green", .green)
+    ]
     
     // Limit the selectable dates from last seven days to next seven days
     private var limitDateRange: Range<Date> = Date(timeIntervalSinceNow: -60 * 60 * 24 * 7) ..< Date(timeIntervalSinceNow: 60 * 60 * 24 * 7)
@@ -82,6 +93,22 @@ struct DateRangePickerExample: View {
                 .tint(Color.preferredColor(.tintColor))
             Toggle("Picker Visible", isOn: self.managePickerVisibleBinding)
                 .tint(Color.preferredColor(.tintColor))
+            Section("Picker Separator") {
+                Toggle("Customize Separator", isOn: self.$customizeSeparator)
+                    .tint(Color.preferredColor(.tintColor))
+                if self.customizeSeparator {
+                    Toggle("Show Separator", isOn: self.$showSeparator)
+                        .tint(Color.preferredColor(.tintColor))
+                    Picker("Color", selection: self.$separatorColorIndex) {
+                        ForEach(0 ..< self.separatorColors.count, id: \.self) { index in
+                            Text(self.separatorColors[index].0).tag(index)
+                        }
+                    }
+                    Stepper(value: self.$separatorLineWidth, in: 0.33 ... 5.0, step: 0.33) {
+                        Text(String(format: "Line Width: %.2f", self.separatorLineWidth))
+                    }
+                }
+            }
             Section(header: Text("")) {
                 DateRangePicker(title: "Range Selection Long Title Long Title Long Title Long Title Long Title Long Title0", mandatoryFieldIndicator: self.mandatoryFieldIndicator(), isRequired: self.isRequired, selectedRange: self.$selectedRange0, pickerVisible: self.$pickerVisible0)
                     .informationView(isPresented: self.$showsErrorMessage, description: AttributedString("This is information error message."))
@@ -137,6 +164,9 @@ struct DateRangePickerExample: View {
             print("selectedRange5 new Value:\(self.getValueLabel(newValue))")
         }
         .navigationTitle("Date Range Picker")
+        .ifApply(self.customizeSeparator) {
+            $0.pickerSeparator(self.showSeparator, color: self.separatorColors[self.separatorColorIndex].1, lineWidth: self.separatorLineWidth)
+        }
     }
 
     private func getValueLabel(_ selectedRange: ClosedRange<Date>?) -> String {

--- a/Apps/Examples/Examples/FioriSwiftUICore/Picker/DateTimePickerExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/Picker/DateTimePickerExample.swift
@@ -30,6 +30,17 @@ struct DateTimePickerExample: View {
     @State var separatedRangeStartPickerVisible = false
     @State var separatedRangeEndDate: Date? = .now
     @State var separatedRangeEndPickerVisible = false
+
+    @State var customizeSeparator = false
+    @State var showSeparator = true
+    @State var separatorColorIndex = 0
+    @State var separatorLineWidth: CGFloat = 0.33
+    let separatorColors: [(String, Color)] = [
+        ("Default", Color.preferredColor(.separatorOpaque)),
+        ("Red", .red),
+        ("Blue", .blue),
+        ("Green", .green)
+    ]
     
     // Limit the selectable dates from last seven days to next seven days
     var limitDateRange: ClosedRange<Date> = Date(timeIntervalSinceNow: -60 * 60 * 24 * 7) ... Date(timeIntervalSinceNow: 60 * 60 * 24 * 7)
@@ -82,6 +93,20 @@ struct DateTimePickerExample: View {
             Toggle("Show Error/Hint message", isOn: self.$showsErrorMessage)
             Toggle("AI Notice", isOn: self.$showAINotice)
             Toggle("Picker Visible", isOn: self.masterPickerVisibleBinding)
+            Section("Picker Separator") {
+                Toggle("Customize Separator", isOn: self.$customizeSeparator)
+                if self.customizeSeparator {
+                    Toggle("Show Separator", isOn: self.$showSeparator)
+                    Picker("Color", selection: self.$separatorColorIndex) {
+                        ForEach(0 ..< self.separatorColors.count, id: \.self) { index in
+                            Text(self.separatorColors[index].0).tag(index)
+                        }
+                    }
+                    Stepper(value: self.$separatorLineWidth, in: 0.33 ... 5.0, step: 0.33) {
+                        Text(String(format: "Line Width: %.2f", self.separatorLineWidth))
+                    }
+                }
+            }
             Section(header: Text("")) {
                 DateTimePicker(title: "Default", mandatoryFieldIndicator: self.mandatoryFieldIndicator(), isRequired: self.isRequired, selectedDate: self.$s1, pickerVisible: self.$pickerVisible)
                     .informationView(isPresented: self.$showsErrorMessage, description: AttributedString("The Date should be before December."))
@@ -158,6 +183,9 @@ struct DateTimePickerExample: View {
             {
                 self.separatedRangeStartDate = self.separatedRangeEndDate
             }
+        }
+        .ifApply(self.customizeSeparator) {
+            $0.pickerSeparator(self.showSeparator, color: self.separatorColors[self.separatorColorIndex].1, lineWidth: self.separatorLineWidth)
         }
     }
 }

--- a/Apps/Examples/Examples/FioriSwiftUICore/Picker/DurationPickerExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/Picker/DurationPickerExample.swift
@@ -19,6 +19,17 @@ struct DurationPickerExample: View {
     @State var pickerVisible4 = false
     @State var pickerVisible5 = false
 
+    @State var customizeSeparator = false
+    @State var showSeparator = true
+    @State var separatorColorIndex = 0
+    @State var separatorLineWidth: CGFloat = 0.33
+    let separatorColors: [(String, Color)] = [
+        ("Default", Color.preferredColor(.separatorOpaque)),
+        ("Red", .red),
+        ("Blue", .blue),
+        ("Green", .green)
+    ]
+
     var formatter: MeasurementFormatter {
         let formatter = MeasurementFormatter()
         formatter.locale = Locale(identifier: "zh-CN")
@@ -70,6 +81,21 @@ struct DurationPickerExample: View {
             Toggle("AI Notice", isOn: self.$showAINotice)
             Toggle("Picker Visible", isOn: self.masterPickerVisibleBinding)
 
+            Section("Picker Separator") {
+                Toggle("Customize Separator", isOn: self.$customizeSeparator)
+                if self.customizeSeparator {
+                    Toggle("Show Separator", isOn: self.$showSeparator)
+                    Picker("Color", selection: self.$separatorColorIndex) {
+                        ForEach(0 ..< self.separatorColors.count, id: \.self) { index in
+                            Text(self.separatorColors[index].0).tag(index)
+                        }
+                    }
+                    Stepper(value: self.$separatorLineWidth, in: 0.33 ... 5.0, step: 0.33) {
+                        Text(String(format: "Line Width: %.2f", self.separatorLineWidth))
+                    }
+                }
+            }
+
             Section {
                 DurationPicker(title: "Default", selection: self.$selection1, pickerVisible: self.$pickerVisible)
                 
@@ -105,6 +131,9 @@ struct DurationPickerExample: View {
             } header: {
                 Text("Read Only")
             }
+        }
+        .ifApply(self.customizeSeparator) {
+            $0.pickerSeparator(self.showSeparator, color: self.separatorColors[self.separatorColorIndex].1, lineWidth: self.separatorLineWidth)
         }
     }
 }

--- a/Apps/Examples/Examples/FioriSwiftUICore/Picker/ValuePickerExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/Picker/ValuePickerExample.swift
@@ -26,6 +26,17 @@ struct ValuePickerExample: View {
     @State var pickerVisible5 = false
     @State var pickerVisible6 = false
 
+    @State var customizeSeparator = false
+    @State var showSeparator = true
+    @State var separatorColorIndex = 0
+    @State var separatorLineWidth: CGFloat = 0.3
+    let separatorColors: [(String, Color)] = [
+        ("Default", Color.preferredColor(.separatorOpaque)),
+        ("Red", .red),
+        ("Blue", .blue),
+        ("Green", .green)
+    ]
+
     struct CustomValuePickerStyle: ValuePickerStyle {
         func makeBody(_ configuration: ValuePickerConfiguration) -> some View {
             ValuePicker(configuration)
@@ -89,6 +100,20 @@ struct ValuePickerExample: View {
                 Toggle("AI Notice", isOn: self.$showAINotice)
                 Toggle("Picker Visible", isOn: self.masterPickerVisibleBinding)
             }
+            Section("Picker Separator") {
+                Toggle("Customize Separator", isOn: self.$customizeSeparator)
+                if self.customizeSeparator {
+                    Toggle("Show Separator", isOn: self.$showSeparator)
+                    Picker("Color", selection: self.$separatorColorIndex) {
+                        ForEach(0 ..< self.separatorColors.count, id: \.self) { index in
+                            Text(self.separatorColors[index].0).tag(index)
+                        }
+                    }
+                    Stepper(value: self.$separatorLineWidth, in: 0.3 ... 5.0, step: 0.3) {
+                        Text(String(format: "Line Width: %.2f", self.separatorLineWidth))
+                    }
+                }
+            }
             Section {
                 ValuePicker(title: "Picker Title(Default Style)", isRequired: self.isRequired, options: self.valueOptions, selectedIndex: self.$negativeIndex, isTrackingLiveChanges: self.isTrackingLiveChanges, controlState: self.stateArray[self.stateIndex], pickerVisible: self.$pickerVisible1)
                     .aiNoticeView(isPresented: self.$showAINotice)
@@ -137,6 +162,9 @@ struct ValuePickerExample: View {
             }
             .ifApply(!self.isCustomTheming) {
                 $0.onAppear { self.resetTheming() }
+            }
+            .ifApply(self.customizeSeparator) {
+                $0.pickerSeparator(self.showSeparator, color: self.separatorColors[self.separatorColorIndex].1, lineWidth: self.separatorLineWidth)
             }
     }
     

--- a/Sources/FioriSwiftUICore/DateRangePicker/DateRangePickerPopView.swift
+++ b/Sources/FioriSwiftUICore/DateRangePicker/DateRangePickerPopView.swift
@@ -15,6 +15,7 @@ struct DateRangePickerPopView: View {
     
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
     @Environment(\.layoutDirection) var layoutDirection
+    @Environment(\.pickerSeparator) private var pickerSeparatorConfiguration
     
     /// The initializer of DateRangePickerPopView.
     /// - Parameters:
@@ -82,21 +83,23 @@ struct DateRangePickerPopView: View {
                 }
                 .padding([.leading, .trailing], 16)
                 .padding(.top, 10)
-                
-                Divider()
-                    .frame(height: 0.33)
-                    .background(Color.preferredColor(.separator))
-                    .padding(.top, 10)
-                
+
+                if self.pickerSeparatorConfiguration.showSeparator {
+                    self.pickerSeparatorConfiguration.color
+                        .frame(height: self.pickerSeparatorConfiguration.lineWidth)
+                        .padding(.top, 10)
+                }
+
                 CalendarView(model: self.model)
                     .environment(\.monthHeaderDateFormat, "yyyy MMM")
                     .environment(\.customLanguageId, self.customLanguageID)
                     .environment(\.hasEventIndicator, false)
-                
-                Divider()
-                    .frame(height: 0.33)
-                    .background(Color.preferredColor(.separator))
-                    .padding(.bottom, 1)
+
+                if self.pickerSeparatorConfiguration.showSeparator {
+                    self.pickerSeparatorConfiguration.color
+                        .frame(height: self.pickerSeparatorConfiguration.lineWidth)
+                        .padding(.bottom, 1)
+                }
             })
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {

--- a/Sources/FioriSwiftUICore/Utils/HeaderSeparator.swift
+++ b/Sources/FioriSwiftUICore/Utils/HeaderSeparator.swift
@@ -68,8 +68,14 @@ struct PickerSeparatorKey: EnvironmentKey {
     static let defaultValue = PickerSeparatorConfiguration(showSeparator: true, color: Color.preferredColor(.separatorOpaque), lineWidth: 0.33)
 }
 
-public extension EnvironmentValues {
-    // Gets or sets the separator configuration for picker components
+extension EnvironmentValues {
+    /// Gets or sets the separator configuration for picker components.
+    ///
+    /// Propagates the `PickerSeparatorConfiguration` through the view hierarchy.
+    /// Pickers (`DurationPicker`, `DateTimePicker`, `ValuePicker`, `DateRangePicker`)
+    /// read this value to render their internal separator. Prefer the
+    /// `View.pickerSeparator(_:color:lineWidth:)` modifier over setting this
+    /// environment value directly.
     var pickerSeparator: PickerSeparatorConfiguration {
         get { self[PickerSeparatorKey.self] }
         set { self[PickerSeparatorKey.self] = newValue }
@@ -88,6 +94,11 @@ public struct PickerSeparatorConfiguration {
     /// Width of the separator line.
     public let lineWidth: CGFloat
 
+    /// Creates a new picker separator configuration.
+    /// - Parameters:
+    ///   - showSeparator: Whether to show the separator.
+    ///   - color: Color of the separator.
+    ///   - lineWidth: Width of the separator line.
     public init(showSeparator: Bool, color: Color, lineWidth: CGFloat) {
         self.showSeparator = showSeparator
         self.color = color

--- a/Sources/FioriSwiftUICore/Utils/HeaderSeparator.swift
+++ b/Sources/FioriSwiftUICore/Utils/HeaderSeparator.swift
@@ -60,3 +60,65 @@ public extension View {
         self.environment(\.headerSeparator, HeaderSeparatorConfiguration(showSeparator: visibility, color: color, lineWidth: lineWidth))
     }
 }
+
+// Environment key for providing a configurable separator for picker components
+// (DurationPicker, DateTimePicker, ValuePicker, DateRangePicker)
+// Default value matches the previously hardcoded Divider style used by these pickers
+struct PickerSeparatorKey: EnvironmentKey {
+    static let defaultValue = PickerSeparatorConfiguration(showSeparator: true, color: Color.preferredColor(.separatorOpaque), lineWidth: 0.33)
+}
+
+public extension EnvironmentValues {
+    // Gets or sets the separator configuration for picker components
+    var pickerSeparator: PickerSeparatorConfiguration {
+        get { self[PickerSeparatorKey.self] }
+        set { self[PickerSeparatorKey.self] = newValue }
+    }
+}
+
+/// Configuration for the separator used inside picker components such as
+/// `DurationPicker`, `DateTimePicker`, `ValuePicker` and `DateRangePicker`.
+public struct PickerSeparatorConfiguration {
+    /// Whether to show the separator.
+    public let showSeparator: Bool
+
+    /// Color of the separator.
+    public let color: Color
+
+    /// Width of the separator line.
+    public let lineWidth: CGFloat
+
+    public init(showSeparator: Bool, color: Color, lineWidth: CGFloat) {
+        self.showSeparator = showSeparator
+        self.color = color
+        self.lineWidth = lineWidth
+    }
+}
+
+public extension View {
+    /// Sets the separator for picker components.
+    ///
+    /// Applies to `DurationPicker`, `DateTimePicker`, `ValuePicker` and `DateRangePicker`'s
+    /// internal separators.
+    ///
+    /// - Parameters:
+    ///   - visibility: Whether to show the separator.
+    ///   - color: Color of the separator. Defaults to the opaque separator color.
+    ///   - lineWidth: Width of the separator line. Defaults to 0.33.
+    /// - Returns: A view with the applied separator configuration.
+    ///
+    /// Example usage:
+    /// ```swift
+    /// DurationPicker(...)
+    ///     .pickerSeparator(true)                              // default style
+    ///     .pickerSeparator(true, color: .red)                 // red separator
+    ///     .pickerSeparator(true, color: .blue, lineWidth: 1)  // thick blue separator
+    ///     .pickerSeparator(false)                             // hide separator
+    /// ```
+    func pickerSeparator(_ visibility: Bool,
+                         color: Color = Color.preferredColor(.separatorOpaque),
+                         lineWidth: CGFloat = 0.33) -> some View
+    {
+        self.environment(\.pickerSeparator, PickerSeparatorConfiguration(showSeparator: visibility, color: color, lineWidth: lineWidth))
+    }
+}

--- a/Sources/FioriSwiftUICore/_FioriStyles/DateRangePickerStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/DateRangePickerStyle.fiori.swift
@@ -6,9 +6,10 @@ import SwiftUI
 public struct DateRangePickerBaseStyle: DateRangePickerStyle {
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
-    
+    @Environment(\.pickerSeparator) private var pickerSeparatorConfiguration
+
     @State var isPresented = false
-    
+
     public func makeBody(_ configuration: DateRangePickerConfiguration) -> some View {
         VStack {
             VStack(spacing: 0) {
@@ -39,6 +40,7 @@ public struct DateRangePickerBaseStyle: DateRangePickerStyle {
             }) {
                 self.isPresented = false
             }
+            .environment(\.pickerSeparator, self.pickerSeparatorConfiguration)
             .presentationDetents([.large])
         }
     }

--- a/Sources/FioriSwiftUICore/_FioriStyles/DateTimePickerStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/DateTimePickerStyle.fiori.swift
@@ -6,9 +6,10 @@ import SwiftUI
 public struct DateTimePickerBaseStyle: DateTimePickerStyle {
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
     @Environment(\.dateTimePickerAutoSelected) var autoSelected
-    
+    @Environment(\.pickerSeparator) private var pickerSeparatorConfiguration
+
     @State private var selectedDate: Date = .now
-   
+
     public func makeBody(_ configuration: DateTimePickerConfiguration) -> some View {
         VStack {
             VStack(spacing: 0) {
@@ -25,13 +26,12 @@ public struct DateTimePickerBaseStyle: DateTimePickerStyle {
                 .animation(nil, value: configuration.pickerVisible)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
                 .padding(.top, 8)
-                
+
                 if configuration.pickerVisible {
                     LazyVStack {
-                        if !configuration.hidesSeparator {
-                            Divider()
-                                .frame(height: 0.33)
-                                .foregroundStyle(Color.preferredColor(.separatorOpaque))
+                        if !configuration.hidesSeparator, self.pickerSeparatorConfiguration.showSeparator {
+                            self.pickerSeparatorConfiguration.color
+                                .frame(height: self.pickerSeparatorConfiguration.lineWidth)
                                 .padding(.top, 14)
                         }
                         self.showPicker(configuration)

--- a/Sources/FioriSwiftUICore/_FioriStyles/DurationPickerStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/DurationPickerStyle.fiori.swift
@@ -14,7 +14,8 @@ import SwiftUI
 // Base Layout style
 public struct DurationPickerBaseStyle: DurationPickerStyle {
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
-    
+    @Environment(\.pickerSeparator) private var pickerSeparatorConfiguration
+
     public func makeBody(_ configuration: DurationPickerConfiguration) -> some View {
         VStack {
             if self.dynamicTypeSize >= .accessibility3 {
@@ -26,9 +27,10 @@ public struct DurationPickerBaseStyle: DurationPickerStyle {
                 }
             }
             if configuration.pickerVisible {
-                Divider()
-                    .frame(height: 0.33)
-                    .foregroundStyle(Color.preferredColor(.separatorOpaque))
+                if self.pickerSeparatorConfiguration.showSeparator {
+                    self.pickerSeparatorConfiguration.color
+                        .frame(height: self.pickerSeparatorConfiguration.lineWidth)
+                }
                 self.showPicker(configuration)
             }
         }

--- a/Sources/FioriSwiftUICore/_FioriStyles/ValuePickerStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/ValuePickerStyle.fiori.swift
@@ -5,6 +5,7 @@ import SwiftUI
 // Base Layout style
 public struct ValuePickerBaseStyle: ValuePickerStyle {
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
+    @Environment(\.pickerSeparator) private var pickerSeparatorConfiguration
     @State var valueString: AttributedString = .init("")
     @FocusState var isFocused: Bool
 
@@ -19,9 +20,10 @@ public struct ValuePickerBaseStyle: ValuePickerStyle {
                 }
             }
             if configuration.pickerVisible || configuration.alwaysShowPicker {
-                Divider()
-                    .frame(height: 0.3)
-                    .foregroundStyle(Color.preferredColor(.separatorOpaque))
+                if self.pickerSeparatorConfiguration.showSeparator {
+                    self.pickerSeparatorConfiguration.color
+                        .frame(height: self.pickerSeparatorConfiguration.lineWidth)
+                }
                 self.showPicker(configuration)
             }
         }


### PR DESCRIPTION
## Summary
- Introduces a new `pickerSeparator(_:color:lineWidth:)` view modifier (paired with `PickerSeparatorConfiguration` environment value) allowing consumers to customize internal separators of `DurationPicker`, `DateTimePicker`, `ValuePicker`, and `DateRangePicker`. This mirrors the existing header separator API defined in `HeaderSeparator.swift`.
- Replaces hardcoded `Divider()` instances within the four picker styles (including top/bottom dividers in `DateRangePickerPopView`) with environment-driven separators. Default styling matches the original appearance, introducing **no breaking visual/behavior changes** for existing usage.
- For `DateRangePicker`: explicitly forward separator configuration into sheet content (sheets do not automatically inherit parent environment values), ensuring calendar popover separators respect the parent picker’s separator settings.
- Updated all four relevant picker screens in the Examples app with a new "Picker Separator" section containing toggle, color picker, and line width stepper controls to demonstrate and validate the new API.

## API Usage
```swift
// Hide separator entirely
DurationPicker(...).pickerSeparator(false)

// Custom separator color
DateTimePicker(...).pickerSeparator(true, color: .red)

// Custom line width
ValuePicker(...).pickerSeparator(true, lineWidth: 1.0)

// Full customization (visible + custom color + thick line)
DateRangePicker(...).pickerSeparator(true, color: .blue, lineWidth: 2)
```
Default values matching original hardcoded styling:
- `showSeparator: true`
- `color: .separatorOpaque`
- `lineWidth: 0.33`

## Files Changed
### Core
- `Sources/FioriSwiftUICore/Utils/HeaderSeparator.swift`
  - Add `PickerSeparatorKey`, `PickerSeparatorConfiguration`, and `View.pickerSeparator(...)` modifier implementation
- `Sources/FioriSwiftUICore/_FioriStyles/DurationPickerStyle.fiori.swift`
- `Sources/FioriSwiftUICore/_FioriStyles/DateTimePickerStyle.fiori.swift`
  - Integrates with existing `hidesSeparator` config: separator only renders if both configs allow visibility
- `Sources/FioriSwiftUICore/_FioriStyles/ValuePickerStyle.fiori.swift`
- `Sources/FioriSwiftUICore/_FioriStyles/DateRangePickerStyle.fiori.swift`
  - Forward separator environment values into presented sheet content
- `Sources/FioriSwiftUICore/DateRangePicker/DateRangePickerPopView.swift`
  - Refactor top & bottom hardcoded dividers to use environment configuration

### Examples
- `Apps/Examples/Examples/FioriSwiftUICore/Picker/DurationPickerExample.swift`
- `Apps/Examples/Examples/FioriSwiftUICore/Picker/DateTimePickerExample.swift`
- `Apps/Examples/Examples/FioriSwiftUICore/Picker/ValuePickerExample.swift`
- `Apps/Examples/Examples/FioriSwiftUICore/Picker/DateRangePickerExample.swift`

## Out of Scope
- `OrderPicker`: Relies on native List row separators instead of explicit `Divider()` views, excluded from this change. Customization can be implemented later via `.listRowSeparator` if requested.
- Standalone layout placeholder `Divider().hidden()` inside vertical stacks remain untouched — these are structural layout spacers, not functional visual separators.