### PR TITLE
fix: 🐛 [IOSSDKBUG-2157] KeyValueFormview supports individual accessibility config

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/FormViews/KeyValueFormViewExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/FormViews/KeyValueFormViewExample.swift
@@ -57,6 +57,7 @@ struct KeyValueFormViewExample: View {
                 List {
                     Text("Default KeyValueForm")
                     KeyValueFormView(title: self.key1, text: self.isLoading ? self.$valueText3 : self.$valueText1, placeholder: "KeyValueFormView", errorMessage: self.getErrorMessage(), maxTextLength: self.getMaxTextLength(), hintText: self.getHintText(), isCharCountEnabled: self.showsCharCount, allowsBeyondLimit: self.allowsBeyondLimit, isRequired: self.isRequired)
+                        .environment(\.isAccessibilityCombined, false)
                     
                     Text("Existing Text")
                         .italic()

--- a/Sources/FioriSwiftUICore/Utils/SkeletonLoading.swift
+++ b/Sources/FioriSwiftUICore/Utils/SkeletonLoading.swift
@@ -300,12 +300,24 @@ struct IsLoadingKey: EnvironmentKey {
     static let defaultValue: Bool = false
 }
 
+struct IsAccessibilityCombinedKey: EnvironmentKey {
+    static let defaultValue: Bool = true
+}
+
 /// A custom environment key to manage loading state across views.
 public extension EnvironmentValues {
     /// A Boolean value indicating whether content is currently loading. It can be used to show the shimmer effect.
     var isLoading: Bool {
         get { self[IsLoadingKey.self] }
         set { self[IsLoadingKey.self] = newValue }
+    }
+}
+
+public extension EnvironmentValues {
+    /// A Boolean value indicating whether accessibility elements are combined into a single element. When `true`, child elements are combined. Default is `true`.
+    var isAccessibilityCombined: Bool {
+        get { self[IsAccessibilityCombinedKey.self] }
+        set { self[IsAccessibilityCombinedKey.self] = newValue }
     }
 }
 

--- a/Sources/FioriSwiftUICore/_FioriStyles/KeyValueFormViewStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/KeyValueFormViewStyle.fiori.swift
@@ -5,13 +5,16 @@ import SwiftUI
 /// The base layout style for `KeyValueFormView`.
 public struct KeyValueFormViewBaseStyle: KeyValueFormViewStyle {
     @Environment(\.isLoading) var isLoading
+    @Environment(\.isAccessibilityCombined) var isAccessibilityCombined
     public func makeBody(_ configuration: KeyValueFormViewConfiguration) -> some View {
         SkeletonLoadingContainer {
             VStack(alignment: .leading) {
                 self.getTitle(configuration)
                 configuration._noteFormView
             }
-            .accessibilityElement(children: .combine)
+            .ifApply(self.isAccessibilityCombined, content: {
+                $0.accessibilityElement(children: .combine)
+            })
         }
     }
     


### PR DESCRIPTION
# KeyValueFormView: Add Individual Accessibility Configuration Support

### Bug Fix

🐛 Fixes an issue where `KeyValueFormView` lacked support for individual accessibility configuration. Previously, the accessibility element was always combined (`accessibilityElement(children: .combine)`) with no way to override this behavior per instance. This change introduces an environment key `isAccessibilityCombined` that allows callers to control whether the view combines its accessibility elements.

### Changes

* `KeyValueFormViewStyle.fiori.swift`: Replaced the unconditional `.accessibilityElement(children: .combine)` modifier with a conditional `ifApply` block driven by the new `isAccessibilityCombined` environment value. Added `@Environment(\.isAccessibilityCombined)` to `KeyValueFormViewBaseStyle`.

* `SkeletonLoading.swift`: Introduced a new `IsAccessibilityCombinedKey` environment key (default value: `true`) and exposed it via a public `isAccessibilityCombined` property on `EnvironmentValues`.

* `KeyValueFormViewExample.swift`: Added `.environment(\.isAccessibilityCombined, false)` to the first `KeyValueFormView` in the list to demonstrate and validate the new per-instance accessibility configuration.

### Jira Issues

* IOSSDKBUG-2157: KeyValueFormView supports individual accessibility config

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.27.2`

- Event Trigger: `pull_request.opened`
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Correlation ID: `cbf04fb0-7b75-11f1-82fa-50f4b0af4523`
- File Content Strategy: Full file content
- LLM: `anthropic--claude-4.6-sonnet`
</details>
