### PR TITLE
fix: 🐛 [IOSSDKBUG-1468] ACC: Fix the wrong reading order of card media (image and description)

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/FioriButton/CardViewWithTwoButtonsExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/FioriButton/CardViewWithTwoButtonsExample.swift
@@ -14,7 +14,7 @@ struct CardViewWithTwoButtonsExample: View {
                         .aspectRatio(contentMode: .fill)
                         .frame(height: 145)
                 } description: {
-                    Text("Title")
+                    Text("Description")
                 } title: {
                     Text("Title that goes to three lines before truncating just like that")
                         .lineLimit(11)

--- a/Sources/FioriSwiftUICore/_ComponentProtocols/CompositeComponentProtocols.swift
+++ b/Sources/FioriSwiftUICore/_ComponentProtocols/CompositeComponentProtocols.swift
@@ -206,7 +206,7 @@ protocol _CardFooterComponent: _ActionComponent, _SecondaryActionComponent, _Ter
 ///         .aspectRatio(contentMode: .fill)
 ///         .frame(height: 145)
 /// } description: {
-///     Text("Title")
+///     Text("Description")
 /// } title: {
 ///     Text("Title that goes to two lines before truncating")
 /// } subtitle: {
@@ -291,7 +291,7 @@ protocol _CardHeaderComponent: _CardMediaComponent, _CardMainHeaderComponent, _C
 ///         .aspectRatio(contentMode: .fill)
 ///         .frame(height: 145)
 /// } description: {
-///     Text("Title")
+///     Text("Description")
 /// } title: {
 ///     Text("Title that goes to two lines before truncating")
 /// } subtitle: {
@@ -358,7 +358,7 @@ protocol _CardHeaderComponent: _CardMediaComponent, _CardMainHeaderComponent, _C
 ///
 /// ```swift
 /// Card(mediaImage: Image("productThumbnail"),
-///      description: "Title",
+///      description: "Description",
 ///      title: "Title",
 ///      subtitle: "Subtitle",
 ///      icons: [TextOrIcon.icon(Image(systemName: "circle.fill"))],

--- a/Sources/FioriSwiftUICore/_FioriStyles/CardHeaderStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/CardHeaderStyle.fiori.swift
@@ -34,6 +34,7 @@ public struct CardHeaderBaseStyle: CardHeaderStyle {
                     .padding(EdgeInsets(top: 6, leading: 16, bottom: 6, trailing: 16))
             }
         }
+        .accessibilityElement(children: .contain)
     }
 }
 
@@ -317,7 +318,7 @@ extension CardHeaderFioriStyle {
         Color.purple
             .frame(height: 145)
     } description: {
-        Text("Title")
+        Text("Description")
     } title: {
         Text("Title")
     } subtitle: {

--- a/Sources/FioriSwiftUICore/_FioriStyles/CardMediaStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/CardMediaStyle.fiori.swift
@@ -18,9 +18,11 @@ public struct CardMediaBaseStyle: CardMediaStyle {
         // Add default layout here
         ZStack(alignment: .bottomLeading) {
             configuration.mediaImage
-            
+                .accessibilitySortPriority(4)
+
             configuration.description
                 .padding(EdgeInsets(top: 16, leading: 16, bottom: 16, trailing: 16))
+                .accessibilitySortPriority(3)
         }
     }
 }
@@ -167,7 +169,7 @@ extension CardMediaFioriStyle {
             .frame(maxWidth: .infinity, maxHeight: 245)
             .border(Color.blue, width: 3)
     } description: {
-        Text("Title")
+        Text("Description")
     }
     .border(Color.green)
 }
@@ -188,7 +190,7 @@ extension CardMediaFioriStyle {
         Color.purple
             .frame(height: 145)
     } description: {
-        Text("Title")
+        Text("Description")
     }
     .border(Color.green)
 }

--- a/Sources/FioriSwiftUICore/_FioriStyles/CardStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/CardStyle.fiori.swift
@@ -859,7 +859,7 @@ public enum CardTests {
             .aspectRatio(contentMode: .fill)
             .frame(height: 345)
     } description: {
-        Text("Title")
+        Text("Description")
     } title: {
         Text("Title that goes to two lines before truncating just like that")
     } detailImage: {
@@ -1119,7 +1119,7 @@ public enum CardTests {
         Color.purple
             .frame(height: 84)
     } description: {
-        Text("Title")
+        Text("Description")
     } title: {
         Text("Title")
     } subtitle: {
@@ -1178,7 +1178,7 @@ public enum CardTests {
             .aspectRatio(contentMode: .fill)
             .frame(height: 145)
     } description: {
-        Text("Title")
+        Text("Description")
     } title: {
         Text("Title that goes to three lines before truncating just like that")
     } subtitle: {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Card/Card.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Card/Card.generated.swift
@@ -20,7 +20,7 @@ import SwiftUI
 ///         .aspectRatio(contentMode: .fill)
 ///         .frame(height: 145)
 /// } description: {
-///     Text("Title")
+///     Text("Description")
 /// } title: {
 ///     Text("Title that goes to two lines before truncating")
 /// } subtitle: {
@@ -87,7 +87,7 @@ import SwiftUI
 ///
 /// ```swift
 /// Card(mediaImage: Image("productThumbnail"),
-///      description: "Title",
+///      description: "Description",
 ///      title: "Title",
 ///      subtitle: "Subtitle",
 ///      icons: [TextOrIcon.icon(Image(systemName: "circle.fill"))],

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/CardHeader/CardHeader.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/CardHeader/CardHeader.generated.swift
@@ -20,7 +20,7 @@ import SwiftUI
 ///         .aspectRatio(contentMode: .fill)
 ///         .frame(height: 145)
 /// } description: {
-///     Text("Title")
+///     Text("Description")
 /// } title: {
 ///     Text("Title that goes to two lines before truncating")
 /// } subtitle: {


### PR DESCRIPTION
a. fix the reading order
b. change text of description from "Title" to "Description" in examples
c. regenerate related files.