### PR TITLE
fix: 🐛 [2172|2173]add skeleton loading support to components

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/FormCells/StepperViewExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/FormCells/StepperViewExample.swift
@@ -15,6 +15,7 @@ struct StepperViewExample: View {
     
     @State var isDisabled: Bool = false
     @State var toggleDecrementActivate: Bool = true
+    @State var isLoading: Bool = false
     
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
 
@@ -31,6 +32,7 @@ struct StepperViewExample: View {
             Group {
                 Toggle("Disabled State", isOn: self.$isDisabled)
                 Toggle("Activate increment decrement button separately", isOn: self.$toggleDecrementActivate)
+                Toggle("Skeleton Loading", isOn: self.$isLoading)
                 StepperView(
                     title: { Text("Value") },
                     text: self.$normalStepValue,
@@ -149,6 +151,7 @@ struct StepperViewExample: View {
                 .disabled(self.isDisabled)
             }
             .padding(EdgeInsets(top: 9, leading: self.getPadding(), bottom: 11, trailing: self.getPadding()))
+            .environment(\.isLoading, self.isLoading)
 
             Spacer()
         }

--- a/Apps/Examples/Examples/FioriSwiftUICore/Picker/DateRangePickerExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/Picker/DateRangePickerExample.swift
@@ -7,6 +7,7 @@ struct DateRangePickerExample: View {
     @State private var customizedMandatoryIndicator = false
     @State private var showsErrorMessage = false
     @State private var showAINotice: Bool = false
+    @State private var isLoading: Bool = false
     @State private var pickerVisible0 = false
     @State private var pickerVisible1 = false
     @State private var pickerVisible2 = false
@@ -82,6 +83,8 @@ struct DateRangePickerExample: View {
                 .tint(Color.preferredColor(.tintColor))
             Toggle("Picker Visible", isOn: self.managePickerVisibleBinding)
                 .tint(Color.preferredColor(.tintColor))
+            Toggle("Skeleton Loading", isOn: self.$isLoading)
+                .tint(Color.preferredColor(.tintColor))
             Section(header: Text("")) {
                 DateRangePicker(title: "Range Selection Long Title Long Title Long Title Long Title Long Title Long Title0", mandatoryFieldIndicator: self.mandatoryFieldIndicator(), isRequired: self.isRequired, selectedRange: self.$selectedRange0, pickerVisible: self.$pickerVisible0)
                     .informationView(isPresented: self.$showsErrorMessage, description: AttributedString("This is information error message."))
@@ -136,6 +139,7 @@ struct DateRangePickerExample: View {
         .onChange(of: self.selectedRange5) { _, newValue in
             print("selectedRange5 new Value:\(self.getValueLabel(newValue))")
         }
+        .environment(\.isLoading, self.isLoading)
         .navigationTitle("Date Range Picker")
     }
 

--- a/Apps/Examples/Examples/FioriSwiftUICore/Picker/DateTimePickerExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/Picker/DateTimePickerExample.swift
@@ -16,6 +16,7 @@ struct DateTimePickerExample: View {
     @State var isRequired = false
     @State var showsErrorMessage = false
     @State var showAINotice: Bool = false
+    @State var isLoading: Bool = false
     @State var pickerVisible = false
     @State var pickerVisible1 = false
     @State var pickerVisible2 = false
@@ -82,6 +83,7 @@ struct DateTimePickerExample: View {
             Toggle("Show Error/Hint message", isOn: self.$showsErrorMessage)
             Toggle("AI Notice", isOn: self.$showAINotice)
             Toggle("Picker Visible", isOn: self.masterPickerVisibleBinding)
+            Toggle("Skeleton Loading", isOn: self.$isLoading)
             Section(header: Text("")) {
                 DateTimePicker(title: "Default", mandatoryFieldIndicator: self.mandatoryFieldIndicator(), isRequired: self.isRequired, selectedDate: self.$s1, pickerVisible: self.$pickerVisible)
                     .informationView(isPresented: self.$showsErrorMessage, description: AttributedString("The Date should be before December."))
@@ -143,6 +145,7 @@ struct DateTimePickerExample: View {
         .onChange(of: self.s2) { _, _ in
             print("s2 new Value:\(String(describing: self.s2))")
         }
+        .environment(\.isLoading, self.isLoading)
         .onChange(of: self.separatedRangeStartDate) { _, _ in
             if let separatedRangeStartDate,
                let separatedRangeEndDate,

--- a/Sources/FioriSwiftUICore/_FioriStyles/DateRangePickerStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/DateRangePickerStyle.fiori.swift
@@ -29,10 +29,9 @@ public struct DateRangePickerBaseStyle: DateRangePickerStyle {
                 }
             }
             .ifApply(FioriLocale.shared.locale != nil) {
-                $0.environment(\.locale, FioriLocale.shared.locale!)
-            }
-            .ifApply(FioriLocale.shared.locale != nil) {
-                $0.environment(\.calendar, FioriLocale.shared.locale!.calendar)
+                let fioriLocale = FioriLocale.shared.locale ?? .current
+                return $0.environment(\.locale, fioriLocale)
+                    .environment(\.calendar, fioriLocale.calendar)
             }
             .sheet(isPresented: self.$isPresented) {
                 DateRangePickerPopView(startDate: configuration.range?.lowerBound, endDate: configuration.range?.upperBound, selectedRange: configuration.selectedRange, applyActionCallback: { selectedRange in

--- a/Sources/FioriSwiftUICore/_FioriStyles/DateRangePickerStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/DateRangePickerStyle.fiori.swift
@@ -162,31 +162,3 @@ extension DateRangePickerFioriStyle {
         }
     }
 }
-
-/// Predefined skeleton loading patterns for `DateRangePicker`.
-///
-/// Apply the ``EnvironmentValues/isLoading`` environment value to trigger the shimmer effect:
-///
-/// ```swift
-/// DateRangePickerSkeletonLoadingPattern.basic
-///     .environment(\.isLoading, true)
-/// ```
-public enum DateRangePickerSkeletonLoadingPattern {
-    /// A basic range picker skeleton without a selected range.
-    public static let basic = DateRangePicker(
-        title: { Text("Date Range") },
-        selectedRange: .constant(nil),
-        pickerVisible: .constant(false)
-    )
-
-    /// A range picker skeleton with a preselected range.
-    public static let withSelection: DateRangePicker = {
-        let now = Date()
-        let end = Calendar.current.date(byAdding: .day, value: 7, to: now) ?? now
-        return DateRangePicker(
-            title: { Text("Date Range") },
-            selectedRange: .constant(now ... end),
-            pickerVisible: .constant(false)
-        )
-    }()
-}

--- a/Sources/FioriSwiftUICore/_FioriStyles/DateRangePickerStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/DateRangePickerStyle.fiori.swift
@@ -6,43 +6,46 @@ import SwiftUI
 public struct DateRangePickerBaseStyle: DateRangePickerStyle {
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
-    
+    @Environment(\.isLoading) var isLoading
+
     @State var isPresented = false
-    
+
     public func makeBody(_ configuration: DateRangePickerConfiguration) -> some View {
-        VStack {
-            VStack(spacing: 0) {
-                Group {
-                    if self.dynamicTypeSize >= .accessibility3 {
-                        self.configureMainStack(configuration, isVertical: true)
-                    } else {
-                        ViewThatFits(in: .horizontal) {
-                            self.configureMainStack(configuration, isVertical: false)
+        SkeletonLoadingContainer {
+            VStack {
+                VStack(spacing: 0) {
+                    Group {
+                        if self.dynamicTypeSize >= .accessibility3 {
                             self.configureMainStack(configuration, isVertical: true)
+                        } else {
+                            ViewThatFits(in: .horizontal) {
+                                self.configureMainStack(configuration, isVertical: false)
+                                self.configureMainStack(configuration, isVertical: true)
+                            }
                         }
                     }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                    .padding(.top, 8)
                 }
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-                .padding(.top, 8)
             }
-        }
-        .ifApply(FioriLocale.shared.locale != nil) {
-            $0.environment(\.locale, FioriLocale.shared.locale!)
-        }
-        .ifApply(FioriLocale.shared.locale != nil) {
-            $0.environment(\.calendar, FioriLocale.shared.locale!.calendar)
-        }
-        .sheet(isPresented: self.$isPresented) {
-            DateRangePickerPopView(startDate: configuration.range?.lowerBound, endDate: configuration.range?.upperBound, selectedRange: configuration.selectedRange, applyActionCallback: { selectedRange in
-                configuration.selectedRange = selectedRange
-                self.isPresented = false
-            }) {
-                self.isPresented = false
+            .ifApply(FioriLocale.shared.locale != nil) {
+                $0.environment(\.locale, FioriLocale.shared.locale!)
             }
-            .presentationDetents([.large])
+            .ifApply(FioriLocale.shared.locale != nil) {
+                $0.environment(\.calendar, FioriLocale.shared.locale!.calendar)
+            }
+            .sheet(isPresented: self.$isPresented) {
+                DateRangePickerPopView(startDate: configuration.range?.lowerBound, endDate: configuration.range?.upperBound, selectedRange: configuration.selectedRange, applyActionCallback: { selectedRange in
+                    configuration.selectedRange = selectedRange
+                    self.isPresented = false
+                }) {
+                    self.isPresented = false
+                }
+                .presentationDetents([.large])
+            }
         }
     }
-    
+
     func configureMainStack(_ configuration: DateRangePickerConfiguration, isVertical: Bool) -> some View {
         let mainStack = isVertical ? AnyLayout(VStackLayout(alignment: .leading, spacing: 3)) : AnyLayout(HStackLayout())
         return mainStack {
@@ -52,14 +55,14 @@ public struct DateRangePickerBaseStyle: DateRangePickerStyle {
             } else {
                 Divider().hidden()
             }
-            
+
             ValueLabel(valueLabel: AttributedString(self.getValueLabel(configuration)))
                 .accessibilityLabel(self.getValueAccessibilityLabelString(configuration))
         }
         .accessibilityElement(children: .combine)
         .accessibilityHint(self.mainStackAccessibilityHint(configuration))
         .contentShape(Rectangle())
-        .ifApply(configuration.controlState != .disabled && configuration.controlState != .readOnly) {
+        .ifApply(configuration.controlState != .disabled && configuration.controlState != .readOnly && !self.isLoading) {
             $0.onTapGesture(perform: {
                 self.isPresented = true
             })
@@ -119,25 +122,29 @@ extension DateRangePickerFioriStyle {
     
     struct TitleFioriStyle: TitleStyle {
         let dateRangePickerConfiguration: DateRangePickerConfiguration
-        
+        @Environment(\.isLoading) var isLoading
+
         func makeBody(_ configuration: TitleConfiguration) -> some View {
             Title(configuration)
-                .foregroundStyle(Color.preferredColor(self.dateRangePickerConfiguration.controlState == .disabled ? .quaternaryLabel : .primaryLabel))
+                .foregroundStyle(Color.preferredColor(self.isLoading ? .separator : (self.dateRangePickerConfiguration.controlState == .disabled ? .quaternaryLabel : .primaryLabel)))
                 .font(.fiori(forTextStyle: .subheadline, weight: .semibold))
         }
     }
-    
+
     struct ValueLabelFioriStyle: ValueLabelStyle {
         let dateRangePickerConfiguration: DateRangePickerConfiguration
-        
+        @Environment(\.isLoading) var isLoading
+
         func makeBody(_ configuration: ValueLabelConfiguration) -> some View {
             ValueLabel(configuration)
                 .foregroundStyle(self.getFontColor(self.dateRangePickerConfiguration))
                 .font(.fiori(forTextStyle: .body))
         }
-        
+
         func getFontColor(_ configuration: DateRangePickerConfiguration) -> Color {
-            if configuration.controlState == .disabled {
+            if self.isLoading {
+                return .preferredColor(.separator)
+            } else if configuration.controlState == .disabled {
                 return .preferredColor(.separator)
             } else if configuration.selectedRange != nil {
                 return .preferredColor(.tintColor)
@@ -149,9 +156,37 @@ extension DateRangePickerFioriStyle {
     
     struct FormViewFioriStyle: FormViewStyle {
         let dateRangePickerConfiguration: DateRangePickerConfiguration
-        
+
         func makeBody(_ configuration: FormViewConfiguration) -> some View {
             FormView(configuration)
         }
     }
+}
+
+/// Predefined skeleton loading patterns for `DateRangePicker`.
+///
+/// Apply the ``EnvironmentValues/isLoading`` environment value to trigger the shimmer effect:
+///
+/// ```swift
+/// DateRangePickerSkeletonLoadingPattern.basic
+///     .environment(\.isLoading, true)
+/// ```
+public enum DateRangePickerSkeletonLoadingPattern {
+    /// A basic range picker skeleton without a selected range.
+    public static let basic = DateRangePicker(
+        title: { Text("Date Range") },
+        selectedRange: .constant(nil),
+        pickerVisible: .constant(false)
+    )
+
+    /// A range picker skeleton with a preselected range.
+    public static let withSelection: DateRangePicker = {
+        let now = Date()
+        let end = Calendar.current.date(byAdding: .day, value: 7, to: now) ?? now
+        return DateRangePicker(
+            title: { Text("Date Range") },
+            selectedRange: .constant(now ... end),
+            pickerVisible: .constant(false)
+        )
+    }()
 }

--- a/Sources/FioriSwiftUICore/_FioriStyles/DateTimePickerStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/DateTimePickerStyle.fiori.swift
@@ -6,59 +6,62 @@ import SwiftUI
 public struct DateTimePickerBaseStyle: DateTimePickerStyle {
     @Environment(\.dynamicTypeSize) var dynamicTypeSize
     @Environment(\.dateTimePickerAutoSelected) var autoSelected
-    
+    @Environment(\.isLoading) var isLoading
+
     @State private var selectedDate: Date = .now
-   
+
     public func makeBody(_ configuration: DateTimePickerConfiguration) -> some View {
-        VStack {
-            VStack(spacing: 0) {
-                Group {
-                    if self.dynamicTypeSize >= .accessibility3 {
-                        self.configureMainStack(configuration, isVertical: true)
-                    } else {
-                        ViewThatFits(in: .horizontal) {
-                            self.configureMainStack(configuration, isVertical: false)
+        SkeletonLoadingContainer {
+            VStack {
+                VStack(spacing: 0) {
+                    Group {
+                        if self.dynamicTypeSize >= .accessibility3 {
                             self.configureMainStack(configuration, isVertical: true)
+                        } else {
+                            ViewThatFits(in: .horizontal) {
+                                self.configureMainStack(configuration, isVertical: false)
+                                self.configureMainStack(configuration, isVertical: true)
+                            }
                         }
                     }
-                }
-                .animation(nil, value: configuration.pickerVisible)
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-                .padding(.top, 8)
-                
-                if configuration.pickerVisible {
-                    LazyVStack {
-                        if !configuration.hidesSeparator {
-                            Divider()
-                                .frame(height: 0.33)
-                                .foregroundStyle(Color.preferredColor(.separatorOpaque))
-                                .padding(.top, 14)
+                    .animation(nil, value: configuration.pickerVisible)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                    .padding(.top, 8)
+
+                    if configuration.pickerVisible, !self.isLoading {
+                        LazyVStack {
+                            if !configuration.hidesSeparator {
+                                Divider()
+                                    .frame(height: 0.33)
+                                    .foregroundStyle(Color.preferredColor(.separatorOpaque))
+                                    .padding(.top, 14)
+                            }
+                            self.showPicker(configuration)
                         }
-                        self.showPicker(configuration)
+                        .transition(.opacity.combined(with: .scale(scale: 1.0, anchor: .top)))
                     }
-                    .transition(.opacity.combined(with: .scale(scale: 1.0, anchor: .top)))
+                }
+                .animation(.easeInOut(duration: 0.3), value: configuration.pickerVisible)
+            }
+            .onAppear {
+                if let configuredDate = configuration.selectedDate {
+                    self.selectedDate = configuredDate
                 }
             }
-            .animation(.easeInOut(duration: 0.3), value: configuration.pickerVisible)
-        }
-        .onAppear {
-            if let configuredDate = configuration.selectedDate {
-                self.selectedDate = configuredDate
+            .ifApply(FioriLocale.shared.locale != nil) {
+                $0.environment(\.locale, FioriLocale.shared.locale!)
             }
-        }
-        .ifApply(FioriLocale.shared.locale != nil) {
-            $0.environment(\.locale, FioriLocale.shared.locale!)
-        }
-        .ifApply(FioriLocale.shared.locale != nil) {
-            $0.environment(\.calendar, FioriLocale.shared.locale!.calendar)
-        }
-        .onChange(of: configuration.selectedDate) { _, _ in
-            if let configuredDate = configuration.selectedDate {
-                self.selectedDate = configuredDate
+            .ifApply(FioriLocale.shared.locale != nil) {
+                $0.environment(\.calendar, FioriLocale.shared.locale!.calendar)
+            }
+            .onChange(of: configuration.selectedDate) { _, _ in
+                if let configuredDate = configuration.selectedDate {
+                    self.selectedDate = configuredDate
+                }
             }
         }
     }
-    
+
     func configureMainStack(_ configuration: DateTimePickerConfiguration, isVertical: Bool) -> some View {
         let mainStack = isVertical ? AnyLayout(VStackLayout(alignment: .leading, spacing: 3)) : AnyLayout(HStackLayout())
         return mainStack {
@@ -76,7 +79,7 @@ public struct DateTimePickerBaseStyle: DateTimePickerStyle {
         .accessibilityElement(children: .combine)
         .accessibilityHint(self.mainStackAccessibilityHint(configuration))
         .contentShape(Rectangle())
-        .ifApply(configuration.controlState != .disabled && configuration.controlState != .readOnly) {
+        .ifApply(configuration.controlState != .disabled && configuration.controlState != .readOnly && !self.isLoading) {
             $0.onTapGesture(perform: {
                 if configuration.selectedDate == Date(timeIntervalSince1970: 0.0) {
                     configuration.selectedDate = Date()
@@ -164,19 +167,24 @@ extension DateTimePickerFioriStyle {
 
     struct TitleFioriStyle: TitleStyle {
         let dateTimePickerConfiguration: DateTimePickerConfiguration
+        @Environment(\.isLoading) var isLoading
 
         func makeBody(_ configuration: TitleConfiguration) -> some View {
             Title(configuration)
-                .foregroundStyle(Color.preferredColor(self.dateTimePickerConfiguration.controlState == .disabled ? .quaternaryLabel : .primaryLabel))
+                .foregroundStyle(Color.preferredColor(self.isLoading ? .separator : (self.dateTimePickerConfiguration.controlState == .disabled ? .quaternaryLabel : .primaryLabel)))
                 .font(.fiori(forTextStyle: .subheadline, weight: .semibold))
         }
     }
-    
+
     struct ValueLabelFioriStyle: ValueLabelStyle {
         let dateTimePickerConfiguration: DateTimePickerConfiguration
-    
+        @Environment(\.isLoading) var isLoading
+
         func makeBody(_ configuration: ValueLabelConfiguration) -> some View {
             ValueLabel(configuration)
+                .ifApply(self.isLoading) {
+                    $0.foregroundStyle(Color.preferredColor(.separator))
+                }
         }
     }
     
@@ -200,4 +208,38 @@ public extension EnvironmentValues {
         get { self[DateTimePickerAutoSelectedKey.self] }
         set { self[DateTimePickerAutoSelectedKey.self] = newValue }
     }
+}
+
+/// Predefined skeleton loading patterns for `DateTimePicker`.
+///
+/// Apply the ``EnvironmentValues/isLoading`` environment value to trigger the shimmer effect:
+///
+/// ```swift
+/// DateTimePickerSkeletonLoadingPattern.dateAndTime
+///     .environment(\.isLoading, true)
+/// ```
+public enum DateTimePickerSkeletonLoadingPattern {
+    /// A skeleton pattern that displays both a date and a time value.
+    public static let dateAndTime = DateTimePicker(
+        title: { Text("Date & Time") },
+        selectedDate: .constant(Date()),
+        pickerComponents: [.date, .hourAndMinute],
+        pickerVisible: .constant(false)
+    )
+
+    /// A skeleton pattern that displays only a date value.
+    public static let dateOnly = DateTimePicker(
+        title: { Text("Date") },
+        selectedDate: .constant(Date()),
+        pickerComponents: [.date],
+        pickerVisible: .constant(false)
+    )
+
+    /// A skeleton pattern that displays only a time value.
+    public static let timeOnly = DateTimePicker(
+        title: { Text("Time") },
+        selectedDate: .constant(Date()),
+        pickerComponents: [.hourAndMinute],
+        pickerVisible: .constant(false)
+    )
 }

--- a/Sources/FioriSwiftUICore/_FioriStyles/DateTimePickerStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/DateTimePickerStyle.fiori.swift
@@ -49,10 +49,9 @@ public struct DateTimePickerBaseStyle: DateTimePickerStyle {
                 }
             }
             .ifApply(FioriLocale.shared.locale != nil) {
-                $0.environment(\.locale, FioriLocale.shared.locale!)
-            }
-            .ifApply(FioriLocale.shared.locale != nil) {
-                $0.environment(\.calendar, FioriLocale.shared.locale!.calendar)
+                let fioriLocale = FioriLocale.shared.locale ?? .current
+                return $0.environment(\.locale, fioriLocale)
+                    .environment(\.calendar, fioriLocale.calendar)
             }
             .onChange(of: configuration.selectedDate) { _, _ in
                 if let configuredDate = configuration.selectedDate {

--- a/Sources/FioriSwiftUICore/_FioriStyles/StepperFieldStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/StepperFieldStyle.fiori.swift
@@ -254,16 +254,17 @@ extension StepperFieldFioriStyle {
         let stepperFieldConfiguration: StepperFieldConfiguration
         @Environment(\.isEnabled) var isEnabled: Bool
         @Environment(\.colorScheme) var colorScheme
+        @Environment(\.isLoading) var isLoading
 
         func makeBody(_ configuration: DecrementActionConfiguration) -> some View {
             let isDecrementBtnEnabled: Bool = self.isEnabled ? Double(self.stepperFieldConfiguration.text) ?? self.stepperFieldConfiguration.stepRange.lowerBound > self.stepperFieldConfiguration.stepRange.lowerBound ? true : false : false
             let decrementDescFormat = NSLocalizedString("Decrease the value by %f", tableName: "FioriSwiftUICore", bundle: Bundle.accessor, comment: "")
             let decrementDesc = String(format: decrementDescFormat, stepperFieldConfiguration.step)
             return DecrementAction(configuration)
-                .foregroundColor(.preferredColor(.tintColor))
+                .foregroundColor(.preferredColor(self.isLoading ? .separator : .tintColor))
                 .frame(minWidth: 44, minHeight: 44)
                 .fioriButtonStyle(StepperPlainButtonStyle(colorScheme: self.colorScheme))
-                .disabled(!isDecrementBtnEnabled)
+                .disabled(self.isLoading ? true : !isDecrementBtnEnabled)
                 .accessibilityLabel(NSLocalizedString("Stepper decrease", tableName: "FioriSwiftUICore", bundle: Bundle.accessor, comment: ""))
                 .accessibilityValue(Text(decrementDesc))
         }
@@ -272,9 +273,10 @@ extension StepperFieldFioriStyle {
     struct TextInputFieldFioriStyle: TextInputFieldStyle {
         let stepperFieldConfiguration: StepperFieldConfiguration
         @Environment(\.isEnabled) var isEnabled: Bool
+        @Environment(\.isLoading) var isLoading
         func makeBody(_ configuration: TextInputFieldConfiguration) -> some View {
             TextInputField(configuration)
-                .foregroundColor(.preferredColor(self.isEnabled ? .tertiaryLabel : .separator))
+                .foregroundColor(.preferredColor(self.isLoading ? .separator : (self.isEnabled ? .tertiaryLabel : .separator)))
                 .accessibilityLabel(NSLocalizedString("Select specific value", tableName: "FioriSwiftUICore", bundle: Bundle.accessor, comment: ""))
         }
     }
@@ -283,16 +285,17 @@ extension StepperFieldFioriStyle {
         let stepperFieldConfiguration: StepperFieldConfiguration
         @Environment(\.isEnabled) var isEnabled: Bool
         @Environment(\.colorScheme) var colorScheme
+        @Environment(\.isLoading) var isLoading
 
         func makeBody(_ configuration: IncrementActionConfiguration) -> some View {
             let isIncrementBtnEnabled: Bool = self.isEnabled ? Double(self.stepperFieldConfiguration.text) ?? self.stepperFieldConfiguration.stepRange.upperBound < self.stepperFieldConfiguration.stepRange.upperBound ? true : false : false
             let incrementDescFormat = NSLocalizedString("Increase the value by %f", tableName: "FioriSwiftUICore", bundle: Bundle.accessor, comment: "")
             let incrementDesc = String(format: incrementDescFormat, stepperFieldConfiguration.step)
             return IncrementAction(configuration)
-                .foregroundColor(.preferredColor(.tintColor))
+                .foregroundColor(.preferredColor(self.isLoading ? .separator : .tintColor))
                 .frame(minWidth: 44, minHeight: 44)
                 .fioriButtonStyle(StepperPlainButtonStyle(colorScheme: self.colorScheme))
-                .disabled(!isIncrementBtnEnabled)
+                .disabled(self.isLoading ? true : !isIncrementBtnEnabled)
                 .accessibilityLabel(NSLocalizedString("Stepper increase", tableName: "FioriSwiftUICore", bundle: Bundle.accessor, comment: ""))
                 .accessibilityValue(Text(incrementDesc))
         }

--- a/Sources/FioriSwiftUICore/_FioriStyles/StepperViewStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/StepperViewStyle.fiori.swift
@@ -4,28 +4,32 @@ import SwiftUI
 
 // Base Layout style
 public struct StepperViewBaseStyle: StepperViewStyle {
+    @Environment(\.isLoading) var isLoading
+
     public func makeBody(_ configuration: StepperViewConfiguration) -> some View {
         @State var showDescription = !configuration.description.isEmpty
-        return VStack(spacing: 0) {
-            ViewThatFits(in: .horizontal) {
-                HStack(spacing: 0) {
-                    configuration.title
-                    Spacer().layoutPriority(1)
-                    configuration._stepperField
-                }
-                VStack(alignment: .leading, spacing: 0) {
-                    configuration.title
-                    HStack {
+        return SkeletonLoadingContainer {
+            VStack(spacing: 0) {
+                ViewThatFits(in: .horizontal) {
+                    HStack(spacing: 0) {
+                        configuration.title
                         Spacer().layoutPriority(1)
                         configuration._stepperField
                     }
+                    VStack(alignment: .leading, spacing: 0) {
+                        configuration.title
+                        HStack {
+                            Spacer().layoutPriority(1)
+                            configuration._stepperField
+                        }
+                    }
                 }
-            }
-            if showDescription {
-                HStack(spacing: 0) {
-                    configuration._informationView
-                    Spacer()
-                }.padding(.top, 4)
+                if showDescription {
+                    HStack(spacing: 0) {
+                        configuration._informationView
+                        Spacer()
+                    }.padding(.top, 4)
+                }
             }
         }
     }
@@ -42,10 +46,11 @@ extension StepperViewFioriStyle {
     struct TitleFioriStyle: TitleStyle {
         let stepperViewConfiguration: StepperViewConfiguration
         @Environment(\.isEnabled) var isEnabled: Bool
+        @Environment(\.isLoading) var isLoading
 
         func makeBody(_ configuration: TitleConfiguration) -> some View {
             Title(configuration)
-                .foregroundColor(.preferredColor(self.isEnabled ? .primaryLabel : .separator))
+                .foregroundColor(.preferredColor(self.isLoading ? .separator : (self.isEnabled ? .primaryLabel : .separator)))
                 .font(.fiori(forTextStyle: .subheadline, weight: .semibold))
                 .padding(EdgeInsets(top: 11, leading: 0, bottom: 11, trailing: 0))
                 .layoutPriority(1)
@@ -63,10 +68,11 @@ extension StepperViewFioriStyle {
     struct TextInputFieldFioriStyle: TextInputFieldStyle {
         let stepperViewConfiguration: StepperViewConfiguration
         @Environment(\.isEnabled) var isEnabled
+        @Environment(\.isLoading) var isLoading
 
         func makeBody(_ configuration: TextInputFieldConfiguration) -> some View {
             TextInputField(configuration)
-                .foregroundColor(.preferredColor(self.isEnabled ? .primaryLabel : .separator))
+                .foregroundColor(.preferredColor(self.isLoading ? .separator : (self.isEnabled ? .primaryLabel : .separator)))
                 .font(.fiori(forTextStyle: .body))
                 .padding(EdgeInsets(top: 0, leading: 2, bottom: 0, trailing: 2))
                 .frame(minWidth: 44)
@@ -86,23 +92,25 @@ extension StepperViewFioriStyle {
     struct DescriptionFioriStyle: DescriptionStyle {
         let stepperViewConfiguration: StepperViewConfiguration
         @Environment(\.isEnabled) var isEnabled
+        @Environment(\.isLoading) var isLoading
 
         func makeBody(_ configuration: DescriptionConfiguration) -> some View {
             Description(configuration)
                 .font(.fiori(forTextStyle: .footnote))
-                .foregroundColor(.preferredColor(self.isEnabled ? .tertiaryLabel : .separator))
+                .foregroundColor(.preferredColor(self.isLoading ? .separator : (self.isEnabled ? .tertiaryLabel : .separator)))
         }
     }
-    
+
     struct StepperFieldFioriStyle: StepperFieldStyle {
         let stepperViewConfiguration: StepperViewConfiguration
         @FocusState var isFocused: Bool
-    
+        @Environment(\.isLoading) var isLoading
+
         func makeBody(_ configuration: StepperFieldConfiguration) -> some View {
             StepperField(configuration)
                 .overlay(
                     RoundedRectangle(cornerRadius: 10)
-                        .stroke(lineWidth: self.isFocused ? 2 : 0.5)
+                        .stroke(lineWidth: self.isLoading ? 0 : (self.isFocused ? 2 : 0.5))
                         .foregroundColor(.preferredColor(self.isFocused ? .tintColor : .separator))
                 )
                 .focused(self.$isFocused)


### PR DESCRIPTION
## PR Description
### Summary
Adds Skeleton Loading support to StepperView, DateTimePicker, and DateRangePicker.
These components previously did not respond to the SDK's existing skeleton loading mechanism.
They now render the shimmer/placeholder effect when the `\.isLoading` environment value is set, consistent with components like Card, ObjectItem, and ObjectHeader.

Jira: 2172, 2173

### What changed
- `StepperViewStyle.fiori.swift`
  - Wrapped `StepperViewBaseStyle.makeBody` in `SkeletonLoadingContainer`.
  - `TitleFioriStyle`, `TextInputFieldFioriStyle`, `DescriptionFioriStyle`, and `StepperFieldFioriStyle` now read `@Environment(\.isLoading)` and switch to the `.separator` placeholder color; the field border is hidden while loading.
- `StepperFieldStyle.fiori.swift`
  - `DecrementActionFioriStyle`, `IncrementActionFioriStyle`, and `TextInputFieldFioriStyle` respond to `isLoading`, using the placeholder color and disabling the increment/decrement buttons during loading to prevent interaction.
- `DateTimePickerStyle.fiori.swift`
  - Wrapped `DateTimePickerBaseStyle.makeBody` in `SkeletonLoadingContainer`.
  - While loading, the expandable date panel stays collapsed and tap gestures are suppressed.
  - `TitleFioriStyle` / `ValueLabelFioriStyle` apply the placeholder color.
- `DateRangePickerStyle.fiori.swift`
  - Wrapped `DateRangePickerBaseStyle.makeBody` in `SkeletonLoadingContainer`.
  - While loading, tapping no longer presents the range-selection sheet.
  - `TitleFioriStyle` / `ValueLabelFioriStyle` apply the placeholder color.


### Examples
- Added a "Skeleton Loading" toggle to the existing example screens (`StepperViewExample`, `DateTimePickerExample`, `DateRangePickerExample`) that drives `.environment(\.isLoading, …)`, so the loading state can be demonstrated in-app.
