### PR TITLE
fix: 🐛 [IOSSDKBUG-2144] NoteFormView - When maxTextEditorHeight is set to nil, the full text should always be displayed immediately, without requiring a view re-render.

### DIFF
--- a/Sources/FioriSwiftUICore/_FioriStyles/NoteFormViewStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/NoteFormViewStyle.fiori.swift
@@ -99,7 +99,6 @@ extension NoteFormViewFioriStyle {
         @Environment(\.isLoading) var isLoading
         @Environment(\.isCustomizedBorder) var isCustomizedBorder
         @Environment(\.noteFormViewCornerRadius) var noteFormViewCornerRadius
-        @State private var textContentHeight: CGFloat = 0
         
         @ViewBuilder
         func makeBody(_ configuration: NoteFormViewConfiguration) -> some View {
@@ -116,7 +115,12 @@ extension NoteFormViewFioriStyle {
                 }
                 .placeholderTextEditorStyle { config in
                     PlaceholderTextEditor(config)
-                        .frame(minHeight: self.getMinHeight(configuration), maxHeight: configuration.maxTextEditorHeight == nil ? (self.textContentHeight > 0 ? max(self.getMinHeight(configuration), self.textContentHeight) : .infinity) : self.getMaxHeight(configuration))
+                        .frame(minHeight: self.getMinHeight(configuration), maxHeight: self.getMaxHeight(configuration))
+                        // When no maxTextEditorHeight is set, disable scrolling so that
+                        // TextEditor uses its content height as intrinsic size natively in SwiftUI.
+                        // When maxTextEditorHeight is set, scrolling remains enabled so the
+                        // editor stays within the given height limit and scrolls internally.
+                        .scrollDisabled(configuration.maxTextEditorHeight == nil)
                         .background(self.getBackgroundColor(configuration))
                         .clipShape(RoundedRectangle(cornerRadius: self.noteFormViewCornerRadius))
                         .overlay(
@@ -133,16 +137,6 @@ extension NoteFormViewFioriStyle {
                             self.checkCharCount(configuration, textString: s)
                         }
                         .padding(.bottom, self.isInfoViewNeeded(configuration) ? 0 : 7)
-                        .ifApply(configuration.maxTextEditorHeight == nil) {
-                            $0.modifier(FioriIntrospectModifier<UITextView> { textView in
-                                let newHeight = textView.contentSize.height
-                                guard newHeight > 0 else { return }
-                                DispatchQueue.main.async {
-                                    guard newHeight != self.textContentHeight else { return }
-                                    self.textContentHeight = newHeight
-                                }
-                            })
-                        }
                 }
                 .textViewStyle { config in
                     TextView(config)

--- a/Sources/FioriSwiftUICore/_FioriStyles/NoteFormViewStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/NoteFormViewStyle.fiori.swift
@@ -99,6 +99,7 @@ extension NoteFormViewFioriStyle {
         @Environment(\.isLoading) var isLoading
         @Environment(\.isCustomizedBorder) var isCustomizedBorder
         @Environment(\.noteFormViewCornerRadius) var noteFormViewCornerRadius
+        @Environment(\.noteFormViewScrollingEnabled) var noteFormViewScrollingEnabled
         
         @ViewBuilder
         func makeBody(_ configuration: NoteFormViewConfiguration) -> some View {
@@ -114,13 +115,11 @@ extension NoteFormViewFioriStyle {
                         .padding(.top, -8)
                 }
                 .placeholderTextEditorStyle { config in
+                    let scrollEnabled = self.noteFormViewScrollingEnabled ?? (configuration.maxTextEditorHeight != nil)
                     PlaceholderTextEditor(config)
-                        .frame(minHeight: self.getMinHeight(configuration), maxHeight: self.getMaxHeight(configuration))
-                        // When no maxTextEditorHeight is set, disable scrolling so that
-                        // TextEditor uses its content height as intrinsic size natively in SwiftUI.
-                        // When maxTextEditorHeight is set, scrolling remains enabled so the
-                        // editor stays within the given height limit and scrolls internally.
-                        .scrollDisabled(configuration.maxTextEditorHeight == nil)
+                        .frame(minHeight: self.getMinHeight(configuration))
+                        .frame(maxHeight: self.getMaxHeight(configuration))
+                        .scrollDisabled(!scrollEnabled)
                         .background(self.getBackgroundColor(configuration))
                         .clipShape(RoundedRectangle(cornerRadius: self.noteFormViewCornerRadius))
                         .overlay(
@@ -263,5 +262,41 @@ public extension View {
     /// - Returns: A view with specified corner radius.
     func noteFormViewCornerRadius(_ cornerRadius: CGFloat) -> some View {
         environment(\.noteFormViewCornerRadius, cornerRadius)
+    }
+}
+
+// MARK: - NoteFormView Scrolling Enabled
+
+struct NoteFormViewScrollingEnabledKey: EnvironmentKey {
+    /// nil means "auto": scroll when maxTextEditorHeight is set, no-scroll otherwise.
+    static let defaultValue: Bool? = nil
+}
+
+public extension EnvironmentValues {
+    /// Controls whether the NoteFormView's text editor scrolls internally.
+    /// - `nil` (default): automatically determined by `maxTextEditorHeight`.
+    ///   - `maxTextEditorHeight` is set → scrolling enabled (editor stays within height limit).
+    ///   - `maxTextEditorHeight` is nil → scrolling disabled (editor expands to fit all content).
+    /// - `true`: always enable scrolling, useful when the editor is inside a height-constrained parent view.
+    /// - `false`: always disable scrolling, editor always expands to fit all content.
+    var noteFormViewScrollingEnabled: Bool? {
+        get { self[NoteFormViewScrollingEnabledKey.self] }
+        set { self[NoteFormViewScrollingEnabledKey.self] = newValue }
+    }
+}
+
+public extension View {
+    /// Controls whether the NoteFormView's text editor scrolls internally.
+    /// ```swift
+    /// // Force scrolling enabled when NoteFormView is inside a height-constrained parent:
+    /// VStack {
+    ///     NoteFormView(text: $text, maxTextEditorHeight: nil)
+    /// }
+    /// .frame(height: 100)
+    /// .noteFormViewScrollingEnabled(true)
+    /// ```
+    /// - Parameter enabled: `true` to enable scrolling, `false` to disable, `nil` for automatic behavior.
+    func noteFormViewScrollingEnabled(_ enabled: Bool?) -> some View {
+        environment(\.noteFormViewScrollingEnabled, enabled)
     }
 }

--- a/Sources/FioriSwiftUICore/_FioriStyles/NoteFormViewStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/NoteFormViewStyle.fiori.swift
@@ -99,6 +99,8 @@ extension NoteFormViewFioriStyle {
         @Environment(\.isLoading) var isLoading
         @Environment(\.isCustomizedBorder) var isCustomizedBorder
         @Environment(\.noteFormViewCornerRadius) var noteFormViewCornerRadius
+        @State private var textContentHeight: CGFloat = 0
+        
         @ViewBuilder
         func makeBody(_ configuration: NoteFormViewConfiguration) -> some View {
             NoteFormView(configuration)
@@ -116,6 +118,9 @@ extension NoteFormViewFioriStyle {
                     PlaceholderTextEditor(config)
                         .frame(minHeight: self.getMinHeight(configuration))
                         .frame(maxHeight: self.getMaxHeight(configuration))
+                        .ifApply(configuration.maxTextEditorHeight == nil && self.textContentHeight > 0) {
+                            $0.frame(height: max(self.getMinHeight(configuration), self.textContentHeight))
+                        }
                         .background(self.getBackgroundColor(configuration))
                         .clipShape(RoundedRectangle(cornerRadius: self.noteFormViewCornerRadius))
                         .overlay(
@@ -132,6 +137,15 @@ extension NoteFormViewFioriStyle {
                             self.checkCharCount(configuration, textString: s)
                         }
                         .padding(.bottom, self.isInfoViewNeeded(configuration) ? 0 : 7)
+                        .ifApply(configuration.maxTextEditorHeight == nil) {
+                            $0.modifier(FioriIntrospectModifier<UITextView> { textView in
+                                let newHeight = textView.contentSize.height
+                                guard newHeight > 0, newHeight != self.textContentHeight else { return }
+                                DispatchQueue.main.async {
+                                    self.textContentHeight = newHeight
+                                }
+                            })
+                        }
                 }
                 .textViewStyle { config in
                     TextView(config)

--- a/Sources/FioriSwiftUICore/_FioriStyles/NoteFormViewStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/NoteFormViewStyle.fiori.swift
@@ -116,11 +116,7 @@ extension NoteFormViewFioriStyle {
                 }
                 .placeholderTextEditorStyle { config in
                     PlaceholderTextEditor(config)
-                        .frame(minHeight: self.getMinHeight(configuration))
-                        .frame(maxHeight: self.getMaxHeight(configuration))
-                        .ifApply(configuration.maxTextEditorHeight == nil && self.textContentHeight > 0) {
-                            $0.frame(height: max(self.getMinHeight(configuration), self.textContentHeight))
-                        }
+                        .frame(minHeight: self.getMinHeight(configuration), maxHeight: configuration.maxTextEditorHeight == nil ? (self.textContentHeight > 0 ? max(self.getMinHeight(configuration), self.textContentHeight) : .infinity) : self.getMaxHeight(configuration))
                         .background(self.getBackgroundColor(configuration))
                         .clipShape(RoundedRectangle(cornerRadius: self.noteFormViewCornerRadius))
                         .overlay(
@@ -140,8 +136,9 @@ extension NoteFormViewFioriStyle {
                         .ifApply(configuration.maxTextEditorHeight == nil) {
                             $0.modifier(FioriIntrospectModifier<UITextView> { textView in
                                 let newHeight = textView.contentSize.height
-                                guard newHeight > 0, newHeight != self.textContentHeight else { return }
+                                guard newHeight > 0 else { return }
                                 DispatchQueue.main.async {
+                                    guard newHeight != self.textContentHeight else { return }
                                     self.textContentHeight = newHeight
                                 }
                             })


### PR DESCRIPTION
Dev Result:
<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-07-02 at 10 48 13" src="https://github.com/user-attachments/assets/08e9ca9e-a26e-4440-adec-e7ca4456526b" />
