### PR TITLE
feat: 🎸 [0]Add Passcode Policy support to the Authentication

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/Onboarding/AuthenticationScreenSample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/Onboarding/AuthenticationScreenSample.swift
@@ -23,7 +23,25 @@ struct AuthenticationExamples: View {
             Button("Dynamic Authentication") {
                 self.showsDynamicAuth = true
             }
-            
+
+            NavigationLink(
+                destination: PasscodePolicyAuthenticationExample(showsIllustratedMessage: self.showsIllustratedMessage))
+            {
+                Text("Passcode Policy")
+            }
+
+            NavigationLink(
+                destination: CreatePasscodeFlowExample(showsIllustratedMessage: self.showsIllustratedMessage))
+            {
+                Text("Create Passcode Flow")
+            }
+
+            NavigationLink(
+                destination: CustomInputPasscodePolicyExample(showsIllustratedMessage: self.showsIllustratedMessage))
+            {
+                Text("Passcode Policy (Custom Input)")
+            }
+
             Toggle(isOn: self.$showsIllustratedMessage) {
                 Text("Show Illustration Message")
             }
@@ -217,5 +235,178 @@ struct AuthenticationExample: View {
                            bannerTapped: nil,
                            alignment: nil,
                            messageType: self.messageType)
+    }
+}
+
+// MARK: - Passcode Policy (single screen)
+
+/// Demonstrates a single-screen passcode entry validated against a `FioriPasscodePolicy`.
+struct PasscodePolicyAuthenticationExample: View {
+    @State private var passcode: String = ""
+    @State var showsIllustratedMessage: Bool
+
+    private let policy: FioriPasscodePolicy = {
+        var policy = FioriPasscodePolicy(minLength: 8, hasDigit: true, hasUpper: true, hasSpecial: true, minUniqueChars: 4)
+        policy.addPasscodeRule(FioriPasscodeRule(displayName: "At least 2 lowercase letters", isDisplayed: true) { passcode in
+            passcode.unicodeScalars.filter { CharacterSet.lowercaseLetters.contains($0) }.count >= 2
+        })
+        return policy
+    }()
+
+    var body: some View {
+        Authentication(detailImage: {
+            if self.showsIllustratedMessage {
+                Image(.illustration).resizable().aspectRatio(contentMode: .fit)
+            }
+        }, title: {
+            Text("Create Passcode")
+        }, subtitle: {
+            Text("Your passcode must meet the requirements below.")
+        }, isDisabled: !self.policy.validate(passcode: self.passcode)) {
+            print("passcode accepted ......")
+        }
+        .authenticationStyle(PasscodePolicyAuthenticationStyle(passcode: self.$passcode, policy: self.policy))
+        .navigationBarTitle("Passcode Policy", displayMode: .inline)
+    }
+}
+
+// MARK: - Create Passcode Flow (two steps: create -> confirm)
+
+/// Demonstrates a two-step "create passcode" flow using `PasscodePolicyAuthenticationStyle`:
+/// 1. `CreatePasscodeView` — enter a new passcode that must satisfy the policy.
+/// 2. `ConfirmPasscodeView` — re-enter the passcode; it must match the one from step 1.
+struct CreatePasscodeFlowExample: View {
+    @State var showsIllustratedMessage: Bool
+
+    /// The policy for the "create" step.
+    private let policy: FioriPasscodePolicy = {
+        var policy = FioriPasscodePolicy(minLength: 8, hasDigit: true, hasUpper: true, hasSpecial: true, minUniqueChars: 4)
+        policy.addPasscodeRule(FioriPasscodeRule(displayName: "At least 2 lowercase letters", isDisplayed: true) { passcode in
+            passcode.unicodeScalars.filter { CharacterSet.lowercaseLetters.contains($0) }.count >= 2
+        })
+        return policy
+    }()
+
+    var body: some View {
+        CreatePasscodeView(policy: self.policy, showsIllustratedMessage: self.showsIllustratedMessage)
+    }
+}
+
+/// Step 1: enter a new passcode that satisfies the policy, then continue to confirmation.
+struct CreatePasscodeView: View {
+    let policy: FioriPasscodePolicy
+    var showsIllustratedMessage: Bool
+
+    @State private var passcode: String = ""
+    @State private var showsConfirm: Bool = false
+
+    var body: some View {
+        Authentication(detailImage: {
+            if self.showsIllustratedMessage {
+                Image(.illustration).resizable().aspectRatio(contentMode: .fit)
+            }
+        }, title: {
+            Text("Create Passcode")
+        }, subtitle: {
+            Text("Your passcode must meet the requirements below.")
+        }, signInAction: {
+            FioriButton { _ in Text("Next") }
+        }, isDisabled: !self.policy.validate(passcode: self.passcode)) {
+            self.showsConfirm = true
+        }
+        .authenticationStyle(PasscodePolicyAuthenticationStyle(passcode: self.$passcode, policy: self.policy))
+        .navigationBarTitle("Create Passcode", displayMode: .inline)
+        .navigationDestination(isPresented: self.$showsConfirm) {
+            ConfirmPasscodeView(originalPasscode: self.passcode, showsIllustratedMessage: self.showsIllustratedMessage)
+        }
+    }
+}
+
+/// Step 2: re-enter the passcode; it must match the one created in step 1.
+struct ConfirmPasscodeView: View {
+    let originalPasscode: String
+    var showsIllustratedMessage: Bool
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var passcode: String = ""
+    @State private var isPresentedBanner: Bool = false
+
+    /// A policy whose single displayed requirement is "matches the original passcode".
+    private var confirmPolicy: FioriPasscodePolicy {
+        var policy = FioriPasscodePolicy(minLength: 0)
+        let original = self.originalPasscode
+        policy.addPasscodeRule(FioriPasscodeRule(displayName: "Matches the passcode above", isDisplayed: true) { passcode in
+            !passcode.isEmpty && passcode == original
+        })
+        return policy
+    }
+
+    var body: some View {
+        Authentication(detailImage: {
+            if self.showsIllustratedMessage {
+                Image(.illustration).resizable().aspectRatio(contentMode: .fit)
+            }
+        }, title: {
+            Text("Confirm Passcode")
+        }, subtitle: {
+            Text("Re-enter your passcode to confirm.")
+        }, signInAction: {
+            FioriButton { _ in Text("Done") }
+        }, isDisabled: !self.confirmPolicy.validate(passcode: self.passcode)) {
+            print("passcode created ......")
+            self.isPresentedBanner = true
+        }
+        .authenticationStyle(PasscodePolicyAuthenticationStyle(passcode: self.$passcode, policy: self.confirmPolicy))
+        .navigationBarTitle("Confirm Passcode", displayMode: .inline)
+        .bannerMessageView(isPresented: self.$isPresentedBanner,
+                           pushContentDown: .constant(false),
+                           icon: { EmptyView() },
+                           title: "Passcode created successfully",
+                           bannerTapped: nil,
+                           alignment: nil,
+                           messageType: .positive)
+    }
+}
+
+// MARK: - Passcode Policy with custom authInput
+
+/// Demonstrates supplying a custom `authInput` (multiple fields / custom styles) while still
+/// letting `PasscodePolicyAuthenticationStyle` append the live requirement checklist below it.
+/// The custom passcode field and the style share the same `passcode` binding, so the checklist
+/// updates as the user types.
+struct CustomInputPasscodePolicyExample: View {
+    @State private var name: String = ""
+    @State private var passcode: String = ""
+    @State var showsIllustratedMessage: Bool
+
+    private let policy = FioriPasscodePolicy(minLength: 8, hasDigit: true, hasUpper: true, hasSpecial: true, minUniqueChars: 4)
+
+    var body: some View {
+        Authentication(detailImage: {
+            if self.showsIllustratedMessage {
+                Image(.illustration).resizable().aspectRatio(contentMode: .fit)
+            }
+        }, title: {
+            Text("Create Passcode")
+        }, subtitle: {
+            Text("Custom fields with an appended requirement checklist.")
+        }, authInput: {
+            VStack(spacing: 16) {
+                TextFieldFormView(title: "User Name:", text: self.$name, placeholder: "Enter your name")
+                    .textFieldFormViewStyle(AuthTextFieldStyle())
+                    .titleStyle { config in
+                        config.title.font(.fiori(forTextStyle: .headline, weight: .medium))
+                    }
+                TextFieldFormView(title: "Passcode:", text: self.$passcode, isSecureEnabled: true, placeholder: "Enter your passcode")
+                    .textFieldFormViewStyle(AuthTextFieldStyle())
+                    .titleStyle { config in
+                        config.title.font(.fiori(forTextStyle: .headline, weight: .medium))
+                    }
+            }
+        }, isDisabled: self.name.isEmpty || !self.policy.validate(passcode: self.passcode)) {
+            print("passcode accepted ......")
+        }
+        .authenticationStyle(PasscodePolicyAuthenticationStyle(passcode: self.$passcode, policy: self.policy))
+        .navigationBarTitle("Custom Input", displayMode: .inline)
     }
 }

