### PR TITLE
fix: 🐛 typo in English source file for translation

### DIFF
--- a/Sources/FioriSwiftUICore/_FioriStyles/WritingAssistantFormStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/WritingAssistantFormStyle.fiori.swift
@@ -74,7 +74,7 @@ extension WritingAssistantFormFioriStyle {
         func makeBody(_ configuration: RedoActionConfiguration) -> some View {
             RedoAction(configuration)
                 .fioriButtonStyle(AIWAActionButtonStyle())
-                .accessibilityLabel(NSLocalizedString("Rodo change", tableName: "FioriSwiftUICore", bundle: Bundle.accessor, comment: "Redo change"))
+                .accessibilityLabel(NSLocalizedString("Redo change", tableName: "FioriSwiftUICore", bundle: Bundle.accessor, comment: "Redo change"))
                 .accessibilityAddTraits(.isButton)
         }
     }

--- a/Sources/FioriSwiftUICore/_localization/en.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/en.lproj/FioriSwiftUICore.strings
@@ -653,7 +653,7 @@
 "Undo change" = "Undo change";
 
 /* XBUT: Writing assistant redo accessibility label */
-"Rodo change" = "Rodo change";
+"Redo change" = "Redo change";
 
 /* XBUT: Close button title */
 "Close" = "Close";


### PR DESCRIPTION
# Fix Typo in English Localization File for Writing Assistant

### Bug Fix

🐛 Corrected a typo in the English localization strings file where the "Redo change" button label for the AI Writing Assistant was misspelled as "Rodo change".

### Changes

* `Sources/FioriSwiftUICore/_localization/en.lproj/FioriSwiftUICore.strings`: Fixed the accessibility label for the writing assistant redo button from `"Rodo change"` to `"Redo change"`.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.26`

- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- File Content Strategy: Full file content
- Correlation ID: `e259a560-975b-11f1-8f8f-d6fa9c79bf0d`
- LLM: `anthropic--claude-4.6-sonnet`
- Event Trigger: `pull_request.opened`
</details>
