### PR TITLE
fix: 🐛 [IOSSDKBUG-2230] APP crashed after clicking EULA Examples item on iOS 18.6

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/Onboarding/EULAViewSample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/Onboarding/EULAViewSample.swift
@@ -20,13 +20,24 @@ struct EULAViewDataModel {
     /// Parses an HTML resource into an `NSAttributedString`.
     /// - Important: HTML parsing relies on WebKit and MUST run on the main thread.
     @MainActor
-    static func loadHTML(resource: String, withExtension ext: String = "html") -> NSAttributedString? {
+    static func loadHTML(resource: String, withExtension ext: String = "html") async -> NSAttributedString? {
         guard let url = Bundle.main.url(forResource: resource, withExtension: ext) else {
             print("EULA resource not found: \(resource).\(ext)")
             return nil
         }
+
+        // Read the file on a background thread (Data is Sendable, so it's safe to return across actors)
+        let data: Data
         do {
-            let data = try Data(contentsOf: url)
+            data = try await Task.detached(priority: .userInitiated) {
+                try Data(contentsOf: url)
+            }.value
+        } catch {
+            print("Failed to read EULA HTML (\(resource)): \(error)")
+            return nil
+        }
+
+        do {
             let attString = try NSMutableAttributedString(
                 data: data,
                 options: [.documentType: NSAttributedString.DocumentType.html],
@@ -101,7 +112,7 @@ struct EULALongHtmlSample: View {
             self.presentationMode.wrappedValue.dismiss()
         }
         .task {
-            if let att = EULAViewDataModel.loadHTML(resource: "EULAText") {
+            if let att = await EULAViewDataModel.loadHTML(resource: "EULAText") {
                 self.model.bodyAttributedText = att
             }
         }
@@ -122,7 +133,7 @@ struct EULAShortHtmlSample: View {
             self.presentationMode.wrappedValue.dismiss()
         }
         .task {
-            if let att = EULAViewDataModel.loadHTML(resource: "EULA2") {
+            if let att = await EULAViewDataModel.loadHTML(resource: "EULA2") {
                 self.model.bodyAttributedText = att
             }
         }

--- a/Apps/Examples/Examples/FioriSwiftUICore/Onboarding/EULAViewSample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/Onboarding/EULAViewSample.swift
@@ -15,21 +15,29 @@ struct EULAViewDataModel {
     
     var didCancel: (() -> Void)?
     
-    static let HTML = EULAViewDataModel(bodyAttributedText: NSAttributedString(string: "http://www.sap.com\nThis is a legally binding agreement (\"Agreement\") between Company and SAP SE which provides the terms of your use of the SAP mobile application (Software). By clicking \"Accept\" or by installing and/or using the Software, you on behalf of the Company are agreeing to all of the terms and conditions stated in this Agreement. If you do not agree to these terms, do not click \"Agree\", and do not use the Software. You represent and warrant that you have the authority to bind the Company to the terms of this Agreement.\n\n"))
+    static let HTML = EULAViewDataModel(bodyAttributedText: NSAttributedString(string: "http://www.sap.com\nThis is a legally binding agreement (\"Agreement\") between Company and SAP SE which provides the terms of your use of the SAP mobile application (Software). By clicking \"Accept\" or by installing and/or using the Software, you on behalf of the Company are agreeing to all of the terms and conditions stated in this Agreement. If you do not agree to these terms, do not click \"Agree\", and do not use the Software. You represent and warrant that you have the authority to bind the Company to the terms of this Agreement.\n\n"))
     
-    static let LongHTML: EULAViewDataModel = {
-        let eulaURL = Bundle.main.url(forResource: "EULAText", withExtension: "html")!
-        let eulaData = try! Data(contentsOf: eulaURL)
-        let eulaAttString = try! NSMutableAttributedString(data: eulaData, options: [.documentType: NSAttributedString.DocumentType.html], documentAttributes: nil)
-        return EULAViewDataModel(bodyAttributedText: eulaAttString)
-    }()
-    
-    static let ShortHTML: EULAViewDataModel = {
-        let eulaURL = Bundle.main.url(forResource: "EULA2", withExtension: "html")!
-        let eulaData = try! Data(contentsOf: eulaURL)
-        let eulaAttString = try! NSMutableAttributedString(data: eulaData, options: [.documentType: NSAttributedString.DocumentType.html], documentAttributes: nil)
-        return EULAViewDataModel(bodyAttributedText: eulaAttString)
-    }()
+    /// Parses an HTML resource into an `NSAttributedString`.
+    /// - Important: HTML parsing relies on WebKit and MUST run on the main thread.
+    @MainActor
+    static func loadHTML(resource: String, withExtension ext: String = "html") -> NSAttributedString? {
+        guard let url = Bundle.main.url(forResource: resource, withExtension: ext) else {
+            print("EULA resource not found: \(resource).\(ext)")
+            return nil
+        }
+        do {
+            let data = try Data(contentsOf: url)
+            let attString = try NSMutableAttributedString(
+                data: data,
+                options: [.documentType: NSAttributedString.DocumentType.html],
+                documentAttributes: nil
+            )
+            return attString
+        } catch {
+            print("Failed to parse EULA HTML (\(resource)): \(error)")
+            return nil
+        }
+    }
     
     static let ConcatAttributedStrings: EULAViewDataModel = {
         let title = "CUSTOM EULA"
@@ -82,11 +90,20 @@ struct EULAViewSample: View {
 struct EULALongHtmlSample: View {
     @Environment(\.presentationMode) var presentationMode
     
-    let model = EULAViewDataModel.LongHTML
+    @State private var model = EULAViewDataModel()
     
     var body: some View {
-        EULAView(title: AttributedString(self.model.title), bodyText: AttributedString(self.model.bodyAttributedText ?? NSAttributedString(string: "")), didAgree: self.model.didAgree, didDisagree: self.model.didDisagree) {
+        EULAView(title: AttributedString(self.model.title),
+                 bodyText: AttributedString(self.model.bodyAttributedText ?? NSAttributedString(string: "")),
+                 didAgree: self.model.didAgree,
+                 didDisagree: self.model.didDisagree)
+        {
             self.presentationMode.wrappedValue.dismiss()
+        }
+        .task {
+            if let att = EULAViewDataModel.loadHTML(resource: "EULAText") {
+                self.model.bodyAttributedText = att
+            }
         }
     }
 }
@@ -94,11 +111,20 @@ struct EULALongHtmlSample: View {
 struct EULAShortHtmlSample: View {
     @Environment(\.presentationMode) var presentationMode
     
-    let model = EULAViewDataModel.ShortHTML
+    @State private var model = EULAViewDataModel()
     
     var body: some View {
-        EULAView(title: AttributedString(self.model.title), bodyText: AttributedString(self.model.bodyAttributedText ?? NSAttributedString(string: "")), didAgree: self.model.didAgree, didDisagree: self.model.didDisagree) {
+        EULAView(title: AttributedString(self.model.title),
+                 bodyText: AttributedString(self.model.bodyAttributedText ?? NSAttributedString(string: "")),
+                 didAgree: self.model.didAgree,
+                 didDisagree: self.model.didDisagree)
+        {
             self.presentationMode.wrappedValue.dismiss()
+        }
+        .task {
+            if let att = EULAViewDataModel.loadHTML(resource: "EULA2") {
+                self.model.bodyAttributedText = att
+            }
         }
     }
 }


### PR DESCRIPTION
# Fix App Crash on EULA Examples in iOS 18.6

### Bug Fix

🐛 Resolved a crash that occurred when navigating to EULA example items on iOS 18.6. The root cause was that HTML parsing via `NSAttributedString` relies on WebKit internally and **must run on the main thread**. The previous implementation parsed HTML eagerly as static stored properties (computed at initialization time), which caused a thread violation crash on iOS 18.6.

### Changes

* `EULAViewSample.swift`:
  - Replaced the `LongHTML` and `ShortHTML` static stored properties (which used `try!` and forced synchronous HTML parsing at init time) with a new `@MainActor`-annotated `loadHTML(resource:withExtension:)` static method that safely parses HTML with proper error handling.
  - Updated `EULALongHtmlSample` and `EULAShortHtmlSample` views to use `@State private var model = EULAViewDataModel()` instead of eagerly-loaded static models.
  - Added `.task { }` modifiers to both sample views so HTML content is loaded asynchronously on the main actor after the view appears, avoiding the threading issue.

### Jira Issues

* IOSSDKBUG-2230: APP crashed after clicking EULA Examples item on iOS 18.6

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.26`

- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Correlation ID: `c3958c10-9a13-11f1-8c6c-1902d622bcb9`
- File Content Strategy: Full file content
- Event Trigger: `pull_request.opened`
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- LLM: `anthropic--claude-4.6-sonnet`
</details>