--- a/Sources/FioriSwiftUICore/Models/FioriPasscodePolicy.swift
+++ b/Sources/FioriSwiftUICore/Models/FioriPasscodePolicy.swift
@@ -1,0 +1,262 @@
+import Foundation
+
+/// A passcode policy that defines the requirements a passcode must satisfy.
+///
+/// This is the SwiftUI counterpart of the UIKit `FUIPasscodePolicy`. It carries the pure
+/// validation business logic (minimum length, required character classes, minimum unique
+/// characters, and user-defined rules) and is decoupled from any UI so it can be reused and
+/// unit-tested. Use it together with `PasscodePolicyAuthenticationStyle` to drive a
+/// requirement checklist in the `Authentication` component.
+///
+/// Example:
+/// ```swift
+/// var policy = FioriPasscodePolicy(minLength: 8, hasDigit: true, hasUpper: true, hasSpecial: true, minUniqueChars: 4)
+/// policy.addPasscodeRule(FioriPasscodeRule(displayName: "At least 2 lowercase", isDisplayed: true) { passcode in
+///     passcode.unicodeScalars.filter { CharacterSet.lowercaseLetters.contains($0) }.count >= 2
+/// })
+/// let isValid = policy.validate(passcode: "Abc12!de")
+/// ```
+public struct FioriPasscodePolicy {
+    /// The default minimum length of characters in a passcode.
+    public static let defaultMinLength = 8
+
+    /// Represents "no limit" for `Int` properties such as `minUniqueChars`.
+    public static let noLimit = -1
+
+    /// The minimum number of characters in the passcode.
+    /// `validate(passcode:)` returns `false` if the passcode length is less than this value.
+    public var minLength: Int
+
+    /// Whether the passcode must contain at least one digit.
+    public var hasDigit: Bool
+
+    /// Whether the passcode must contain at least one uppercase character.
+    public var hasUpper: Bool
+
+    /// Whether the passcode must contain at least one lowercase character.
+    public var hasLower: Bool
+
+    /// Whether the passcode must contain at least one special (non-alphanumeric) character.
+    public var hasSpecial: Bool
+
+    /// When `true`, the passcode must contain digits only. All of `hasDigit`, `hasUpper`,
+    /// `hasLower`, and `hasSpecial` are ignored when this is `true`.
+    public var isDigitsOnly: Bool
+
+    /// The minimum number of unique characters the passcode must contain.
+    /// A value of `noLimit` (or `0`) disables this check.
+    public var minUniqueChars: Int
+
+    /// The user-defined passcode rules added to this policy.
+    public private(set) var passcodeRules: [FioriPasscodeRule]
+
+    // When `minUniqueChars` is 0 or `noLimit`, the check is always satisfied, so skip it.
+    var hasMinUniqueChars: Bool {
+        self.minUniqueChars > 0
+    }
+
+    /// Creates a passcode policy.
+    /// - Parameters:
+    ///   - minLength: Minimum number of characters. Defaults to `defaultMinLength` (8).
+    ///   - hasDigit: Requires at least one digit. Defaults to `false`.
+    ///   - hasUpper: Requires at least one uppercase character. Defaults to `false`.
+    ///   - hasLower: Requires at least one lowercase character. Defaults to `false`.
+    ///   - hasSpecial: Requires at least one special character. Defaults to `false`.
+    ///   - isDigitsOnly: Requires the passcode to contain digits only. Defaults to `false`.
+    ///   - minUniqueChars: Minimum number of unique characters. Defaults to `noLimit`.
+    public init(minLength: Int = FioriPasscodePolicy.defaultMinLength,
+                hasDigit: Bool = false,
+                hasUpper: Bool = false,
+                hasLower: Bool = false,
+                hasSpecial: Bool = false,
+                isDigitsOnly: Bool = false,
+                minUniqueChars: Int = FioriPasscodePolicy.noLimit)
+    {
+        self.minLength = minLength
+        self.hasDigit = hasDigit
+        self.hasUpper = hasUpper
+        self.hasLower = hasLower
+        self.hasSpecial = hasSpecial
+        self.isDigitsOnly = isDigitsOnly
+        self.minUniqueChars = minUniqueChars
+        self.passcodeRules = []
+    }
+
+    /// Adds a user-defined passcode rule to the policy.
+    /// - Parameter rule: The rule to add.
+    public mutating func addPasscodeRule(_ rule: FioriPasscodeRule) {
+        self.passcodeRules.append(rule)
+    }
+
+    /// Validates a passcode against the policy.
+    ///
+    /// The passcode passes only if every enabled requirement is satisfied.
+    /// - Parameter passcode: The passcode to check.
+    /// - Returns: `true` if the passcode satisfies all requirements.
+    public func validate(passcode: String) -> Bool {
+        if passcode.count < self.minLength {
+            return false
+        }
+
+        for rule in self.passcodeRules where !rule.rule(passcode) {
+            return false
+        }
+
+        if self.isDigitsOnly {
+            guard self.checkDigitOnly(passcode) else { return false }
+            if self.hasMinUniqueChars, !self.checkUniqueChars(passcode) {
+                return false
+            }
+            return true
+        }
+
+        if self.hasDigit, !self.checkDigit(passcode) {
+            return false
+        }
+        if self.hasUpper, !self.checkUpper(passcode) {
+            return false
+        }
+        if self.hasLower, !self.checkLower(passcode) {
+            return false
+        }
+        if self.hasSpecial, !self.checkSpecial(passcode) {
+            return false
+        }
+        if self.hasMinUniqueChars, !self.checkUniqueChars(passcode) {
+            return false
+        }
+
+        return true
+    }
+
+    /// Returns each enabled requirement together with whether it is currently satisfied by
+    /// the given passcode. This is intended to drive a live requirement checklist in the UI.
+    /// - Parameter passcode: The passcode to evaluate.
+    /// - Returns: The list of requirements with their current satisfaction state.
+    public func requirements(for passcode: String) -> [(requirement: FioriPasscodeRequirement, isSatisfied: Bool)] {
+        var result = self.requirements()
+            .map { (requirement: $0, isSatisfied: $0.check(passcode)) }
+        // Include displayed user-defined rules.
+        for rule in self.passcodeRules where rule.isDisplayed {
+            let requirement = FioriPasscodeRequirement(id: "rule.\(rule.displayName)", displayName: rule.displayName, check: rule.rule)
+            result.append((requirement: requirement, isSatisfied: rule.rule(passcode)))
+        }
+        return result
+    }
+
+    /// Builds the list of enabled built-in requirements (without evaluating them).
+    private func requirements() -> [FioriPasscodeRequirement] {
+        var result = [FioriPasscodeRequirement]()
+
+        if self.minLength > 0 {
+            let format = "At least %d characters".localizedFioriString()
+            let name = String(format: format, self.minLength)
+            result.append(FioriPasscodeRequirement(id: "minLength", displayName: name) { $0.count >= self.minLength })
+        }
+
+        if self.isDigitsOnly {
+            result.append(FioriPasscodeRequirement(id: "isDigitsOnly", displayName: "Digits only".localizedFioriString(), check: self.checkDigitOnly))
+        } else {
+            if self.hasDigit {
+                result.append(FioriPasscodeRequirement(id: "hasDigit", displayName: "At least one digit".localizedFioriString(), check: self.checkDigit))
+            }
+            if self.hasUpper {
+                result.append(FioriPasscodeRequirement(id: "hasUpper", displayName: "At least one uppercase letter".localizedFioriString(), check: self.checkUpper))
+            }
+            if self.hasLower {
+                result.append(FioriPasscodeRequirement(id: "hasLower", displayName: "At least one lowercase letter".localizedFioriString(), check: self.checkLower))
+            }
+            if self.hasSpecial {
+                result.append(FioriPasscodeRequirement(id: "hasSpecial", displayName: "At least one special character".localizedFioriString(), check: self.checkSpecial))
+            }
+        }
+
+        if self.hasMinUniqueChars {
+            let format = "At least %d unique characters".localizedFioriString()
+            let name = String(format: format, self.minUniqueChars)
+            result.append(FioriPasscodeRequirement(id: "minUniqueChars", displayName: name, check: self.checkUniqueChars))
+        }
+
+        return result
+    }
+
+    // MARK: - Character checks (ported from UIKit FUIPasscodePolicy)
+
+    func checkDigit(_ passcode: String) -> Bool {
+        for c in passcode.unicodeScalars where CharacterSet.decimalDigits.contains(c) {
+            return true
+        }
+        return false
+    }
+
+    func checkDigitOnly(_ passcode: String) -> Bool {
+        for c in passcode.unicodeScalars where !CharacterSet.decimalDigits.contains(c) {
+            return false
+        }
+        return !passcode.isEmpty
+    }
+
+    func checkUpper(_ passcode: String) -> Bool {
+        for c in passcode.unicodeScalars where CharacterSet.uppercaseLetters.contains(c) {
+            return true
+        }
+        return false
+    }
+
+    func checkLower(_ passcode: String) -> Bool {
+        for c in passcode.unicodeScalars where CharacterSet.lowercaseLetters.contains(c) {
+            return true
+        }
+        return false
+    }
+
+    func checkSpecial(_ passcode: String) -> Bool {
+        // A special character is anything that is not alphanumeric.
+        for c in passcode.unicodeScalars where !CharacterSet.alphanumerics.contains(c) {
+            return true
+        }
+        return false
+    }
+
+    func checkUniqueChars(_ passcode: String) -> Bool {
+        var seen = Set<UnicodeScalar>()
+        for c in passcode.unicodeScalars {
+            seen.insert(c)
+        }
+        return seen.count >= self.minUniqueChars
+    }
+}
+
+/// A single passcode requirement that can be displayed in a requirement checklist.
+public struct FioriPasscodeRequirement: Identifiable {
+    /// A stable identifier for the requirement.
+    public let id: String
+    /// The user-facing description of the requirement.
+    public let displayName: String
+    /// The closure that evaluates whether a passcode satisfies this requirement.
+    let check: (String) -> Bool
+
+    init(id: String, displayName: String, check: @escaping (String) -> Bool) {
+        self.id = id
+        self.displayName = displayName
+        self.check = check
+    }
+}
+
+/// A user-defined passcode rule that can be added to a `FioriPasscodePolicy`.
+public struct FioriPasscodeRule {
+    let displayName: String
+    let isDisplayed: Bool
+    let rule: (String) -> Bool
+
+    /// Creates a user-defined passcode rule.
+    /// - Parameters:
+    ///   - displayName: The text shown for this rule in the requirement checklist.
+    ///   - isDisplayed: Whether this rule is shown to the user in the checklist.
+    ///   - rule: The closure that returns `true` when the passcode satisfies the rule.
+    public init(displayName: String, isDisplayed: Bool, rule: @escaping (String) -> Bool) {
+        self.displayName = displayName
+        self.isDisplayed = isDisplayed
+        self.rule = rule
+    }
+}

