### PR TITLE
fix: 🐛 [IOSSDKBUG-2250] Add flag to control whether to display "Today" in TimelinePreview item timestamps

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/Timeline/TimelinePreviewExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/Timeline/TimelinePreviewExample.swift
@@ -10,8 +10,18 @@ struct TimelinePreviewItemModelImplementation: TimelinePreviewItemModel {
     var formatter: DateFormatter?
     var isFuture: Bool?
     var isCurrent: Bool?
+    var showsTodayText: Bool
     
-    init(id: UUID = UUID(), title: String, icon: Image? = nil, timelineNode: FioriSwiftUICore.TimelineNodeType, due: Date, dateFormat: String? = nil, isFuture: Bool? = nil, isCurrent: Bool? = nil) {
+    init(id: UUID = UUID(),
+         title: String,
+         icon: Image? = nil,
+         timelineNode: FioriSwiftUICore.TimelineNodeType,
+         due: Date,
+         dateFormat: String? = nil,
+         isFuture: Bool? = nil,
+         isCurrent: Bool? = nil,
+         showsTodayText: Bool = true)
+    {
         self.id = id
         self.title = title
         self.icon = icon
@@ -25,6 +35,7 @@ struct TimelinePreviewItemModelImplementation: TimelinePreviewItemModel {
         }
         self.isFuture = isFuture
         self.isCurrent = isCurrent
+        self.showsTodayText = showsTodayText
     }
 }
 

--- a/Sources/FioriSwiftUICore/Components/TimelinePreviewItemProtocol.swift
+++ b/Sources/FioriSwiftUICore/Components/TimelinePreviewItemProtocol.swift
@@ -11,6 +11,7 @@ public protocol TimelinePreviewItemModel: Identifiable {
     var formatter: DateFormatter? { get }
     var isFuture: Bool? { get set }
     var isCurrent: Bool? { get set }
+    var showsTodayText: Bool { get }
 }
 
 public extension TimelinePreviewItemModel {
@@ -23,6 +24,9 @@ public extension TimelinePreviewItemModel {
         f.dateFormat = "MMMM dd yyyy"
         return f
     }
+    
+    /// Defaults to `true`: today's items are shown as "Today, {date}".
+    var showsTodayText: Bool { true }
 }
 
 /// Extension to provide an initializer for `TimelinePreviewItem` from a `TimelinePreviewItemModel`.

--- a/Sources/FioriSwiftUICore/_FioriStyles/TimelinePreviewStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/TimelinePreviewStyle.fiori.swift
@@ -86,8 +86,11 @@ struct BuildTimelinePreviewItem: View {
                 let timestampFormat = NSLocalizedString("Today, %@", tableName: "FioriSwiftUICore", bundle: Bundle.accessor, comment: "")
                 let timestampString = String(format: timestampFormat, dateString)
                 let isToday = Calendar.current.isDateInToday(item.due)
-                let dateAttributedString = AttributedString(isToday ? timestampString : dateString)
-                let a11yTime = isToday ? NSLocalizedString("Today", tableName: "FioriSwiftUICore", bundle: Bundle.accessor, comment: "") : dateString
+                let showsTodayText = isToday && item.showsTodayText
+                let dateAttributedString = AttributedString(showsTodayText ? timestampString : dateString)
+                let a11yTime = showsTodayText
+                    ? NSLocalizedString("Today", tableName: "FioriSwiftUICore", bundle: Bundle.accessor, comment: "")
+                    : dateString
                 let isFuture = item.isFuture ?? false
                 let statusDescription = isToday ? NSLocalizedString("Current", tableName: "FioriSwiftUICore", bundle: Bundle.accessor, comment: "") : (isFuture ? NSLocalizedString("Future", tableName: "FioriSwiftUICore", bundle: Bundle.accessor, comment: "") : NSLocalizedString("Past", tableName: "FioriSwiftUICore", bundle: Bundle.accessor, comment: ""))
                 let typeDescription = self.getNodeDescription(for: item.timelineNode)


### PR DESCRIPTION
Dev Results:
<img width="2868" height="1320" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-08-13 at 14 50 05" src="https://github.com/user-attachments/assets/ea3bf311-5ab3-4848-bf5d-33a7a5baedd5" />
<img width="2868" height="1320" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-08-13 at 14 48 44" src="https://github.com/user-attachments/assets/cd2c029f-dd7e-45ee-90c6-fa573caffc7b" />
