### PR TITLE
fix: 🐛 [IOSSDKBUG-1631] use _VariadicView to render MenuSelection action in same frame

### DIFF
--- a/Sources/FioriSwiftUICore/_FioriStyles/MenuSelectionStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/MenuSelectionStyle.fiori.swift
@@ -32,9 +32,11 @@ struct MenuSelectionViewLayout: _VariadicView_MultiViewRoot {
     
     func body(children: _VariadicView.Children) -> some View {
         VStack(alignment: .leading) {
-            self.makeBody(children)
+            let isListCollapsed = self.maxNumberOfItems > 0 && !self.configuration.isExpanded && children.count > self.maxNumberOfItems
             
-            if self.isListCollapsed(children) {
+            self.makeItemsBody(children, isListCollapsed: isListCollapsed)
+            
+            if isListCollapsed {
                 Group {
                     if self.configuration.action.isEmpty {
                         self.defaultAction(children)
@@ -48,12 +50,9 @@ struct MenuSelectionViewLayout: _VariadicView_MultiViewRoot {
             }
         }
     }
-    
-    func isListCollapsed(_ children: _VariadicView.Children) -> Bool {
-        self.maxNumberOfItems > 0 && !self.configuration.isExpanded && children.count > self.maxNumberOfItems
-    }
-    
+
     func defaultAction(_ children: _VariadicView.Children) -> some View {
+        // `children.count` is the total unfiltered count, as _VariadicView always provides all children.
         FioriButton(title: .init("View All (%d)", args: children.count, locale: self.locale))
             .fioriButtonStyle(FioriSecondaryButtonStyle(colorStyle: .normal, isLoading: self.isLoading))
             .environment(\.isEnabled, true)
@@ -61,8 +60,8 @@ struct MenuSelectionViewLayout: _VariadicView_MultiViewRoot {
     }
     
     @ViewBuilder
-    func makeBody(_ children: _VariadicView.Children) -> some View {
-        let limitedNumberOfItems = !self.isListCollapsed(children) ? 0 : self.maxNumberOfItems
+    func makeItemsBody(_ children: _VariadicView.Children, isListCollapsed: Bool) -> some View {
+        let limitedNumberOfItems = !isListCollapsed ? 0 : self.maxNumberOfItems
         if limitedNumberOfItems <= 0 {
             children
         } else {

--- a/Sources/FioriSwiftUICore/_FioriStyles/MenuSelectionStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/MenuSelectionStyle.fiori.swift
@@ -16,44 +16,60 @@ import SwiftUI
 
 // Base Layout style
 public struct MenuSelectionBaseStyle: MenuSelectionStyle {
+    public func makeBody(_ configuration: MenuSelectionConfiguration) -> some View {
+        _VariadicView.Tree(MenuSelectionViewLayout(configuration: configuration)) {
+            configuration.items
+        }
+    }
+}
+
+struct MenuSelectionViewLayout: _VariadicView_MultiViewRoot {
+    let configuration: MenuSelectionConfiguration
+    
     @Environment(\.maxNumberOfItems) var maxNumberOfItems
-    @State private var itemCount = 0
     @Environment(\.locale) var locale
     @Environment(\.isLoading) var isLoading
     
-    public func makeBody(_ configuration: MenuSelectionConfiguration) -> some View {
+    func body(children: _VariadicView.Children) -> some View {
         VStack(alignment: .leading) {
-            _CountableView(maxNumberOfItems: !self.isListCollapsed(configuration) ? 0 : self.maxNumberOfItems) {
-                configuration.items
-            }
-            .onPreferenceChange(ItemCountPreferenceKey.self, perform: { value in
-                self.itemCount = value
-            })
-           
-            if self.isListCollapsed(configuration) {
+            self.makeBody(children)
+            
+            if self.isListCollapsed(children) {
                 Group {
-                    if configuration.action.isEmpty {
-                        self.defaultAction
+                    if self.configuration.action.isEmpty {
+                        self.defaultAction(children)
                     } else {
-                        configuration.action
+                        self.configuration.action
                     }
                 }
                 .onSimultaneousTapGesture {
-                    configuration.isExpanded = true
+                    self.configuration.isExpanded = true
                 }
             }
         }
     }
     
-    private func isListCollapsed(_ config: MenuSelectionConfiguration) -> Bool {
-        self.maxNumberOfItems > 0 && !config.isExpanded && self.itemCount > self.maxNumberOfItems
+    func isListCollapsed(_ children: _VariadicView.Children) -> Bool {
+        self.maxNumberOfItems > 0 && !self.configuration.isExpanded && children.count > self.maxNumberOfItems
     }
     
-    private var defaultAction: some View {
-        FioriButton(title: .init("View All (%d)", args: self.itemCount, locale: self.locale))
+    func defaultAction(_ children: _VariadicView.Children) -> some View {
+        FioriButton(title: .init("View All (%d)", args: children.count, locale: self.locale))
             .fioriButtonStyle(FioriSecondaryButtonStyle(colorStyle: .normal, isLoading: self.isLoading))
             .environment(\.isEnabled, true)
             .accessibilityIdentifier("FioriSwiftUICore.MenuSelection.ViewAllButton")
+    }
+    
+    @ViewBuilder
+    func makeBody(_ children: _VariadicView.Children) -> some View {
+        let limitedNumberOfItems = !self.isListCollapsed(children) ? 0 : self.maxNumberOfItems
+        if limitedNumberOfItems <= 0 {
+            children
+        } else {
+            ForEach(0 ..< min(limitedNumberOfItems, children.count), id: \.self) {
+                children[$0]
+            }
+        }
     }
 }
 


### PR DESCRIPTION
# Fix: Use `_VariadicView` to Render `MenuSelection` Action in the Same Frame

### Bug Fix

🐛 Resolved a rendering issue in the `MenuSelection` component where the action button was not rendered in the same frame as the menu items. The fix replaces the previous `_CountableView` + `onPreferenceChange` approach (which required two render passes to count items) with a direct `_VariadicView`-based layout, allowing item count and action visibility to be determined in a single render pass.

### Changes

* `MenuSelectionStyle.fiori.swift`:
  - Restructured `MenuSelectionBaseStyle` to use `_VariadicView.Tree` with a dedicated `MenuSelectionViewLayout` conforming to `_VariadicView_MultiViewRoot`.
  - Removed the `@State private var itemCount` property and the `_CountableView`/`onPreferenceChange` mechanism that caused deferred rendering.
  - Replaced `isListCollapsed(_:)` to accept `_VariadicView.Children` directly, using `children.count` instead of the previously tracked `itemCount` state.
  - Updated `defaultAction` and `makeBody` to take `_VariadicView.Children` as a parameter, computing item limits inline without relying on state updates.
  - Added a new `makeBody(_ children:)` `@ViewBuilder` method that slices the children list based on `maxNumberOfItems`, replacing the old `_CountableView` usage.

### Jira Issues

* IOSSDKBUG-1631

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.30`

- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- LLM: `anthropic--claude-4.6-sonnet`
- Event Trigger: `pull_request.opened`
- File Content Strategy: Full file content
- Correlation ID: `23fbfa60-9acf-11f1-8893-54640d09f511`
</details>