--- a/Sources/FioriSwiftUICore/Models/FioriPasscodePolicy.swift
+++ b/Sources/FioriSwiftUICore/Models/FioriPasscodePolicy.swift
@@ -40,7 +40,8 @@ public struct FioriPasscodePolicy {
     public var hasSpecial: Bool
 
     /// When `true`, the passcode must contain digits only. All of `hasDigit`, `hasUpper`,
-    /// `hasLower`, and `hasSpecial` are ignored when this is `true`.
+    /// `hasLower`, and `hasSpecial` are ignored when this is `true`. User-defined rules added
+    /// via `addPasscodeRule(_:)` are still evaluated.
     public var isDigitsOnly: Bool
 
     /// The minimum number of unique characters the passcode must contain.
@@ -90,7 +91,8 @@ public struct FioriPasscodePolicy {
 
     /// Validates a passcode against the policy.
     ///
-    /// The passcode passes only if every enabled requirement is satisfied.
+    /// The passcode passes only if every enabled requirement is satisfied. User-defined rules
+    /// added via `addPasscodeRule(_:)` are always evaluated, including when `isDigitsOnly` is `true`.
     /// - Parameter passcode: The passcode to check.
     /// - Returns: `true` if the passcode satisfies all requirements.
     public func validate(passcode: String) -> Bool {
@@ -131,15 +133,19 @@ public struct FioriPasscodePolicy {
 
     /// Returns each enabled requirement together with whether it is currently satisfied by
     /// the given passcode. This is intended to drive a live requirement checklist in the UI.
+    ///
+    /// - Note: Displayed user-defined rules (see `addPasscodeRule(_:)`) are always included,
+    ///   regardless of `isDigitsOnly`.
     /// - Parameter passcode: The passcode to evaluate.
     /// - Returns: The list of requirements with their current satisfaction state.
     public func requirements(for passcode: String) -> [(requirement: FioriPasscodeRequirement, isSatisfied: Bool)] {
         var result = self.requirements()
             .map { (requirement: $0, isSatisfied: $0.check(passcode)) }
-        // Include displayed user-defined rules.
-        for rule in self.passcodeRules where rule.isDisplayed {
-            let requirement = FioriPasscodeRequirement(id: "rule.\(rule.displayName)", displayName: rule.displayName, check: rule.rule)
-            result.append((requirement: requirement, isSatisfied: rule.rule(passcode)))
+        // Include displayed user-defined rules. Use the rule's index for a stable, unique id so
+        // rules that share a display name do not collide in SwiftUI's ForEach.
+        for (index, rule) in self.passcodeRules.enumerated() where rule.isDisplayed {
+            let requirement = FioriPasscodeRequirement(id: "rule.\(index)", displayName: rule.displayName, check: rule.rule)
+            result.append((requirement: requirement, isSatisfied: requirement.check(passcode)))
         }
         return result
     }
@@ -245,8 +251,10 @@ public struct FioriPasscodeRequirement: Identifiable {
 
 /// A user-defined passcode rule that can be added to a `FioriPasscodePolicy`.
 public struct FioriPasscodeRule {
-    let displayName: String
-    let isDisplayed: Bool
+    /// The text shown for this rule in the requirement checklist.
+    public let displayName: String
+    /// Whether this rule is shown to the user in the checklist.
+    public let isDisplayed: Bool
     let rule: (String) -> Bool
 
     /// Creates a user-defined passcode rule.

--- a/Sources/FioriSwiftUICore/_FioriStyles/AuthenticationStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/AuthenticationStyle.fiori.swift
@@ -238,6 +238,11 @@ struct PasscodePolicyInputStyle: AuthInputStyle {
                 TextFieldFormView(title: "", text: self.$passcode, isSecureEnabled: true, placeholder: AttributedString("passcode".localizedFioriString()))
                     .textFieldFormViewStyle(AuthTextFieldStyle())
                     .focused(self.$passcodeFocused)
+                    .onAppear {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+                            self.passcodeFocused = true
+                        }
+                    }
             } else {
                 // Render the caller-provided custom input (custom fields / styles) as-is.
                 configuration.authInput
@@ -255,11 +260,6 @@ struct PasscodePolicyInputStyle: AuthInputStyle {
                     }
                     .accessibilityElement(children: .combine)
                 }
-            }
-        }
-        .onAppear {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
-                self.passcodeFocused = true
             }
         }
     }

--- a/Sources/FioriSwiftUICore/_FioriStyles/AuthenticationStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/AuthenticationStyle.fiori.swift
@@ -185,6 +185,86 @@ struct AuthInputFieldStyle: AuthInputStyle {
     }
 }
 
+// MARK: - Passcode Policy Authentication Style
+
+/// A custom authentication style that validates a passcode against a `FioriPasscodePolicy`.
+///
+/// It renders a secure passcode field followed by a live requirement checklist: each requirement
+/// defined by the policy is shown with a checkmark that updates as the user types. Use the policy's
+/// `validate(passcode:)` to drive the sign-in button's disabled state, for example:
+/// ```swift
+/// Authentication(
+///     title: { Text("Create Passcode") },
+///     isDisabled: !policy.validate(passcode: passcode)
+/// ) { /* accepted */ }
+/// .authenticationStyle(PasscodePolicyAuthenticationStyle(passcode: $passcode, policy: policy))
+/// ```
+public struct PasscodePolicyAuthenticationStyle: AuthenticationStyle {
+    @Binding var passcode: String
+    let policy: FioriPasscodePolicy
+
+    /// Initializes the passcode policy authentication style.
+    /// - Parameters:
+    ///   - passcode: Binding for the passcode field.
+    ///   - policy: The passcode policy that defines the requirements.
+    public init(passcode: Binding<String>, policy: FioriPasscodePolicy) {
+        self._passcode = passcode
+        self.policy = policy
+    }
+
+    public func makeBody(_ configuration: AuthenticationConfiguration) -> some View {
+        Authentication(configuration)
+            .authInputStyle(PasscodePolicyInputStyle(passcode: self.$passcode, policy: self.policy))
+    }
+}
+
+// MARK: - Passcode Policy Input Style
+
+/// Input style for `PasscodePolicyAuthenticationStyle`: renders the passcode input followed by a
+/// live requirement checklist driven by the `FioriPasscodePolicy`.
+///
+/// If the caller supplies a custom `authInput` (any number of fields / custom styles) via
+/// `Authentication(authInput:)`, that content is rendered as-is and the requirement checklist is
+/// appended below it. Otherwise a built-in secure passcode field is used.
+struct PasscodePolicyInputStyle: AuthInputStyle {
+    @Binding var passcode: String
+    let policy: FioriPasscodePolicy
+    @FocusState private var passcodeFocused: Bool
+
+    func makeBody(_ configuration: AuthInputConfiguration) -> some View {
+        VStack(alignment: .leading, spacing: 16) {
+            if configuration.authInput.isEmpty {
+                // No custom input provided: use a built-in secure passcode field.
+                TextFieldFormView(title: "", text: self.$passcode, isSecureEnabled: true, placeholder: AttributedString("passcode".localizedFioriString()))
+                    .textFieldFormViewStyle(AuthTextFieldStyle())
+                    .focused(self.$passcodeFocused)
+            } else {
+                // Render the caller-provided custom input (custom fields / styles) as-is.
+                configuration.authInput
+            }
+
+            // Live requirement checklist, appended below whichever input is shown.
+            VStack(alignment: .leading, spacing: 8) {
+                ForEach(self.policy.requirements(for: self.passcode), id: \.requirement.id) { item in
+                    HStack(spacing: 8) {
+                        Image(systemName: item.isSatisfied ? "checkmark.circle.fill" : "circle")
+                            .foregroundStyle(item.isSatisfied ? Color.preferredColor(.positiveLabel) : Color.preferredColor(.tertiaryLabel))
+                        Text(item.requirement.displayName)
+                            .font(.fiori(forTextStyle: .subheadline))
+                            .foregroundStyle(item.isSatisfied ? Color.preferredColor(.primaryLabel) : Color.preferredColor(.tertiaryLabel))
+                    }
+                    .accessibilityElement(children: .combine)
+                }
+            }
+        }
+        .onAppear {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+                self.passcodeFocused = true
+            }
+        }
+    }
+}
+
 // MARK: - Auth Text Field Style
 
 /// Style for authentication Text fields

