### PR TITLE
fix: 🐛 [1871] [ACC] announce feedback title as header

### DIFF
--- a/Sources/FioriSwiftUICore/_FioriStyles/AIUserFeedbackStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/AIUserFeedbackStyle.fiori.swift
@@ -248,6 +248,7 @@ public struct AIUserFeedbackBaseStyle: AIUserFeedbackStyle {
                 Text(configuration.navigationTitle ?? "")
                     .foregroundColor(Color.preferredColor(.primaryLabel))
                     .font(Font.fiori(forTextStyle: .subheadline, weight: .black))
+                    .accessibilityAddTraits(.isHeader)
             }
         }
         .navigationBarBackButtonHidden(true)


### PR DESCRIPTION
# Fix: Announce Feedback Title as Accessibility Header

### Bug Fix

🐛 Fixed an accessibility issue where the navigation title in the AI User Feedback view was not being announced as a header by assistive technologies (e.g., VoiceOver).

### Changes

* `AIUserFeedbackStyle.fiori.swift`: Added `.accessibilityAddTraits(.isHeader)` to the navigation bar's principal title `Text` view, ensuring it is correctly identified and announced as a header by screen readers.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.27.6`

- Correlation ID: `60870950-7f5b-11f1-92e6-1ec49c26cb6d`
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Event Trigger: `pull_request.opened`
- File Content Strategy: Full file content
- LLM: `anthropic--claude-4.6-sonnet`
</details>
