### PR TITLE
fix: 🐛 [IOSSDKBUG-2137] Switch On-State Color Does Not Revert After Edit/Toggle(part1)

### DIFF
--- a/Sources/FioriSwiftUICore/_FioriStyles/SideBarListItemStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/SideBarListItemStyle.fiori.swift
@@ -65,7 +65,7 @@ public struct SideBarListItemBaseStyle: SideBarListItemStyle {
                     } else if SideBarUtility.isEditing(self.modelObject, self.editMode?.wrappedValue) {
                         configuration._switch
                             .frame(width: 50, height: 35)
-                            .tint(Color.preferredColor(configuration.isOn ? .tintColor : .secondaryFill))
+                            .toggleStyle(SwitchToggleStyle(tint: Color.preferredColor(.tintColor)))
                             .opacity(1.0)
                         dragImage
                     }


### PR DESCRIPTION
Dev result:
Before:

https://github.com/user-attachments/assets/afb5983a-3f12-4476-86c2-22129bb7af17


After:

https://github.com/user-attachments/assets/d7598b9d-34e6-4fd2-b14c-42747ea969d2