--- a/Sources/FioriSwiftUICore/_localization/en.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/en.lproj/FioriSwiftUICore.strings
@@ -715,3 +715,24 @@
 
 /* XACT: The accessibility label for the checkbox */
 "Checkbox" = "Checkbox";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "At least %d characters";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "At least %d unique characters";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "At least one digit";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "At least one uppercase letter";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "At least one lowercase letter";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "At least one special character";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "Digits only";

--- a/Tests/FioriSwiftUITests/FioriSwiftUICore/FioriPasscodePolicyTests.swift
+++ b/Tests/FioriSwiftUITests/FioriSwiftUICore/FioriPasscodePolicyTests.swift
@@ -1,0 +1,92 @@
+@testable import FioriSwiftUICore
+import XCTest
+
+final class FioriPasscodePolicyTests: XCTestCase {
+    // MARK: - validate(passcode:)
+
+    func testTooShortFails() {
+        let policy = FioriPasscodePolicy(minLength: 8)
+        XCTAssertFalse(policy.validate(passcode: "Abc12!"))
+        XCTAssertTrue(policy.validate(passcode: "abcdefgh"))
+    }
+
+    func testRequiresDigit() {
+        let policy = FioriPasscodePolicy(minLength: 4, hasDigit: true)
+        XCTAssertFalse(policy.validate(passcode: "abcd"))
+        XCTAssertTrue(policy.validate(passcode: "abc1"))
+    }
+
+    func testRequiresUpperLowerSpecial() {
+        let policy = FioriPasscodePolicy(minLength: 4, hasUpper: true, hasLower: true, hasSpecial: true)
+        XCTAssertFalse(policy.validate(passcode: "abcd"), "missing upper and special")
+        XCTAssertFalse(policy.validate(passcode: "Abcd"), "missing special")
+        XCTAssertTrue(policy.validate(passcode: "Abc!"))
+    }
+
+    func testMinUniqueChars() {
+        let policy = FioriPasscodePolicy(minLength: 4, minUniqueChars: 4)
+        XCTAssertFalse(policy.validate(passcode: "aabb"), "only 2 unique chars")
+        XCTAssertTrue(policy.validate(passcode: "abcd"))
+    }
+
+    func testDigitsOnly() {
+        let policy = FioriPasscodePolicy(minLength: 4, isDigitsOnly: true)
+        XCTAssertFalse(policy.validate(passcode: "12a4"))
+        XCTAssertTrue(policy.validate(passcode: "1234"))
+    }
+
+    func testDigitsOnlyIgnoresCharacterClassRequirements() {
+        // When isDigitsOnly is true, hasUpper/hasLower/hasSpecial are ignored.
+        let policy = FioriPasscodePolicy(minLength: 4, hasUpper: true, hasSpecial: true, isDigitsOnly: true)
+        XCTAssertTrue(policy.validate(passcode: "1234"))
+    }
+
+    func testCustomRule() {
+        var policy = FioriPasscodePolicy(minLength: 4)
+        policy.addPasscodeRule(FioriPasscodeRule(displayName: "2+ lowercase", isDisplayed: true) { passcode in
+            passcode.unicodeScalars.filter { CharacterSet.lowercaseLetters.contains($0) }.count >= 2
+        })
+        XCTAssertFalse(policy.validate(passcode: "A1B2"), "no lowercase")
+        XCTAssertTrue(policy.validate(passcode: "ab12"))
+    }
+
+    func testAllRequirementsCombined() {
+        var policy = FioriPasscodePolicy(minLength: 8, hasDigit: true, hasUpper: true, hasSpecial: true, minUniqueChars: 4)
+        policy.addPasscodeRule(FioriPasscodeRule(displayName: "2+ lowercase", isDisplayed: true) { passcode in
+            passcode.unicodeScalars.filter { CharacterSet.lowercaseLetters.contains($0) }.count >= 2
+        })
+        XCTAssertFalse(policy.validate(passcode: "Ab1!"), "too short")
+        XCTAssertTrue(policy.validate(passcode: "Abcd12!x"))
+    }
+
+    // MARK: - requirements(for:)
+
+    func testRequirementsListsEnabledChecks() {
+        let policy = FioriPasscodePolicy(minLength: 8, hasDigit: true, hasUpper: true, minUniqueChars: 4)
+        let ids = policy.requirements(for: "").map(\.requirement.id)
+        XCTAssertTrue(ids.contains("minLength"))
+        XCTAssertTrue(ids.contains("hasDigit"))
+        XCTAssertTrue(ids.contains("hasUpper"))
+        XCTAssertTrue(ids.contains("minUniqueChars"))
+        XCTAssertFalse(ids.contains("hasLower"), "hasLower not enabled")
+        XCTAssertFalse(ids.contains("hasSpecial"), "hasSpecial not enabled")
+    }
+
+    func testRequirementsSatisfactionUpdates() {
+        let policy = FioriPasscodePolicy(minLength: 8, hasDigit: true)
+        let empty = policy.requirements(for: "")
+        XCTAssertTrue(empty.allSatisfy { !$0.isSatisfied })
+
+        let full = policy.requirements(for: "abcdefg1")
+        XCTAssertTrue(full.allSatisfy(\.isSatisfied))
+    }
+
+    func testRequirementsIncludesDisplayedCustomRuleOnly() {
+        var policy = FioriPasscodePolicy(minLength: 4)
+        policy.addPasscodeRule(FioriPasscodeRule(displayName: "shown", isDisplayed: true) { _ in true })
+        policy.addPasscodeRule(FioriPasscodeRule(displayName: "hidden", isDisplayed: false) { _ in true })
+        let names = policy.requirements(for: "abcd").map(\.requirement.displayName)
+        XCTAssertTrue(names.contains("shown"))
+        XCTAssertFalse(names.contains("hidden"))
+    }
+}


