### PR TITLE
fix: 🐛 [IOSSDKBUG-2195] Fix the overlapping issue in CardFullWidthSingleButtonExample

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/FioriButton/CardFullWidthSingleButtonExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/FioriButton/CardFullWidthSingleButtonExample.swift
@@ -94,6 +94,8 @@ struct CardFullWidthSingleButtonExample: View {
         }
     }
     
+    @State private var availableGridViewWidth: CGFloat = 0
+    
     var body: some View {
         List {
             Section {
@@ -117,7 +119,8 @@ struct CardFullWidthSingleButtonExample: View {
                 .padding(EdgeInsets(top: 5, leading: 20, bottom: 5, trailing: 20))
                 
                 if self.isGridView {
-                    let columns = Array(repeating: GridItem(.flexible(), spacing: 8), count: 2)
+                    let count = self.availableGridViewWidth < 300 * 2 + 8 ? 1 : 2
+                    let columns = Array(repeating: GridItem(.flexible(), spacing: 8), count: count)
                     ScrollViewReader { proxy in
                         LazyVGrid(columns: columns, spacing: 10) {
                             ForEach(self._dataSource) { item in
@@ -133,6 +136,12 @@ struct CardFullWidthSingleButtonExample: View {
                             }
                         }
                     }
+                    .padding(.horizontal, 16)
+                    .onGeometryChange(for: CGFloat.self, of: { proxy in
+                        proxy.size.width
+                    }, action: { newValue in
+                        self.availableGridViewWidth = newValue
+                    })
                 } else {
                     ScrollViewReader { proxy in
                         ScrollView(.horizontal, showsIndicators: false) {

--- a/Apps/Examples/Examples/FioriSwiftUICore/FioriButton/CardFullWidthSingleButtonExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/FioriButton/CardFullWidthSingleButtonExample.swift
@@ -95,6 +95,7 @@ struct CardFullWidthSingleButtonExample: View {
     }
     
     @State private var availableGridViewWidth: CGFloat = 0
+    private var cardWidth: CGFloat = 300
     
     var body: some View {
         List {
@@ -119,7 +120,7 @@ struct CardFullWidthSingleButtonExample: View {
                 .padding(EdgeInsets(top: 5, leading: 20, bottom: 5, trailing: 20))
                 
                 if self.isGridView {
-                    let count = self.availableGridViewWidth < 300 * 2 + 8 ? 1 : 2
+                    let count = self.availableGridViewWidth < self.cardWidth * 2 + 8 ? 1 : 2
                     let columns = Array(repeating: GridItem(.flexible(), spacing: 8), count: count)
                     ScrollViewReader { proxy in
                         LazyVGrid(columns: columns, spacing: 10) {
@@ -149,7 +150,7 @@ struct CardFullWidthSingleButtonExample: View {
                                 ForEach(0 ..< self._dataSource.count, id: \.self) { index in
                                     let item = self._dataSource[index]
                                     self.cardView(for: item)
-                                        .frame(maxWidth: 300)
+                                        .frame(maxWidth: self.cardWidth)
                                         .accessibility(sortPriority: Double(self._dataSource.count - index))
                                         .id(item.id)
                                 }
@@ -212,7 +213,7 @@ struct CardFullWidthSingleButtonExample: View {
             .fioriButtonStyle(FioriPrimaryButtonStyle(.infinity, loadingState: item.loadingState))
             .disabled(item.loadingState != .unspecified)
         }
-        .frame(width: 300)
+        .frame(width: self.cardWidth)
         .fixedSize(horizontal: false, vertical: true)
         .background(Color.white)
         .accessibilityElement(children: .contain)

--- a/Apps/Examples/Examples/FioriSwiftUICore/FioriButton/CardFullWidthSingleButtonExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/FioriButton/CardFullWidthSingleButtonExample.swift
@@ -120,7 +120,7 @@ struct CardFullWidthSingleButtonExample: View {
                 .padding(EdgeInsets(top: 5, leading: 20, bottom: 5, trailing: 20))
                 
                 if self.isGridView {
-                    let count = self.availableGridViewWidth < self.cardWidth * 2 + 8 ? 1 : 2
+                    let count = self.availableGridViewWidth < self.cardWidth * 2 + 8 + 32 ? 1 : 2
                     let columns = Array(repeating: GridItem(.flexible(), spacing: 8), count: count)
                     ScrollViewReader { proxy in
                         LazyVGrid(columns: columns, spacing: 10) {


### PR DESCRIPTION
Before:
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-20 at 17 53 53" src="https://github.com/user-attachments/assets/5f7f1947-7f90-4b76-8b42-4d90ab744b3e" />

After:
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-21 at 16 17 12" src="https://github.com/user-attachments/assets/055c8471-9744-4ed3-969a-b605c983b60b" />
<img width="2622" height="1206" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-21 at 16 17 20" src="https://github.com/user-attachments/assets/467572b8-b81a-48e5-a7de-2a363c57e21a" />
