### PR TITLE
fix: 🐛  [IOSSDKBUG-2209]Cherry-pick -  AttachmentGroup photo picker add maxSelectionCount controllable

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/Attachment/AttachmentGroupExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/Attachment/AttachmentGroupExample.swift
@@ -7,6 +7,7 @@ import SwiftUI
 struct AttachmentGroupExample: View {
     @State var attachmentInfo: [AttachmentInfo]
     @State private var maxCount: Int?
+    @State private var maxPhotoSelectionCount: Int?
     @State private var state: ControlState
     @State private var showOperations: Bool
     @State var images: [UIImage]
@@ -40,6 +41,7 @@ struct AttachmentGroupExample: View {
     init() {
         self.attachmentInfo = []
         self.maxCount = nil
+        self.maxPhotoSelectionCount = nil
         self.state = .normal
         self.opsAsMenu = true
         self.showOperations = false
@@ -228,6 +230,7 @@ struct AttachmentGroupExample: View {
             title: { Text("Attachments (\(self.attachmentInfo.count))") },
             attachments: self.$attachmentInfo,
             maxCount: self.maxCount,
+            maxPhotoSelectionCount: self.maxPhotoSelectionCount,
             delegate: self.useDemoDelegate ? MyAttachmentDelegateForInProgressAndErrorDemo() : BasicAttachmentDelegate(),
             controlState: self.state,
             errorMessage: self.$error,

--- a/Sources/FioriSwiftUICore/Attachment/DefaultOperationsModifier.swift
+++ b/Sources/FioriSwiftUICore/Attachment/DefaultOperationsModifier.swift
@@ -134,7 +134,22 @@ public struct DefaultOperationsModifier: ViewModifier {
     }
     
     var photoPicker: some View {
-        let maxSelectionCount = self.context.configuration?.maxCount == nil ? nil : (self.context.configuration?.maxCount ?? 0) - (self.context.configuration?.attachments.count ?? 0)
+        let maxSelectionCount: Int? = {
+            let remaining: Int? = {
+                guard let maxCount = self.context.configuration?.maxCount else {
+                    return nil
+                }
+                return max(0, maxCount - (self.context.configuration?.attachments.count ?? 0))
+            }()
+            if let explicit = self.context.configuration?.maxPhotoSelectionCount {
+                if let remaining {
+                    return min(explicit, remaining)
+                }
+                return explicit
+            }
+            return remaining
+        }()
+
         return PhotosPicker(
             "Pick a photo",
             selection: self.$selectedPhotos,

--- a/Sources/FioriSwiftUICore/_ComponentProtocols/CompositeComponentProtocols.swift
+++ b/Sources/FioriSwiftUICore/_ComponentProtocols/CompositeComponentProtocols.swift
@@ -2092,6 +2092,13 @@ protocol _AttachmentGroupComponent: _TitleComponent, _MandatoryField {
     /// The maximum number of attachments
     var maxCount: Int? { get }
     
+    // sourcery: defaultValue = "nil"
+    /// The maximum number of images allowed to be selected in a single album pick.
+    /// When set, the PhotosPicker's selection limit is the smaller of this value and the remaining count (maxCount - existing attachment count), ensuring the total never exceeds `maxCount`.
+    /// When `nil`, the selection limit falls back to the remaining count only.
+    /// If `maxCount` is also `nil` (no total limit), this value is used directly as the selection limit.
+    var maxPhotoSelectionCount: Int? { get }
+    
     // sourcery: defaultValue = "BasicAttachmentDelegate()"
     /// App specific attachment processing logics for adding or deleting attachments.
     var delegate: AttachmentDelegate { get }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/AttachmentGroup/AttachmentGroup.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/AttachmentGroup/AttachmentGroup.generated.swift
@@ -66,6 +66,11 @@ public struct AttachmentGroup {
     @Binding var attachments: [AttachmentInfo]
     /// The maximum number of attachments
     let maxCount: Int?
+    /// The maximum number of images allowed to be selected in a single album pick.
+    /// When set, the PhotosPicker's selection limit is the smaller of this value and the remaining count (maxCount - existing attachment count), ensuring the total never exceeds `maxCount`.
+    /// When `nil`, the selection limit falls back to the remaining count only.
+    /// If `maxCount` is also `nil` (no total limit), this value is used directly as the selection limit.
+    let maxPhotoSelectionCount: Int?
     /// App specific attachment processing logics for adding or deleting attachments.
     let delegate: AttachmentDelegate
     /// The state of attachment group component
@@ -89,6 +94,7 @@ public struct AttachmentGroup {
                 context: AttachmentContext = AttachmentContext(),
                 attachments: Binding<[AttachmentInfo]>,
                 maxCount: Int? = nil,
+                maxPhotoSelectionCount: Int? = nil,
                 delegate: AttachmentDelegate = BasicAttachmentDelegate(),
                 controlState: ControlState = .normal,
                 errorMessage: Binding<AttributedString?> = .constant(nil),
@@ -101,6 +107,7 @@ public struct AttachmentGroup {
         self.context = context
         self._attachments = attachments
         self.maxCount = maxCount
+        self.maxPhotoSelectionCount = maxPhotoSelectionCount
         self.delegate = delegate
         self.controlState = controlState
         self._errorMessage = errorMessage
@@ -122,6 +129,7 @@ public extension AttachmentGroup {
          context: AttachmentContext = AttachmentContext(),
          attachments: Binding<[AttachmentInfo]>,
          maxCount: Int? = nil,
+         maxPhotoSelectionCount: Int? = nil,
          delegate: AttachmentDelegate = BasicAttachmentDelegate(),
          controlState: ControlState = .normal,
          errorMessage: Binding<AttributedString?>,
@@ -131,7 +139,7 @@ public extension AttachmentGroup {
     {
         self.init(title: {
             TextWithMandatoryFieldIndicator(text: title, isRequired: isRequired, mandatoryFieldIndicator: mandatoryFieldIndicator)
-        }, context: context, attachments: attachments, maxCount: maxCount, delegate: delegate, controlState: controlState, errorMessage: errorMessage, operations: operations, onPreview: onPreview, defaultAttachmentExtraInfo: defaultAttachmentExtraInfo)
+        }, context: context, attachments: attachments, maxCount: maxCount, maxPhotoSelectionCount: maxPhotoSelectionCount, delegate: delegate, controlState: controlState, errorMessage: errorMessage, operations: operations, onPreview: onPreview, defaultAttachmentExtraInfo: defaultAttachmentExtraInfo)
     }
 }
 
@@ -145,6 +153,7 @@ public extension AttachmentGroup {
         self.context = configuration.context
         self._attachments = configuration.$attachments
         self.maxCount = configuration.maxCount
+        self.maxPhotoSelectionCount = configuration.maxPhotoSelectionCount
         self.delegate = configuration.delegate
         self.controlState = configuration.controlState
         self._errorMessage = configuration.$errorMessage
@@ -161,7 +170,7 @@ extension AttachmentGroup: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, title: .init(self.title), context: self.context, attachments: self.$attachments, maxCount: self.maxCount, delegate: self.delegate, controlState: self.controlState, errorMessage: self.$errorMessage, operations: .init(self.operations), onPreview: self.onPreview, defaultAttachmentExtraInfo: self.defaultAttachmentExtraInfo)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, title: .init(self.title), context: self.context, attachments: self.$attachments, maxCount: self.maxCount, maxPhotoSelectionCount: self.maxPhotoSelectionCount, delegate: self.delegate, controlState: self.controlState, errorMessage: self.$errorMessage, operations: .init(self.operations), onPreview: self.onPreview, defaultAttachmentExtraInfo: self.defaultAttachmentExtraInfo)).typeErased
                 .transformEnvironment(\.attachmentGroupStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -179,7 +188,7 @@ private extension AttachmentGroup {
     }
 
     func defaultStyle() -> some View {
-        AttachmentGroup(.init(componentIdentifier: self.componentIdentifier, title: .init(self.title), context: self.context, attachments: self.$attachments, maxCount: self.maxCount, delegate: self.delegate, controlState: self.controlState, errorMessage: self.$errorMessage, operations: .init(self.operations), onPreview: self.onPreview, defaultAttachmentExtraInfo: self.defaultAttachmentExtraInfo))
+        AttachmentGroup(.init(componentIdentifier: self.componentIdentifier, title: .init(self.title), context: self.context, attachments: self.$attachments, maxCount: self.maxCount, maxPhotoSelectionCount: self.maxPhotoSelectionCount, delegate: self.delegate, controlState: self.controlState, errorMessage: self.$errorMessage, operations: .init(self.operations), onPreview: self.onPreview, defaultAttachmentExtraInfo: self.defaultAttachmentExtraInfo))
             .shouldApplyDefaultStyle(false)
             .attachmentGroupStyle(AttachmentGroupFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/AttachmentGroup/AttachmentGroupStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/AttachmentGroup/AttachmentGroupStyle.generated.swift
@@ -27,6 +27,7 @@ public struct AttachmentGroupConfiguration {
     public let context: AttachmentContext
     @Binding public var attachments: [AttachmentInfo]
     public let maxCount: Int?
+    public let maxPhotoSelectionCount: Int?
     public let delegate: AttachmentDelegate
     public let controlState: ControlState
     @Binding public var errorMessage: AttributedString?


### PR DESCRIPTION
# Add `maxPhotoSelectionCount` Parameter to `AttachmentGroup` Photo Picker

### New Feature

✨ Introduces a new `maxPhotoSelectionCount` parameter on `AttachmentGroup` to allow apps to control the maximum number of images a user can select in a single photo album pick session.

When set, the `PhotosPicker` selection limit is capped at the smaller of `maxPhotoSelectionCount` and the remaining available slots (`maxCount - existing attachment count`), ensuring the total attachment count never exceeds `maxCount`. If `maxCount` is not set, `maxPhotoSelectionCount` is applied directly as the picker's selection limit.

### Changes

* `CompositeComponentProtocols.swift`: Added `maxPhotoSelectionCount: Int?` property to `_AttachmentGroupComponent` protocol with detailed documentation.
* `AttachmentGroup.generated.swift`: Propagated `maxPhotoSelectionCount` through all `AttachmentGroup` initializers, the `AttachmentGroupConfiguration`-based init, and both `defaultStyle()` and `resolve` call sites.
* `AttachmentGroupStyle.generated.swift`: Added `maxPhotoSelectionCount` to `AttachmentGroupConfiguration`.
* `DefaultOperationsModifier.swift`: Replaced the simple inline `maxSelectionCount` calculation with a safer closure-based computation that properly handles `nil` cases, clamps the remaining count to `≥ 0` using `max(0, ...)`, and combines it with the new explicit `maxPhotoSelectionCount` using `min`.
* `AttachmentGroupExample.swift`: Updated the example to wire up the new `maxPhotoSelectionCount` state variable and pass it to `AttachmentGroup`.

### Jira Issues

* IOSSDKBUG-2209

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.26`

- Correlation ID: `a8467d80-96f2-11f1-9c3f-2c6c5c707ed7`
- LLM: `anthropic--claude-4.6-sonnet`
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- File Content Strategy: Full file content
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.opened`
</details>