### PR DESCRIPTION
# Add Passcode Policy support to the Authentication component
## Summary
This PR brings the passcode-policy validation business logic from the UIKit SDK (`FUIPasscodePolicy` in SAPFiori) to the SwiftUI Authentication component.

It introduces a reusable, unit-testable policy type and a public `AuthenticationStyle` that renders a passcode field with a live requirement checklist. Apps can enforce passcode rules (minimum length, required character classes, minimum unique characters, and custom rules) with real-time visual feedback.

## What's included
1. **FioriPasscodePolicy** — pure validation logic
`Sources/FioriSwiftUICore/Models/FioriPasscodePolicy.swift`
- Ported character-class validation from UIKit `FUIPasscodePolicy`: minimum length, digit/upper/lower/special, digits-only, minimum unique chars, user-defined rules.
- `validate(passcode:)` returns whether a passcode satisfies the whole policy.
- New `requirements(for:)` returns each enabled requirement with its current satisfaction state, purpose-built to drive a live UI checklist.
- Decoupled from UI, reusable and unit-testable.
- Out of scope (deferred): HCPms config parsing, TouchID/biometrics, lock/foreground timeouts, expiry/history/retry.

2. **PasscodePolicyAuthenticationStyle** — public style
`Sources/FioriSwiftUICore/_FioriStyles/AuthenticationStyle.fiori.swift`
- New public `AuthenticationStyle`, hand-written following existing `BasicAuthenticationStyle` pattern (no Sourcery generated changes required).
- Internal `PasscodePolicyInputStyle` renders a secure passcode field plus live requirement checklist (checkmarks update as user types; satisfied/unsatisfied use `positiveLabel` / `tertiaryLabel`).
- Custom input support: if caller supplies a custom `authInput` (multiple fields / custom styles), the content renders as-is and requirement checklist is appended below; otherwise built-in secure passcode field is used.

3. **Localization**
Added English strings for built-in requirement labels:
`Sources/FioriSwiftUICore/_localization/en.lproj/FioriSwiftUICore.strings`

4. **Examples**
`Apps/Examples/.../Onboarding/AuthenticationScreenSample.swift`
- Passcode Policy — single-screen passcode entry validated against a policy.
- Create Passcode Flow — two-step create → confirm flow (`CreatePasscodeView` / `ConfirmPasscodeView`); confirm step reuses same style with a "matches the passcode above" rule.
- Passcode Policy (Custom Input) — demonstrates custom multi-field `authInput` with checklist appended below.

5. **Unit tests**
`Tests/FioriSwiftUITests/FioriSwiftUICore/FioriPasscodePolicyTests.swift`
- Covers `validate(passcode:)`: too short, missing character classes, insufficient unique chars, digits-only, custom rules, combined scenarios.
- Covers `requirements(for:)`: enabled-check listing, satisfaction updates, displayed-only custom rules.

Screenshot:


https://github.com/user-attachments/assets/83c57097-d7d9-4846-9b6a-1c0733fdc149

