### PR TITLE
fix: 🐛 [IOSSDKBUG-2221]Cherry-pick - TextFieldFormView clear button cannot get focused when voice over is running

### DIFF
--- a/Sources/FioriSwiftUICore/_FioriStyles/PlaceholderTextFieldStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/PlaceholderTextFieldStyle.fiori.swift
@@ -5,9 +5,18 @@ import SwiftUI
 /// The base layout style for `PlaceholderTextField`.
 public struct PlaceholderTextFieldBaseStyle: PlaceholderTextFieldStyle {
     @FocusState var isFocused: Bool
+    @Environment(\.isEnabled) private var isEnabled
 
     public func makeBody(_ configuration: PlaceholderTextFieldConfiguration) -> some View {
-        HStack {
+        let showClear = self.isFocused
+            && !configuration.text.isEmpty
+            && !(configuration.isSecureEnabled ?? false)
+
+        let accessible = self.isEnabled
+            && !configuration.text.isEmpty
+            && !(configuration.isSecureEnabled ?? false)
+
+        return HStack {
             ZStack(alignment: .center) {
                 configuration._textInputField.body
                     .focused(self.$isFocused)
@@ -24,16 +33,28 @@ public struct PlaceholderTextFieldBaseStyle: PlaceholderTextFieldStyle {
                     }
                 }
             }
-            if self.isFocused, !configuration.text.isEmpty, !(configuration.isSecureEnabled ?? false) {
-                Button(action: {
-                    configuration.text = ""
-                }) {
-                    Image(systemName: "xmark.circle")
-                        .font(.fiori(forTextStyle: .body))
-                        .foregroundColor(.preferredColor(.tertiaryLabel))
-                        .padding(.trailing, 1)
-                }
-                .buttonStyle(.plain)
+            Button(action: {
+                configuration.text = ""
+            }) {
+                Image(systemName: "xmark.circle")
+                    .font(.fiori(forTextStyle: .body))
+                    .foregroundColor(.preferredColor(.tertiaryLabel))
+                    .padding(.trailing, 1)
+            }
+            .opacity(showClear ? 1 : 0)
+            .allowsHitTesting(showClear)
+            .accessibilityLabel("Clear".localizedFioriString())
+            .accessibilityHidden(!accessible)
+        }
+        .accessibilityElement(children: .contain)
+        .onChange(of: self.isFocused) { _, _ in
+            DispatchQueue.main.async {
+                UIAccessibility.post(notification: .layoutChanged, argument: nil)
+            }
+        }
+        .onChange(of: configuration.text.isEmpty) { _, _ in
+            DispatchQueue.main.async {
+                UIAccessibility.post(notification: .layoutChanged, argument: nil)
             }
         }
     }

--- a/Sources/FioriSwiftUICore/_FioriStyles/TextFieldFormViewStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/TextFieldFormViewStyle.fiori.swift
@@ -128,7 +128,7 @@ extension TextFieldFormViewFioriStyle {
                         .typeErased
                         .padding(.top, -3)
                 }
-                .accessibilityElement(children: .combine)
+                .accessibilityElement(children: .contain)
                 .setCustomAction(self.showsActionButton(configuration), configuration: configuration, isFocused: self.$isFocused, isEditing: self.$isEditing, actionIconAccessibilityLabel: self.getActionAccessibilityLabel(configuration))
                 .setGestureOnTextFieldView(self.$isFocused, isEditing: self.$isEditing)
         }

--- a/Sources/FioriSwiftUICore/_FioriStyles/TitleFormViewStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/TitleFormViewStyle.fiori.swift
@@ -16,7 +16,7 @@ public struct TitleFormViewBaseStyle: TitleFormViewStyle {
             .textInputInfoView(isPresented: Binding(get: { self.isInfoViewNeeded(configuration) }, set: { _ in }), description: self.getInfoString(configuration), counter: self.getCounterString(configuration))
             .padding(.top, -1)
             .padding(.bottom, self.isInfoViewNeeded(configuration) ? -12 : -1)
-            .accessibilityElement(children: .combine)
+            .accessibilityElement(children: .contain)
             .accessibilityHint(self.getAccessibilityHint(configuration, isFocused: self.isFocused))
             .disabled(configuration.controlState == .disabled)
         }


### PR DESCRIPTION
# Fix: TextFieldFormView Clear Button Accessibility with VoiceOver

🐛 **Bug Fix:** Resolved an issue where the clear button in `TextFieldFormView` could not receive focus when VoiceOver was running.

### Changes

The root cause was that the clear button was conditionally added/removed from the view hierarchy, preventing VoiceOver from focusing on it. The fix keeps the button always present in the hierarchy but controls its visibility and interactivity through opacity and hit-testing, while also posting accessibility layout change notifications to inform VoiceOver of state changes.

* `PlaceholderTextFieldStyle.fiori.swift`:
  - Added `@Environment(\.isEnabled)` to track the enabled state.
  - Extracted `showClear` and `accessible` computed variables to separately control visual visibility and accessibility exposure of the clear button.
  - Replaced the conditional `if`-wrapped clear button with an always-present button that uses `.opacity()` and `.allowsHitTesting()` to control appearance and interaction.
  - Added `.accessibilityLabel("Clear")` and `.accessibilityHidden(!accessible)` to the clear button for proper VoiceOver support.
  - Added `.accessibilityElement(children: .contain)` on the `HStack` to ensure child elements remain individually accessible.
  - Added `onChange` handlers for `isFocused` and `text.isEmpty` to post `UIAccessibility.layoutChanged` notifications, prompting VoiceOver to re-evaluate the accessibility tree.

* `TextFieldFormViewStyle.fiori.swift`: Changed `.accessibilityElement(children: .combine)` to `.accessibilityElement(children: .contain)` to allow child elements (including the clear button) to remain individually accessible to VoiceOver.

* `TitleFormViewStyle.fiori.swift`: Changed `.accessibilityElement(children: .combine)` to `.accessibilityElement(children: .contain)` for the same reason — preserving individual child accessibility.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.26`

- LLM: `anthropic--claude-4.6-sonnet`
- Correlation ID: `bb9d7b10-96f5-11f1-9b15-5993071dd9d7`
- File Content Strategy: Full file content
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.opened`
</details>
