### PR TITLE
fix: 🐛  [IOSSDKBUG-2250] cherry-pick - Add flag to control whether to display "Today" in TimelinePreview item timestamps

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/Timeline/TimelinePreviewExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/Timeline/TimelinePreviewExample.swift
@@ -10,8 +10,18 @@ struct TimelinePreviewItemModelImplementation: TimelinePreviewItemModel {
     var formatter: DateFormatter?
     var isFuture: Bool?
     var isCurrent: Bool?
+    var showsTodayText: Bool
     
-    init(id: UUID = UUID(), title: String, icon: Image? = nil, timelineNode: FioriSwiftUICore.TimelineNodeType, due: Date, dateFormat: String? = nil, isFuture: Bool? = nil, isCurrent: Bool? = nil) {
+    init(id: UUID = UUID(),
+         title: String,
+         icon: Image? = nil,
+         timelineNode: FioriSwiftUICore.TimelineNodeType,
+         due: Date,
+         dateFormat: String? = nil,
+         isFuture: Bool? = nil,
+         isCurrent: Bool? = nil,
+         showsTodayText: Bool = true)
+    {
         self.id = id
         self.title = title
         self.icon = icon
@@ -25,6 +35,7 @@ struct TimelinePreviewItemModelImplementation: TimelinePreviewItemModel {
         }
         self.isFuture = isFuture
         self.isCurrent = isCurrent
+        self.showsTodayText = showsTodayText
     }
 }
 

--- a/Sources/FioriSwiftUICore/Components/TimelinePreviewItemProtocol.swift
+++ b/Sources/FioriSwiftUICore/Components/TimelinePreviewItemProtocol.swift
@@ -11,6 +11,7 @@ public protocol TimelinePreviewItemModel: Identifiable {
     var formatter: DateFormatter? { get }
     var isFuture: Bool? { get set }
     var isCurrent: Bool? { get set }
+    var showsTodayText: Bool { get }
 }
 
 public extension TimelinePreviewItemModel {
@@ -23,6 +24,9 @@ public extension TimelinePreviewItemModel {
         f.dateFormat = "MMMM dd yyyy"
         return f
     }
+    
+    /// Defaults to `true`: today's items are shown as "Today, {date}".
+    var showsTodayText: Bool { true }
 }
 
 /// Extension to provide an initializer for `TimelinePreviewItem` from a `TimelinePreviewItemModel`.

--- a/Sources/FioriSwiftUICore/_FioriStyles/TimelinePreviewStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/TimelinePreviewStyle.fiori.swift
@@ -86,8 +86,11 @@ struct BuildTimelinePreviewItem: View {
                 let timestampFormat = NSLocalizedString("Today, %@", tableName: "FioriSwiftUICore", bundle: Bundle.accessor, comment: "")
                 let timestampString = String(format: timestampFormat, dateString)
                 let isToday = Calendar.current.isDateInToday(item.due)
-                let dateAttributedString = AttributedString(isToday ? timestampString : dateString)
-                let a11yTime = isToday ? NSLocalizedString("Today", tableName: "FioriSwiftUICore", bundle: Bundle.accessor, comment: "") : dateString
+                let showsTodayText = isToday && item.showsTodayText
+                let dateAttributedString = AttributedString(showsTodayText ? timestampString : dateString)
+                let a11yTime = showsTodayText
+                    ? NSLocalizedString("Today", tableName: "FioriSwiftUICore", bundle: Bundle.accessor, comment: "")
+                    : dateString
                 let isFuture = item.isFuture ?? false
                 let statusDescription = isToday ? NSLocalizedString("Current", tableName: "FioriSwiftUICore", bundle: Bundle.accessor, comment: "") : (isFuture ? NSLocalizedString("Future", tableName: "FioriSwiftUICore", bundle: Bundle.accessor, comment: "") : NSLocalizedString("Past", tableName: "FioriSwiftUICore", bundle: Bundle.accessor, comment: ""))
                 let typeDescription = self.getNodeDescription(for: item.timelineNode)


### PR DESCRIPTION
# Add `showsTodayText` Flag to Control "Today" Display in TimelinePreview Timestamps

### Bug Fix

🐛 Adds a `showsTodayText` flag to `TimelinePreviewItemModel` to allow consumers to control whether today's date is displayed as `"Today, {date}"` or just the plain date string in `TimelinePreview` item timestamps.

### Changes

* `TimelinePreviewItemProtocol.swift`: Added `showsTodayText: Bool { get }` to the `TimelinePreviewItemModel` protocol, with a default extension implementation returning `true` to preserve existing behavior.
* `TimelinePreviewStyle.fiori.swift`: Updated the timestamp rendering logic to only apply the "Today, {date}" format when both `isToday` is `true` **and** `item.showsTodayText` is `true`. Same logic applied to the accessibility label.
* `TimelinePreviewExample.swift`: Added `showsTodayText` property to the example model implementation with a default value of `true`, and updated the initializer to accept and assign the new parameter.

### Jira Issues

* IOSSDKBUG-2250

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.26`

- File Content Strategy: Full file content
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- LLM: `anthropic--claude-4.6-sonnet`
- Correlation ID: `3e49dd30-97bc-11f1-9f4a-c589dda1566e`
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.opened`
</details>
