### PR TITLE
fix: 🐛 [IOSSDKBUG-2176] Make the text fields show a red border when there's an error

### DIFF
--- a/Sources/FioriSwiftUICore/_FioriStyles/TextInputInfoViewStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/TextInputInfoViewStyle.fiori.swift
@@ -389,6 +389,10 @@ struct TextInputFormViewConfiguration {
     }
 
     func hasErrorMessage() -> Bool {
+        if let errorMessage, !String(errorMessage.characters).trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return true
+        }
+        
         guard let maxTextLength, maxTextLength > 0 else {
             // No limit
             return false


### PR DESCRIPTION
Before:
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-07 at 16 00 34" src="https://github.com/user-attachments/assets/20aad4d0-2f20-430b-8a12-c82f21b6dea7" />
After:
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-07 at 15 59 05" src="https://github.com/user-attachments/assets/2ee4df31-e7b9-4939-9c87-eb41d86d6c0e" />

