### PR TITLE
fix: 🐛 [IOSSDKBUG-2221] TextFieldFormView clear button cannot get focused when voice over is running

### DIFF
--- a/Sources/FioriSwiftUICore/_FioriStyles/PlaceholderTextFieldStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/PlaceholderTextFieldStyle.fiori.swift
@@ -5,9 +5,18 @@ import SwiftUI
 /// The base layout style for `PlaceholderTextField`.
 public struct PlaceholderTextFieldBaseStyle: PlaceholderTextFieldStyle {
     @FocusState var isFocused: Bool
+    @Environment(\.isEnabled) private var isEnabled
 
     public func makeBody(_ configuration: PlaceholderTextFieldConfiguration) -> some View {
-        HStack {
+        let showClear = self.isFocused
+            && !configuration.text.isEmpty
+            && !(configuration.isSecureEnabled ?? false)
+
+        let accessible = self.isEnabled
+            && !configuration.text.isEmpty
+            && !(configuration.isSecureEnabled ?? false)
+
+        return HStack {
             ZStack(alignment: .center) {
                 configuration._textInputField.body
                     .focused(self.$isFocused)
@@ -24,16 +33,28 @@ public struct PlaceholderTextFieldBaseStyle: PlaceholderTextFieldStyle {
                     }
                 }
             }
-            if self.isFocused, !configuration.text.isEmpty, !(configuration.isSecureEnabled ?? false) {
-                Button(action: {
-                    configuration.text = ""
-                }) {
-                    Image(systemName: "xmark.circle")
-                        .font(.fiori(forTextStyle: .body))
-                        .foregroundColor(.preferredColor(.tertiaryLabel))
-                        .padding(.trailing, 1)
-                }
-                .buttonStyle(.plain)
+            Button(action: {
+                configuration.text = ""
+            }) {
+                Image(systemName: "xmark.circle")
+                    .font(.fiori(forTextStyle: .body))
+                    .foregroundColor(.preferredColor(.tertiaryLabel))
+                    .padding(.trailing, 1)
+            }
+            .opacity(showClear ? 1 : 0)
+            .allowsHitTesting(showClear)
+            .accessibilityLabel(Text("Clear text"))
+            .accessibilityHidden(!accessible)
+        }
+        .accessibilityElement(children: .contain)
+        .onChange(of: self.isFocused) { _, _ in
+            DispatchQueue.main.async {
+                UIAccessibility.post(notification: .layoutChanged, argument: nil)
+            }
+        }
+        .onChange(of: configuration.text.isEmpty) { _, _ in
+            DispatchQueue.main.async {
+                UIAccessibility.post(notification: .layoutChanged, argument: nil)
             }
         }
     }

--- a/Sources/FioriSwiftUICore/_FioriStyles/PlaceholderTextFieldStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/PlaceholderTextFieldStyle.fiori.swift
@@ -43,7 +43,7 @@ public struct PlaceholderTextFieldBaseStyle: PlaceholderTextFieldStyle {
             }
             .opacity(showClear ? 1 : 0)
             .allowsHitTesting(showClear)
-            .accessibilityLabel(Text("Clear text"))
+            .accessibilityLabel("Clear".localizedFioriString())
             .accessibilityHidden(!accessible)
         }
         .accessibilityElement(children: .contain)

--- a/Sources/FioriSwiftUICore/_FioriStyles/TextFieldFormViewStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/TextFieldFormViewStyle.fiori.swift
@@ -128,7 +128,7 @@ extension TextFieldFormViewFioriStyle {
                         .typeErased
                         .padding(.top, -3)
                 }
-                .accessibilityElement(children: .combine)
+                .accessibilityElement(children: .contain)
                 .setCustomAction(self.showsActionButton(configuration), configuration: configuration, isFocused: self.$isFocused, isEditing: self.$isEditing, actionIconAccessibilityLabel: self.getActionAccessibilityLabel(configuration))
                 .setGestureOnTextFieldView(self.$isFocused, isEditing: self.$isEditing)
         }

--- a/Sources/FioriSwiftUICore/_FioriStyles/TitleFormViewStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/TitleFormViewStyle.fiori.swift
@@ -18,7 +18,7 @@ public struct TitleFormViewBaseStyle: TitleFormViewStyle {
             .textInputInfoView(isPresented: Binding(get: { self.isInfoViewNeeded(configuration) }, set: { _ in }), description: self.getInfoString(configuration), counter: self.getCounterString(configuration))
             .padding(.top, -1)
             .padding(.bottom, self.isInfoViewNeeded(configuration) ? -12 : -1)
-            .accessibilityElement(children: .combine)
+            .accessibilityElement(children: .contain)
             .accessibilityHint(self.getAccessibilityHint(configuration, isFocused: self.isFocused))
             .disabled(configuration.controlState == .disabled)
         }


### PR DESCRIPTION
# Fix: VoiceOver Accessibility for TextFieldFormView Clear Button Focus

🐛 **Bug Fix:** Resolved an issue where the clear button in `TextFieldFormView` could not receive VoiceOver focus when accessibility features were enabled.

### Changes

The root cause was that the clear button was conditionally added/removed from the view hierarchy using an `if` statement, which prevented VoiceOver from discovering and focusing it. The fix replaces conditional rendering with visibility and hit-testing control, while also posting accessibility layout change notifications so VoiceOver can update its element tree.

Additionally, the accessibility grouping strategy for `TextFieldFormView` and `TitleFormView` was changed from `.combine` to `.contain` to allow VoiceOver to navigate into child elements (like the clear button) individually.

* `PlaceholderTextFieldStyle.fiori.swift`:
  - Extracted `showClear` and `accessible` computed conditions for the clear button.
  - Replaced conditional `if`-rendered `Button` with an always-present button whose visibility is controlled via `.opacity()` and interactivity via `.allowsHitTesting()`.
  - Added `.accessibilityLabel("Clear text")` and `.accessibilityHidden(!accessible)` to the clear button for proper VoiceOver support.
  - Added `.accessibilityElement(children: .contain)` on the `HStack`.
  - Added `onChange` handlers for `isFocused` and `configuration.text.isEmpty` that post `UIAccessibility.layoutChanged` notifications, prompting VoiceOver to refresh its element tree.

* `TextFieldFormViewStyle.fiori.swift`:
  - Changed `.accessibilityElement(children: .combine)` to `.accessibilityElement(children: .contain)` to allow VoiceOver to focus individual child elements.

* `TitleFormViewStyle.fiori.swift`:
  - Changed `.accessibilityElement(children: .combine)` to `.accessibilityElement(children: .contain)` for the same reason.

### Jira Issues

* IOSSDKBUG-2221: TextFieldFormView clear button cannot get focused when VoiceOver is running

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.26`

- LLM: `anthropic--claude-4.6-sonnet`
- Correlation ID: `e6d72960-96ba-11f1-8644-942535778201`
- File Content Strategy: Full file content
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.opened`
</details>
