### PR TITLE
fix: 🐛 [IOSSDKBUG-2157] KeyValueFormview supports individual accessibility config (#1726)

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/FormViews/KeyValueFormViewExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/FormViews/KeyValueFormViewExample.swift
@@ -57,6 +57,7 @@ struct KeyValueFormViewExample: View {
                 List {
                     Text("Default KeyValueForm")
                     KeyValueFormView(title: self.key1, text: self.isLoading ? self.$valueText3 : self.$valueText1, placeholder: "KeyValueFormView", errorMessage: self.getErrorMessage(), maxTextLength: self.getMaxTextLength(), hintText: self.getHintText(), isCharCountEnabled: self.showsCharCount, allowsBeyondLimit: self.allowsBeyondLimit, isRequired: self.isRequired)
+                        .environment(\.isAccessibilityCombined, false)
                     
                     Text("Existing Text")
                         .italic()

--- a/Sources/FioriSwiftUICore/Utils/SkeletonLoading.swift
+++ b/Sources/FioriSwiftUICore/Utils/SkeletonLoading.swift
@@ -300,12 +300,24 @@ struct IsLoadingKey: EnvironmentKey {
     static let defaultValue: Bool = false
 }
 
+struct IsAccessibilityCombinedKey: EnvironmentKey {
+    static let defaultValue: Bool = true
+}
+
 /// A custom environment key to manage loading state across views.
 public extension EnvironmentValues {
     /// A Boolean value indicating whether content is currently loading. It can be used to show the shimmer effect.
     var isLoading: Bool {
         get { self[IsLoadingKey.self] }
         set { self[IsLoadingKey.self] = newValue }
+    }
+}
+
+public extension EnvironmentValues {
+    /// A Boolean value indicating whether accessibility elements are combined into a single element. When `true`, child elements are combined. Default is `true`.
+    var isAccessibilityCombined: Bool {
+        get { self[IsAccessibilityCombinedKey.self] }
+        set { self[IsAccessibilityCombinedKey.self] = newValue }
     }
 }
 

--- a/Sources/FioriSwiftUICore/_FioriStyles/KeyValueFormViewStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/KeyValueFormViewStyle.fiori.swift
@@ -5,13 +5,16 @@ import SwiftUI
 /// The base layout style for `KeyValueFormView`.
 public struct KeyValueFormViewBaseStyle: KeyValueFormViewStyle {
     @Environment(\.isLoading) var isLoading
+    @Environment(\.isAccessibilityCombined) var isAccessibilityCombined
     public func makeBody(_ configuration: KeyValueFormViewConfiguration) -> some View {
         SkeletonLoadingContainer {
             VStack(alignment: .leading) {
                 self.getTitle(configuration)
                 configuration._noteFormView
             }
-            .accessibilityElement(children: .combine)
+            .ifApply(self.isAccessibilityCombined, content: {
+                $0.accessibilityElement(children: .combine)
+            })
         }
     }
     


### PR DESCRIPTION
# Fix: `KeyValueFormView` Supports Individual Accessibility Configuration

### Bug Fix

🐛 Resolves an issue where `KeyValueFormView` always combined its accessibility elements with no way to override this behavior per instance. A new `isAccessibilityCombined` environment key is introduced, allowing callers to control accessibility grouping on a per-view basis.

### Changes

* `KeyValueFormViewStyle.fiori.swift`: Added `@Environment(\.isAccessibilityCombined)` to `KeyValueFormViewBaseStyle` and replaced the unconditional `.accessibilityElement(children: .combine)` modifier with a conditional `ifApply` block driven by the new environment value.

* `SkeletonLoading.swift`: Introduced the `IsAccessibilityCombinedKey` environment key (default: `true`) and exposed it as a public `isAccessibilityCombined` property on `EnvironmentValues`.

* `KeyValueFormViewExample.swift`: Added `.environment(\.isAccessibilityCombined, false)` to the first `KeyValueFormView` in the list to demonstrate per-instance accessibility configuration.

### Jira Issues

* IOSSDKBUG-2157: KeyValueFormView supports individual accessibility config

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.27.6`

- Correlation ID: `08bc37e0-7c40-11f1-8767-acd26ed5caed`
- GithubContextProvider: [https://github.com/SAP/cloud-sdk-ios-fiori/pull/1726](https://github.com/SAP/cloud-sdk-ios-fiori/pull/1726)
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Event Trigger: `pull_request.opened`
- File Content Strategy: Full file content
- LLM: `anthropic--claude-4.6-sonnet`
</details>
