### PR TITLE
fix: 🐛 [IOSSDKBUG-1658] Sidebar ACC issues

### DIFF
--- a/Sources/FioriSwiftUICore/_FioriStyles/SideBarListItemStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/SideBarListItemStyle.fiori.swift
@@ -79,7 +79,7 @@ public struct SideBarListItemBaseStyle: SideBarListItemStyle {
         .accessibilityAddTraits(.isButton)
         .accessibilityRemoveTraits(.isSelected)
         .accessibilityLabel({
-            if let subtitle = configuration.data.subtitle, !subtitle.isEmpty {
+            if let subtitle = configuration.data.subtitle, !subtitle.trimmingCharacters(in: .whitespaces).isEmpty {
                 return "\(configuration.data.title), \(subtitle)"
             }
             return configuration.data.title

--- a/Sources/FioriSwiftUICore/_FioriStyles/SideBarListItemStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/SideBarListItemStyle.fiori.swift
@@ -58,6 +58,7 @@ public struct SideBarListItemBaseStyle: SideBarListItemStyle {
                     }
                     
                     configuration.title.frame(height: 44, alignment: .leading).multilineTextAlignment(.leading)
+
                     Spacer()
                     if !SideBarUtility.isEditing(self.modelObject, self.editMode?.wrappedValue) {
                         configuration.subtitle.frame(height: 44, alignment: .leading).multilineTextAlignment(.trailing)

--- a/Sources/FioriSwiftUICore/_FioriStyles/SideBarListItemStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/SideBarListItemStyle.fiori.swift
@@ -78,7 +78,12 @@ public struct SideBarListItemBaseStyle: SideBarListItemStyle {
         .accessibilityElement(children: .ignore)
         .accessibilityAddTraits(.isButton)
         .accessibilityRemoveTraits(.isSelected)
-        .accessibilityLabel(configuration.data.title)
+        .accessibilityLabel({
+            if let subtitle = configuration.data.subtitle, !subtitle.isEmpty {
+                return "\(configuration.data.title), \(subtitle)"
+            }
+            return configuration.data.title
+        }())
     }
 }
 
@@ -111,7 +116,9 @@ extension SideBarListItemFioriStyle {
         @EnvironmentObject private var modelObject: SideBarListItemModelObject
         @EnvironmentObject private var sidebarModelObject: SideBarModelObject
         @Environment(\.editMode) private var editMode
-        
+        @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+        @Environment(\.colorScheme) private var colorScheme
+
         func makeBody(_ configuration: IconConfiguration) -> some View {
             Group {
                 if self.modelObject.isSelected, !SideBarUtility.isEditing(self.sidebarModelObject, self.editMode?.wrappedValue) {
@@ -120,9 +127,12 @@ extension SideBarListItemFioriStyle {
                         .fontWeight(.bold)
                         .foregroundStyle(Color.preferredColor(.quinaryLabel))
                 } else {
+                    let iconColor = self.reduceTransparency && self.colorScheme == .dark
+                        ? Color.preferredColor(.tintColor, background: .lightConstant)
+                        : Color.preferredColor(.tintColor)
                     Icon(configuration)
                         .font(.fiori(forTextStyle: .body))
-                        .foregroundStyle(Color.preferredColor(.tintColor))
+                        .foregroundStyle(iconColor)
                 }
             }
         }

--- a/Sources/FioriSwiftUICore/_FioriStyles/SideBarStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/SideBarStyle.fiori.swift
@@ -410,9 +410,11 @@ class SideBarModelObject: ObservableObject {
 
 private struct SideBarListSectionDisclosureStyle: DisclosureGroupStyle {
     @Environment(\.sizeCategory) private var sizeCategory
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+    @Environment(\.colorScheme) private var colorScheme
     @ScaledMetric var scale: CGFloat = 1
     var onDisclosureGroupToggled: () -> Void
-    
+
     func makeBody(configuration: Configuration) -> some View {
         VStack(spacing: 0) {
             HStack {
@@ -420,12 +422,15 @@ private struct SideBarListSectionDisclosureStyle: DisclosureGroupStyle {
                     .font(.fiori(forTextStyle: .title3))
                     .foregroundColor(.preferredColor(.primaryLabel))
                 Spacer()
+                let chevronColor = self.reduceTransparency && self.colorScheme == .dark
+                    ? Color.preferredColor(.tintColor, background: .lightConstant)
+                    : Color.preferredColor(.tintColor)
                 Image(systemName: configuration.isExpanded ? "chevron.down" : "chevron.right")
                     .resizable()
                     .aspectRatio(contentMode: .fit)
                     .frame(width: 14 * self.scale, height: 14 * self.scale)
                     .font(.fiori(fixedSize: 17, weight: .semibold))
-                    .foregroundColor(.preferredColor(.tintColor))
+                    .foregroundColor(chevronColor)
             }
             .padding(EdgeInsets(top: 0, leading: 0, bottom: 11, trailing: 0))
             


### PR DESCRIPTION
# Fix Sidebar Accessibility Issues

🐛 **Bug Fix:** Resolves multiple accessibility issues in the Sidebar component, including improved VoiceOver labels and better color contrast for reduced transparency in dark mode.

### Changes

* `SideBarListItemStyle.fiori.swift`:
  - Updated the accessibility label to include the subtitle when available, combining title and subtitle (e.g., `"Title, Subtitle"`) for better VoiceOver support.
  - Added `accessibilityReduceTransparency` and `colorScheme` environment variables to `IconFioriStyle`.
  - Updated icon foreground color to use a light-constant tint color when "Reduce Transparency" is enabled in dark mode, ensuring sufficient color contrast.

* `SideBarStyle.fiori.swift`:
  - Added `accessibilityReduceTransparency` and `colorScheme` environment variables to `SideBarListSectionDisclosureStyle`.
  - Updated the chevron icon foreground color to use a light-constant tint color when "Reduce Transparency" is enabled in dark mode, improving visibility.

### Jira Issues

* IOSSDKBUG-1658: Sidebar ACC issues

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.26`

- LLM: `anthropic--claude-4.6-sonnet`
- File Content Strategy: Full file content
- Correlation ID: `f70b0730-977c-11f1-973a-c3501676fc3a`
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.opened`
</details>
