### PR TITLE
fix: 🐛 [1868] W.A. disclosure indicator meet minimum contrast

### DIFF
--- a/Sources/FioriSwiftUICore/AIWritingAssistant/InternalWAForm.swift
+++ b/Sources/FioriSwiftUICore/AIWritingAssistant/InternalWAForm.swift
@@ -224,12 +224,19 @@ struct InternalWAForm: View {
             NavigationLink {
                 InternalWAForm(configuration: self.configuration, menus: [item.children], isTopLevel: false, navigationBarTitleString: item.title)
             } label: {
-                Text(item.title)
-                    .foregroundStyle(Color.preferredColor(self.isEnabled && item.isEnabled ? .primaryLabel : .quaternaryLabel))
-                    .font(Font.fiori(forTextStyle: .body))
-                    .accessibilityHint("\(String(format: NSLocalizedString("Open to see %@ options", tableName: "FioriSwiftUICore", bundle: Bundle.accessor, comment: ""), item.title))")
-                    .accessibilityAddTraits(.isButton)
+                HStack(spacing: 0) {
+                    Text(item.title)
+                        .foregroundStyle(Color.preferredColor(self.isEnabled && item.isEnabled ? .primaryLabel : .quaternaryLabel))
+                        .font(Font.fiori(forTextStyle: .body))
+                        .accessibilityHint("\(String(format: NSLocalizedString("Open to see %@ options", tableName: "FioriSwiftUICore", bundle: Bundle.accessor, comment: ""), item.title))")
+                        .accessibilityAddTraits(.isButton)
+                    Spacer(minLength: 8)
+                    FioriIcon.arrows.slimArrowRight
+                        .font(.system(.callout, weight: .semibold))
+                        .foregroundStyle(Color.preferredColor(.separator))
+                }
             }
+            .navigationLinkIndicatorVisibility(.hidden)
             .disabled(!item.isEnabled)
         }
     }


### PR DESCRIPTION
# Fix: Writing Assistant Disclosure Indicator Contrast

🐛 **Bug Fix**: Resolved a contrast issue with the Writing Assistant (W.A.) disclosure indicator by replacing the system-provided navigation link chevron with a custom icon that meets minimum contrast requirements.

### Changes

* `InternalWAForm.swift`: Wrapped the navigation link label in an `HStack` and replaced the default system navigation link indicator with a custom `FioriIcon.arrows.slimArrowRight` icon using `.separator` color. The native indicator is hidden via `.navigationLinkIndicatorVisibility(.hidden)`, ensuring the disclosure chevron meets minimum contrast accessibility standards.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.27.6`

- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- LLM: `anthropic--claude-4.6-sonnet`
- File Content Strategy: Full file content
- Correlation ID: `f38b8730-80f0-11f1-9838-2e319e610f3e`
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Event Trigger: `pull_request.opened`
</details>
