### PR TITLE
fix: 🐛 [IOSSDKBUG-2176] Make the text fields show a red border when there's an error

### DIFF
--- a/Sources/FioriSwiftUICore/_FioriStyles/TextInputInfoViewStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/TextInputInfoViewStyle.fiori.swift
@@ -389,7 +389,7 @@ struct TextInputFormViewConfiguration {
     }
 
     func hasErrorMessage() -> Bool {
-        if let errorMessage, !String(errorMessage.characters).trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        if let errorMessage, !errorMessage.characters.isEmpty {
             return true
         }
         


### PR DESCRIPTION
# Fix: Show Red Border on Text Fields When Error Message Is Present

### Bug Fix

🐛 Resolved an issue where text fields were not displaying a red border when an error message was set. The root cause was an overly strict check that trimmed whitespace and newlines before evaluating whether the error message was non-empty. This caused certain valid error messages (e.g., messages consisting only of whitespace) to be ignored, preventing the error state from being triggered correctly.

### Changes

* `Sources/FioriSwiftUICore/_FioriStyles/TextInputInfoViewStyle.fiori.swift`: Simplified the `hasErrorMessage()` check from trimming whitespace/newlines before evaluating emptiness to directly checking if the `errorMessage` characters collection is non-empty. This ensures the error border is shown whenever an error message is present.

### Jira Issues

* IOSSDKBUG-2176: Make the text fields show a red border when there's an error

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.27.2`

- Event Trigger: `pull_request.opened`
- LLM: `anthropic--claude-4.6-sonnet`
- File Content Strategy: Full file content
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Correlation ID: `e492d5a0-7a95-11f1-8131-3b473abac4f7`
</details>
