### PR TITLE
feat: 🎸 [HCPSDKFIORIUIKIT-3267] DatePicker & DateRangePicker enhancement to support clear action

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/Picker/DateRangePickerExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/Picker/DateRangePickerExample.swift
@@ -14,7 +14,8 @@ struct DateRangePickerExample: View {
     @State private var pickerVisible3 = false
     @State private var pickerVisible4 = false
     @State private var pickerVisible5 = false
-
+    
+    @State private var showsClearAction = false
     @State private var customizeSeparator = false
     @State private var showSeparator = true
     @State private var separatorColorIndex = 0
@@ -96,6 +97,8 @@ struct DateRangePickerExample: View {
                 .tint(Color.preferredColor(.tintColor))
             Toggle("Skeleton Loading", isOn: self.$isLoading)
                 .tint(Color.preferredColor(.tintColor))
+            Toggle("Show Clear Action", isOn: self.$showsClearAction)
+            
             Section("Picker Separator") {
                 Toggle("Customize Separator", isOn: self.$customizeSeparator)
                     .tint(Color.preferredColor(.tintColor))
@@ -113,36 +116,39 @@ struct DateRangePickerExample: View {
                 }
             }
             Section(header: Text("")) {
-                DateRangePicker(title: "Range Selection Long Title Long Title Long Title Long Title Long Title Long Title0", mandatoryFieldIndicator: self.mandatoryFieldIndicator(), isRequired: self.isRequired, selectedRange: self.$selectedRange0, pickerVisible: self.$pickerVisible0)
+                DateRangePicker(title: "Range Selection Long Title Long Title Long Title Long Title Long Title Long Title0", mandatoryFieldIndicator: self.mandatoryFieldIndicator(), isRequired: self.isRequired, selectedRange: self.$selectedRange0, pickerVisible: self.$pickerVisible0, showsClearAction: self.showsClearAction)
                     .informationView(isPresented: self.$showsErrorMessage, description: AttributedString("This is information error message."))
                     .informationViewStyle(.error)
                     .aiNoticeView(isPresented: self.$showAINotice, description: "AI Notice")
                 
-                DateRangePicker(title: "Range Selection1", mandatoryFieldIndicator: self.mandatoryFieldIndicator(), isRequired: self.isRequired, selectedRange: self.$selectedRange1, pickerVisible: self.$pickerVisible1)
+                DateRangePicker(title: "Range Selection1", mandatoryFieldIndicator: self.mandatoryFieldIndicator(), isRequired: self.isRequired, selectedRange: self.$selectedRange1, pickerVisible: self.$pickerVisible1, showsClearAction: self.showsClearAction)
                     .informationView(isPresented: self.$showsErrorMessage, description: AttributedString("This is information hint message."))
                     .informationViewStyle(.informational)
                     .aiNoticeView(isPresented: self.$showAINotice, description: "AI Notice")
                     .titleStyle(CustomTitleStyle())
                     .valueLabelStyle(CustomValueLabelStyle())
                 
-                DateRangePicker(title: "Limit inclusive range of selectable dates", mandatoryFieldIndicator: self.mandatoryFieldIndicator(), isRequired: self.isRequired, range: self.limitDateRange, selectedRange: self.$selectedRange2, noRangeSelectedString: "Please select range", pickerVisible: self.$pickerVisible2)
+                DateRangePicker(title: "Limit inclusive range of selectable dates", mandatoryFieldIndicator: self.mandatoryFieldIndicator(), isRequired: self.isRequired, range: self.limitDateRange, selectedRange: self.$selectedRange2, noRangeSelectedString: "Please select range", pickerVisible: self.$pickerVisible2, showsClearAction: self.showsClearAction)
                     .informationView(isPresented: self.$showsErrorMessage, description: AttributedString("This is information warning message."))
                     .informationViewStyle(.warning)
                     .aiNoticeView(isPresented: self.$showAINotice, description: "AI Notice")
                 
-                DateRangePicker(title: "Customized Date Formatter", mandatoryFieldIndicator: self.mandatoryFieldIndicator(), isRequired: self.isRequired, selectedRange: self.$selectedRange3, rangeFormatter: self.customizedDateFormatter, pickerVisible: self.$pickerVisible3)
+                DateRangePicker(title: "Customized Date Formatter", mandatoryFieldIndicator: self.mandatoryFieldIndicator(), isRequired: self.isRequired, selectedRange: self.$selectedRange3, rangeFormatter: self.customizedDateFormatter, pickerVisible: self.$pickerVisible3, showsClearAction: self.showsClearAction)
                     .informationView(isPresented: self.$showsErrorMessage, description: AttributedString("This is information success message."))
                     .informationViewStyle(.success)
                     .aiNoticeView(isPresented: self.$showAINotice, description: "AI Notice")
                 
-                DateRangePicker(title: "Custom Locale & Calendar", mandatoryFieldIndicator: self.mandatoryFieldIndicator(), isRequired: self.isRequired, selectedRange: self.$selectedRange4, pickerVisible: self.$pickerVisible4)
-                    .informationView(isPresented: self.$showsErrorMessage, description: AttributedString("This is information hint message."))
-                    .informationViewStyle(.informational)
-                    .aiNoticeView(isPresented: self.$showAINotice, description: "AI Notice")
-                    .environment(\.locale, Locale(identifier: "zh-Hans"))
-                    .environment(\.calendar, Calendar(identifier: .gregorian))
+                DateRangePicker(title: "Custom Locale & Calendar, Customized Clear Action", mandatoryFieldIndicator: self.mandatoryFieldIndicator(), isRequired: self.isRequired, selectedRange: self.$selectedRange4, pickerVisible: self.$pickerVisible4, showsClearAction: self.showsClearAction) {
+                    Image(systemName: "xmark.square")
+                        .foregroundColor(.red)
+                }
+                .informationView(isPresented: self.$showsErrorMessage, description: AttributedString("This is information hint message."))
+                .informationViewStyle(.informational)
+                .aiNoticeView(isPresented: self.$showAINotice, description: "AI Notice")
+                .environment(\.locale, Locale(identifier: "zh-Hans"))
+                .environment(\.calendar, Calendar(identifier: .gregorian))
             
-                DateRangePicker(title: "Range Selection in Disabled Control State", mandatoryFieldIndicator: self.mandatoryFieldIndicator(true), isRequired: self.isRequired, controlState: .disabled, selectedRange: self.$selectedRange5, pickerVisible: self.$pickerVisible5)
+                DateRangePicker(title: "Range Selection in Disabled Control State,", mandatoryFieldIndicator: self.mandatoryFieldIndicator(true), isRequired: self.isRequired, controlState: .disabled, selectedRange: self.$selectedRange5, pickerVisible: self.$pickerVisible5, showsClearAction: self.showsClearAction)
                     .informationView(isPresented: self.$showsErrorMessage, description: AttributedString("This is information success message."))
                     .informationViewStyle(.success)
                     .aiNoticeView(isPresented: self.$showAINotice, description: "AI Notice")

--- a/Apps/Examples/Examples/FioriSwiftUICore/Picker/DateRangePickerExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/Picker/DateRangePickerExample.swift
@@ -148,7 +148,7 @@ struct DateRangePickerExample: View {
                 .environment(\.locale, Locale(identifier: "zh-Hans"))
                 .environment(\.calendar, Calendar(identifier: .gregorian))
             
-                DateRangePicker(title: "Range Selection in Disabled Control State,", mandatoryFieldIndicator: self.mandatoryFieldIndicator(true), isRequired: self.isRequired, controlState: .disabled, selectedRange: self.$selectedRange5, pickerVisible: self.$pickerVisible5, showsClearAction: self.showsClearAction)
+                DateRangePicker(title: "Range Selection in Disabled Control State", mandatoryFieldIndicator: self.mandatoryFieldIndicator(true), isRequired: self.isRequired, controlState: .disabled, selectedRange: self.$selectedRange5, pickerVisible: self.$pickerVisible5, showsClearAction: self.showsClearAction)
                     .informationView(isPresented: self.$showsErrorMessage, description: AttributedString("This is information success message."))
                     .informationViewStyle(.success)
                     .aiNoticeView(isPresented: self.$showAINotice, description: "AI Notice")

--- a/Apps/Examples/Examples/FioriSwiftUICore/Picker/DateTimePickerExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/Picker/DateTimePickerExample.swift
@@ -16,6 +16,7 @@ struct DateTimePickerExample: View {
     @State var isRequired = false
     @State var showsErrorMessage = false
     @State var showAINotice: Bool = false
+    @State var showsClearAction = false
     @State var isLoading: Bool = false
     @State var pickerVisible = false
     @State var pickerVisible1 = false
@@ -95,6 +96,7 @@ struct DateTimePickerExample: View {
             Toggle("AI Notice", isOn: self.$showAINotice)
             Toggle("Picker Visible", isOn: self.masterPickerVisibleBinding)
             Toggle("Skeleton Loading", isOn: self.$isLoading)
+            Toggle("Show Clear Action", isOn: self.$showsClearAction)
             Section("Picker Separator") {
                 Toggle("Customize Separator", isOn: self.$customizeSeparator)
                 if self.customizeSeparator {
@@ -110,11 +112,11 @@ struct DateTimePickerExample: View {
                 }
             }
             Section(header: Text("")) {
-                DateTimePicker(title: "Default", mandatoryFieldIndicator: self.mandatoryFieldIndicator(), isRequired: self.isRequired, selectedDate: self.$s1, pickerVisible: self.$pickerVisible)
+                DateTimePicker(title: "Default", mandatoryFieldIndicator: self.mandatoryFieldIndicator(), isRequired: self.isRequired, selectedDate: self.$s1, pickerVisible: self.$pickerVisible, showsClearAction: self.showsClearAction)
                     .informationView(isPresented: self.$showsErrorMessage, description: AttributedString("The Date should be before December."))
                     .informationViewStyle(.informational)
                     .aiNoticeView(isPresented: self.$showAINotice, description: "AI Notice")
-                DateTimePicker(title: "Date only(No separator)", mandatoryFieldIndicator: self.mandatoryFieldIndicator(), isRequired: self.isRequired, selectedDate: self.$s2, pickerComponents: [.date], pickerVisible: self.$pickerVisible1, hidesSeparator: true)
+                DateTimePicker(title: "Date only(No separator)", mandatoryFieldIndicator: self.mandatoryFieldIndicator(), isRequired: self.isRequired, selectedDate: self.$s2, pickerComponents: [.date], pickerVisible: self.$pickerVisible1, hidesSeparator: true, showsClearAction: self.showsClearAction)
                     .informationView(isPresented: self.$showsErrorMessage, description: AttributedString("The Date should be before December."))
                     .informationViewStyle(.error)
                     .aiNoticeView(isPresented: self.$showAINotice, description: "AI Notice")
@@ -126,23 +128,23 @@ struct DateTimePickerExample: View {
                             )
                             .clipShape(.rect(cornerRadius: 6))
                     }
-                DateTimePicker(title: "Time only", mandatoryFieldIndicator: self.mandatoryFieldIndicator(), isRequired: self.isRequired, selectedDate: self.$s3, pickerComponents: [.hourAndMinute], pickerVisible: self.$pickerVisible2)
+                DateTimePicker(title: "Time only", mandatoryFieldIndicator: self.mandatoryFieldIndicator(), isRequired: self.isRequired, selectedDate: self.$s3, pickerComponents: [.hourAndMinute], pickerVisible: self.$pickerVisible2, showsClearAction: self.showsClearAction)
                     .accessibilitySortPriority(3) // This is a workaround, because the picker in DateTimePicker style as a popup will not restore original focus when dismissed.
                     .aiNoticeView(isPresented: self.$showAINotice, description: "AI Notice")
-                DateTimePicker(title: "Numeric Date Style", mandatoryFieldIndicator: self.mandatoryFieldIndicator(), isRequired: self.isRequired, selectedDate: self.$s4, pickerComponents: [.date], dateStyle: .numeric, pickerVisible: self.$pickerVisible3)
+                DateTimePicker(title: "Numeric Date Style", mandatoryFieldIndicator: self.mandatoryFieldIndicator(), isRequired: self.isRequired, selectedDate: self.$s4, pickerComponents: [.date], dateStyle: .numeric, pickerVisible: self.$pickerVisible3, showsClearAction: self.showsClearAction)
                     .aiNoticeView(isPresented: self.$showAINotice, description: "AI Notice")
-                DateTimePicker(title: "Auto selected date", mandatoryFieldIndicator: self.mandatoryFieldIndicator(), isRequired: self.isRequired, selectedDate: self.$autoSelectedDate, pickerComponents: [.date], dateStyle: .numeric, pickerVisible: self.$autoSelectedDatePickerVisible)
+                DateTimePicker(title: "Auto selected date", mandatoryFieldIndicator: self.mandatoryFieldIndicator(), isRequired: self.isRequired, selectedDate: self.$autoSelectedDate, pickerComponents: [.date], dateStyle: .numeric, pickerVisible: self.$autoSelectedDatePickerVisible, showsClearAction: self.showsClearAction)
                     .environment(\.dateTimePickerAutoSelected, true)
                     .aiNoticeView(isPresented: self.$showAINotice, description: "AI Notice")
-                DateTimePicker(title: "Long long long long long long label", mandatoryFieldIndicator: self.mandatoryFieldIndicator(), isRequired: self.isRequired, selectedDate: self.$s5, pickerVisible: self.$pickerVisible4)
+                DateTimePicker(title: "Long long long long long long label", mandatoryFieldIndicator: self.mandatoryFieldIndicator(), isRequired: self.isRequired, selectedDate: self.$s5, pickerVisible: self.$pickerVisible4, showsClearAction: self.showsClearAction)
                     .informationView(isPresented: self.$showsErrorMessage, description: AttributedString("The Date should be before December."))
                     .informationViewStyle(.error)
                     .aiNoticeView(isPresented: self.$showAINotice, description: "AI Notice")
-                DateTimePicker(title: "Custom Style", mandatoryFieldIndicator: self.mandatoryFieldIndicator(), isRequired: self.isRequired, selectedDate: self.$s6, pickerVisible: self.$pickerVisible5)
+                DateTimePicker(title: "Custom Style", mandatoryFieldIndicator: self.mandatoryFieldIndicator(), isRequired: self.isRequired, selectedDate: self.$s6, pickerVisible: self.$pickerVisible5, showsClearAction: self.showsClearAction)
                     .titleStyle(CustomTitleStyle())
                     .valueLabelStyle(CustomValueLabelStyle())
                 
-                DateTimePicker(title: "Customized Date Formatter, locale and calendar", mandatoryFieldIndicator: self.mandatoryFieldIndicator(), isRequired: self.isRequired, selectedDate: self.$customizedDate, dateFormatter: self.customizedDateFormatter, pickerVisible: self.$customizedPickerVisible)
+                DateTimePicker(title: "Customized Date Formatter, locale and calendar", mandatoryFieldIndicator: self.mandatoryFieldIndicator(), isRequired: self.isRequired, selectedDate: self.$customizedDate, dateFormatter: self.customizedDateFormatter, pickerVisible: self.$customizedPickerVisible, showsClearAction: self.showsClearAction)
                     .environment(\.locale, Locale(identifier: "zh-Hans"))
                     .environment(\.calendar, Calendar(identifier: .gregorian))
             }
@@ -154,15 +156,18 @@ struct DateTimePickerExample: View {
                 DateTimePicker(title: "In Read-Only Mode", controlState: .readOnly, selectedDate: self.$s7, pickerComponents: [.date], pickerVisible: self.$pickerVisible)
             }
             Section {
-                DateTimePicker(title: "Limit Selectable Dates", range: self.limitDateRange, selectedDate: self.$limitedDate, pickerVisible: self.$limitedDatePickerVisible)
+                DateTimePicker(title: "Limit Selectable Dates", range: self.limitDateRange, selectedDate: self.$limitedDate, pickerVisible: self.$limitedDatePickerVisible, showsClearAction: self.showsClearAction) {
+                    Image(systemName: "xmark.rectangle")
+                        .foregroundColor(.red)
+                }
             } header: {
-                Text("Range")
+                Text("Range, customized clear action")
                     .textCase(.none)
             }
             
             Section {
-                DateTimePicker(title: "Start Date/Time", selectedDate: self.$separatedRangeStartDate, pickerVisible: self.$separatedRangeStartPickerVisible)
-                DateTimePicker(title: "End Date/Time", selectedDate: self.$separatedRangeEndDate, pickerVisible: self.$separatedRangeEndPickerVisible)
+                DateTimePicker(title: "Start Date/Time", selectedDate: self.$separatedRangeStartDate, pickerVisible: self.$separatedRangeStartPickerVisible, showsClearAction: self.showsClearAction)
+                DateTimePicker(title: "End Date/Time", selectedDate: self.$separatedRangeEndDate, pickerVisible: self.$separatedRangeEndPickerVisible, showsClearAction: self.showsClearAction)
             } header: {
                 Text("Select time ranges separately")
             }

--- a/Sources/FioriSwiftUICore/_ComponentProtocols/CompositeComponentProtocols.swift
+++ b/Sources/FioriSwiftUICore/_ComponentProtocols/CompositeComponentProtocols.swift
@@ -996,7 +996,7 @@ protocol _SwitchViewComponent: _TitleComponent, _SwitchComponent, _StateLabelCom
 /// ```
 // sourcery: CompositeComponent
 protocol _DateTimePickerComponent: _TitleComponent, _ValueLabelComponent, _MandatoryField, _FormViewComponent {
-    // The inclusive range of selectable dates.
+    /// The inclusive range of selectable dates.
     var range: ClosedRange<Date>? { get }
     // sourcery: @Binding
     // sourcery: defaultValue = ".constant(nil)"
@@ -1026,6 +1026,16 @@ protocol _DateTimePickerComponent: _TitleComponent, _ValueLabelComponent, _Manda
     // sourcery: defaultValue = false
     /// This property indicates whether the separator is to be displayed. Default is false.
     var hidesSeparator: Bool { get }
+    
+    // sourcery: defaultValue = false
+    /// This property indicates whether the clear action should be displayed. Default is false. When selectedDate is nil, the clear action will be hidden.
+    var showsClearAction: Bool { get }
+    
+    // sourcery: defaultValue = "{ Image(systemName: "xmark.circle").foregroundColor(.gray) }"
+    // sourcery: resultBuilder.defaultValue = "{ Image(systemName: "xmark.circle").foregroundColor(.gray) }"
+    /// view for clear the value
+    @ViewBuilder
+    var clearAction: () -> any View { get }
 }
 
 /// `DateRangePicker`  provides a title and value label with Fiori styling and a `MultiDatePicker`.
@@ -1080,6 +1090,16 @@ protocol _DateRangePickerComponent: _TitleComponent, _ValueLabelComponent, _Mand
     // sourcery: @Binding
     /// This property indicates whether the picker is to be displayed or not.
     var pickerVisible: Bool { get set }
+    
+    // sourcery: defaultValue = false
+    /// This property indicates whether the clear action should be displayed. Default is false. When selectedDate is nil, the clear action will be hidden.
+    var showsClearAction: Bool { get }
+    
+    // sourcery: defaultValue = "{ Image(systemName: "xmark.circle").foregroundColor(.gray) }"
+    // sourcery: resultBuilder.defaultValue = "{ Image(systemName: "xmark.circle").foregroundColor(.gray) }"
+    /// view for clear the value
+    @ViewBuilder
+    var clearAction: () -> any View { get }
 }
 
 // sourcery: CompositeComponent

--- a/Sources/FioriSwiftUICore/_ComponentProtocols/CompositeComponentProtocols.swift
+++ b/Sources/FioriSwiftUICore/_ComponentProtocols/CompositeComponentProtocols.swift
@@ -995,6 +995,7 @@ protocol _SwitchViewComponent: _TitleComponent, _SwitchComponent, _StateLabelCom
 ///    .environment(\.calendar, Calendar(identifier: .gregorian))
 /// ```
 // sourcery: CompositeComponent
+// sourcery: importFrameworks = ["FioriThemeManager"]
 protocol _DateTimePickerComponent: _TitleComponent, _ValueLabelComponent, _MandatoryField, _FormViewComponent {
     /// The inclusive range of selectable dates.
     var range: ClosedRange<Date>? { get }
@@ -1031,8 +1032,8 @@ protocol _DateTimePickerComponent: _TitleComponent, _ValueLabelComponent, _Manda
     /// This property indicates whether the clear action should be displayed. Default is false. When selectedDate is nil, the clear action will be hidden.
     var showsClearAction: Bool { get }
     
-    // sourcery: defaultValue = "{ Image(systemName: "xmark.circle").foregroundColor(.gray) }"
-    // sourcery: resultBuilder.defaultValue = "{ Image(systemName: "xmark.circle").foregroundColor(.gray) }"
+    // sourcery: defaultValue = "{ FioriIcon.actions.sysCancel.foregroundColor(.gray) }"
+    // sourcery: resultBuilder.defaultValue = "{ FioriIcon.actions.sysCancel.foregroundColor(.gray) }"
     /// view for clear the value
     @ViewBuilder
     var clearAction: () -> any View { get }
@@ -1073,6 +1074,7 @@ protocol _DateTimePickerComponent: _TitleComponent, _ValueLabelComponent, _Manda
 ///     .environment(\.calendar, Calendar(identifier: .gregorian))
 /// ```
 // sourcery: CompositeComponent
+// sourcery: importFrameworks = ["FioriThemeManager"]
 protocol _DateRangePickerComponent: _TitleComponent, _ValueLabelComponent, _MandatoryField, _FormViewComponent {
     /// The inclusive range of selectable dates.
     var range: Range<Date>? { get }
@@ -1095,8 +1097,8 @@ protocol _DateRangePickerComponent: _TitleComponent, _ValueLabelComponent, _Mand
     /// This property indicates whether the clear action should be displayed. Default is false. When selectedDate is nil, the clear action will be hidden.
     var showsClearAction: Bool { get }
     
-    // sourcery: defaultValue = "{ Image(systemName: "xmark.circle").foregroundColor(.gray) }"
-    // sourcery: resultBuilder.defaultValue = "{ Image(systemName: "xmark.circle").foregroundColor(.gray) }"
+    // sourcery: defaultValue = "{ FioriIcon.actions.sysCancel.foregroundColor(.gray) }"
+    // sourcery: resultBuilder.defaultValue = "{ FioriIcon.actions.sysCancel.foregroundColor(.gray) }"
     /// view for clear the value
     @ViewBuilder
     var clearAction: () -> any View { get }

--- a/Sources/FioriSwiftUICore/_FioriStyles/DateRangePickerStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/DateRangePickerStyle.fiori.swift
@@ -56,9 +56,22 @@ public struct DateRangePickerBaseStyle: DateRangePickerStyle {
             } else {
                 Divider().hidden()
             }
-
-            ValueLabel(valueLabel: AttributedString(self.getValueLabel(configuration)))
-                .accessibilityLabel(self.getValueAccessibilityLabelString(configuration))
+            
+            HStack(spacing: 4) {
+                ValueLabel(valueLabel: AttributedString(self.getValueLabel(configuration)))
+                    .accessibilityLabel(self.getValueAccessibilityLabelString(configuration))
+                if configuration.controlState != .disabled,
+                   configuration.controlState != .readOnly,
+                   configuration.selectedRange != nil,
+                   configuration.showsClearAction
+                {
+                    configuration.clearAction
+                        .onSimultaneousTapGesture {
+                            configuration.selectedRange = nil
+                        }
+                        .contentShape(.accessibility, .rect.scale(1.2))
+                }
+            }
         }
         .accessibilityElement(children: .combine)
         .accessibilityHint(self.mainStackAccessibilityHint(configuration))
@@ -161,5 +174,59 @@ extension DateRangePickerFioriStyle {
         func makeBody(_ configuration: FormViewConfiguration) -> some View {
             FormView(configuration)
         }
+    }
+}
+
+public extension DateRangePicker {
+    /// Convenience initializer for `DateRangePicker`
+    /// - Parameters:
+    ///   - title: The title view for the date range picker.
+    ///   - valueLabel: The value view for the date range picker.
+    ///   - controlState: The `ControlState` of the form view. The default is `normal`.
+    ///   - errorMessage: The error message of the form view.
+    ///   - range: The inclusive range of selectable dates.
+    ///   - selectedRange: The range of selected dates. Default is nil. It's continuous in ascending order.
+    ///   - rangeFormatter: Range date formatter. The default date formatter conforms system setting, it uses short date type in compact screen and uses long date type in regular screen.
+    ///   - noRangeSelectedString: The text to be displayed when no range is selected. If this property is `nil`, the localized string “No range selected” will be used.
+    ///   - pickerVisible: This property indicates whether the picker is to be displayed or not.
+    init(@ViewBuilder title: () -> any View,
+         @ViewBuilder valueLabel: () -> any View = { EmptyView() },
+         controlState: ControlState = .normal,
+         errorMessage: AttributedString? = nil,
+         range: Range<Date>? = nil,
+         selectedRange: Binding<ClosedRange<Date>?> = .constant(nil),
+         rangeFormatter: DateFormatter? = nil,
+         noRangeSelectedString: String? = nil,
+         pickerVisible: Binding<Bool>)
+    {
+        self.init(title: title, valueLabel: valueLabel, controlState: controlState, errorMessage: errorMessage, range: range, selectedRange: selectedRange, rangeFormatter: rangeFormatter, noRangeSelectedString: noRangeSelectedString, pickerVisible: pickerVisible, showsClearAction: false)
+    }
+    
+    /// Convenience initializer for `DateRangePicker`
+    /// - Parameters:
+    ///   - title: The title string for the date range picker.
+    ///   - valueLabel: The value string for the date range picker.
+    ///   - mandatoryFieldIndicator: The mandatory field indicator for the date range picker.
+    ///   - isRequired: This property indicates whether the mandatory field indicator is to be displayed.
+    ///   - controlState: The `ControlState` of the form view. The default is `normal`.
+    ///   - errorMessage: The error message of the form view.
+    ///   - range: The inclusive range of selectable dates.
+    ///   - selectedRange: The range of selected dates. Default is nil. It's continuous in ascending order.
+    ///   - rangeFormatter: Range date formatter. The default date formatter conforms system setting, it uses short date type in compact screen and uses long date type in regular screen.
+    ///   - noRangeSelectedString: The text to be displayed when no range is selected. If this property is `nil`, the localized string “No range selected” will be used.
+    ///   - pickerVisible: This property indicates whether the picker is to be displayed or not.
+    init(title: AttributedString,
+         valueLabel: AttributedString? = nil,
+         mandatoryFieldIndicator: TextOrIcon? = .text("*"),
+         isRequired: Bool = false,
+         controlState: ControlState = .normal,
+         errorMessage: AttributedString? = nil,
+         range: Range<Date>? = nil,
+         selectedRange: Binding<ClosedRange<Date>?>,
+         rangeFormatter: DateFormatter? = nil,
+         noRangeSelectedString: String? = nil,
+         pickerVisible: Binding<Bool>)
+    {
+        self.init(title: title, valueLabel: valueLabel, mandatoryFieldIndicator: mandatoryFieldIndicator, isRequired: isRequired, controlState: controlState, errorMessage: errorMessage, range: range, selectedRange: selectedRange, rangeFormatter: rangeFormatter, noRangeSelectedString: noRangeSelectedString, pickerVisible: pickerVisible, showsClearAction: false)
     }
 }

--- a/Sources/FioriSwiftUICore/_FioriStyles/DateRangePickerStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/DateRangePickerStyle.fiori.swift
@@ -60,10 +60,10 @@ public struct DateRangePickerBaseStyle: DateRangePickerStyle {
             HStack(spacing: 4) {
                 ValueLabel(valueLabel: AttributedString(self.getValueLabel(configuration)))
                     .accessibilityLabel(self.getValueAccessibilityLabelString(configuration))
-                if configuration.controlState != .disabled,
+                if configuration.showsClearAction,
+                   configuration.controlState != .disabled,
                    configuration.controlState != .readOnly,
-                   configuration.selectedRange != nil,
-                   configuration.showsClearAction
+                   configuration.selectedRange != nil
                 {
                     configuration.clearAction
                         .onSimultaneousTapGesture {

--- a/Sources/FioriSwiftUICore/_FioriStyles/DateRangePickerStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/DateRangePickerStyle.fiori.swift
@@ -230,3 +230,29 @@ public extension DateRangePicker {
         self.init(title: title, valueLabel: valueLabel, mandatoryFieldIndicator: mandatoryFieldIndicator, isRequired: isRequired, controlState: controlState, errorMessage: errorMessage, range: range, selectedRange: selectedRange, rangeFormatter: rangeFormatter, noRangeSelectedString: noRangeSelectedString, pickerVisible: pickerVisible, showsClearAction: false)
     }
 }
+
+public extension DateRangePickerConfiguration {
+    /// Convenience initializer for `DateRangePickerConfiguration`
+    /// - Parameters:
+    ///   - title: The title view for the date range picker.
+    ///   - valueLabel: The value view for the date range picker.
+    ///   - controlState: The `ControlState` of the form view. The default is `normal`.
+    ///   - errorMessage: The error message of the form view.
+    ///   - range: The inclusive range of selectable dates.
+    ///   - selectedRange: The range of selected dates. Default is nil. It's continuous in ascending order.
+    ///   - rangeFormatter: Range date formatter. The default date formatter conforms system setting, it uses short date type in compact screen and uses long date type in regular screen.
+    ///   - noRangeSelectedString: The text to be displayed when no range is selected. If this property is `nil`, the localized string “No range selected” will be used.
+    ///   - pickerVisible: This property indicates whether the picker is to be displayed or not.
+    init(title: Title,
+         valueLabel: ValueLabel,
+         controlState: ControlState,
+         errorMessage: AttributedString?,
+         range: Range<Date>?,
+         selectedRange: Binding<ClosedRange<Date>?>,
+         rangeFormatter: DateFormatter?,
+         noRangeSelectedString: String?,
+         pickerVisible: Binding<Bool>)
+    {
+        self.init(title: title, valueLabel: valueLabel, controlState: controlState, errorMessage: errorMessage, range: range, selectedRange: selectedRange, rangeFormatter: rangeFormatter, noRangeSelectedString: noRangeSelectedString, pickerVisible: pickerVisible, showsClearAction: false, clearAction: .init(EmptyView()))
+    }
+}

--- a/Sources/FioriSwiftUICore/_FioriStyles/DateTimePickerStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/DateTimePickerStyle.fiori.swift
@@ -326,3 +326,37 @@ public extension DateTimePicker {
         self.init(title: title, valueLabel: valueLabel, mandatoryFieldIndicator: mandatoryFieldIndicator, isRequired: isRequired, controlState: controlState, errorMessage: errorMessage, range: range, selectedDate: selectedDate, dateFormatter: dateFormatter, pickerComponents: pickerComponents, dateStyle: dateStyle, timeStyle: timeStyle, noDateSelectedString: noDateSelectedString, pickerVisible: pickerVisible, hidesSeparator: hidesSeparator, showsClearAction: false)
     }
 }
+
+public extension DateTimePickerConfiguration {
+    /// Convenience initializer for `DateTimePickerConfiguration`
+    /// - Parameters:
+    ///   - title: The title view for the date time picker.
+    ///   - valueLabel: The value view for the date time picker.
+    ///   - controlState: The `ControlState` of the form view. The default is `normal`.
+    ///   - errorMessage: The error message of the form view.
+    ///   - range: The inclusive range of selectable dates.
+    ///   - selectedDate: The date value being displayed and selected.
+    ///   - dateFormatter: The `DateFormatter` to be used to display the selected `Date`. Default formatter will use customized dateStyle and timeStyle.
+    ///   - pickerComponents: The components shown in the date picker, default value shows date and time.
+    ///   - dateStyle: The custom style for displaying the date. The default value is `.abbreviated`, showing for example, "Oct 21, 2015".
+    ///   - timeStyle: The custom style for displaying the time. The default value is `.shortened`, showing for example, "4:29 PM" or "16:29".
+    ///   - noDateSelectedString: The text to be displayed when no date is selected. If this property is `nil`, the localized string “No date selected” will be used.
+    ///   - pickerVisible: This property indicates whether the picker is to be displayed.
+    ///   - hidesSeparator: This property indicates whether the separator is to be displayed. Default is false.
+    init(title: Title,
+         valueLabel: ValueLabel,
+         controlState: ControlState,
+         errorMessage: AttributedString?,
+         range: ClosedRange<Date>?,
+         selectedDate: Binding<Date?>,
+         dateFormatter: DateFormatter?,
+         pickerComponents: DatePicker.Components,
+         dateStyle: Date.FormatStyle.DateStyle,
+         timeStyle: Date.FormatStyle.TimeStyle,
+         noDateSelectedString: String?,
+         pickerVisible: Binding<Bool>,
+         hidesSeparator: Bool)
+    {
+        self.init(title: title, valueLabel: valueLabel, controlState: controlState, errorMessage: errorMessage, range: range, selectedDate: selectedDate, dateFormatter: dateFormatter, pickerComponents: pickerComponents, dateStyle: dateStyle, timeStyle: timeStyle, noDateSelectedString: noDateSelectedString, pickerVisible: pickerVisible, hidesSeparator: hidesSeparator, showsClearAction: false, clearAction: .init(EmptyView()))
+    }
+}

--- a/Sources/FioriSwiftUICore/_FioriStyles/DateTimePickerStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/DateTimePickerStyle.fiori.swift
@@ -70,10 +70,24 @@ public struct DateTimePickerBaseStyle: DateTimePickerStyle {
             } else {
                 Divider().hidden()
             }
-            ValueLabel(valueLabel: AttributedString(self.getValueLabel(configuration)))
-                .foregroundStyle(self.getFontColor(configuration))
-                .font(.fiori(forTextStyle: .body))
-                .accessibilityLabel(self.getValueLabel(configuration))
+            
+            HStack(spacing: 4) {
+                ValueLabel(valueLabel: AttributedString(self.getValueLabel(configuration)))
+                    .foregroundStyle(self.getFontColor(configuration))
+                    .font(.fiori(forTextStyle: .body))
+                    .accessibilityLabel(self.getValueLabel(configuration))
+                if configuration.controlState != .disabled,
+                   configuration.controlState != .readOnly,
+                   configuration.selectedDate != nil,
+                   configuration.showsClearAction
+                {
+                    configuration.clearAction
+                        .onSimultaneousTapGesture {
+                            configuration.selectedDate = nil
+                        }
+                        .contentShape(.accessibility, .rect.scale(1.2))
+                }
+            }
         }
         .accessibilityElement(children: .combine)
         .accessibilityHint(self.mainStackAccessibilityHint(configuration))
@@ -241,4 +255,74 @@ public enum DateTimePickerSkeletonLoadingPattern {
         pickerComponents: [.hourAndMinute],
         pickerVisible: .constant(false)
     )
+}
+
+public extension DateTimePicker {
+    /// Convenience initializer for `DateTimePicker`
+    /// - Parameters:
+    ///   - title: The title view for the date time picker.
+    ///   - valueLabel: The value view for the date time picker.
+    ///   - controlState: The `ControlState` of the form view. The default is `normal`.
+    ///   - errorMessage: The error message of the form view.
+    ///   - range: The inclusive range of selectable dates.
+    ///   - selectedDate: The date value being displayed and selected.
+    ///   - dateFormatter: The `DateFormatter` to be used to display the selected `Date`. Default formatter will use customized dateStyle and timeStyle.
+    ///   - pickerComponents: The components shown in the date picker, default value shows date and time.
+    ///   - dateStyle: The custom style for displaying the date. The default value is `.abbreviated`, showing for example, "Oct 21, 2015".
+    ///   - timeStyle: The custom style for displaying the time. The default value is `.shortened`, showing for example, "4:29 PM" or "16:29".
+    ///   - noDateSelectedString: The text to be displayed when no date is selected. If this property is `nil`, the localized string “No date selected” will be used.
+    ///   - pickerVisible: This property indicates whether the picker is to be displayed.
+    ///   - hidesSeparator: This property indicates whether the separator is to be displayed. Default is false.
+    init(@ViewBuilder title: () -> any View,
+         @ViewBuilder valueLabel: () -> any View = { EmptyView() },
+         controlState: ControlState = .normal,
+         errorMessage: AttributedString? = nil,
+         range: ClosedRange<Date>? = nil,
+         selectedDate: Binding<Date?> = .constant(nil),
+         dateFormatter: DateFormatter? = nil,
+         pickerComponents: DatePicker.Components = [.date, .hourAndMinute],
+         dateStyle: Date.FormatStyle.DateStyle = .abbreviated,
+         timeStyle: Date.FormatStyle.TimeStyle = .shortened,
+         noDateSelectedString: String? = nil,
+         pickerVisible: Binding<Bool>,
+         hidesSeparator: Bool = false)
+    {
+        self.init(title: title, valueLabel: valueLabel, controlState: controlState, errorMessage: errorMessage, range: range, selectedDate: selectedDate, dateFormatter: dateFormatter, pickerComponents: pickerComponents, dateStyle: dateStyle, timeStyle: timeStyle, noDateSelectedString: noDateSelectedString, pickerVisible: pickerVisible, hidesSeparator: hidesSeparator, showsClearAction: false)
+    }
+    
+    /// Convenience initializer for `DateTimePicker`
+    /// - Parameters:
+    ///   - title: The title string for the date time picker.
+    ///   - valueLabel: The value string for the date time picker.
+    ///   - mandatoryFieldIndicator: The mandatory field indicator for the date time picker.
+    ///   - isRequired: This property indicates whether the mandatory field indicator is to be displayed.
+    ///   - controlState: The `ControlState` of the form view. The default is `normal`.
+    ///   - errorMessage: The error message of the form view.
+    ///   - range: The inclusive range of selectable dates.
+    ///   - selectedDate: The date value being displayed and selected.
+    ///   - dateFormatter: The `DateFormatter` to be used to display the selected `Date`. Default formatter will use customized dateStyle and timeStyle.
+    ///   - pickerComponents: The components shown in the date picker, default value shows date and time.
+    ///   - dateStyle: The custom style for displaying the date. The default value is `.abbreviated`, showing for example, "Oct 21, 2015".
+    ///   - timeStyle: The custom style for displaying the time. The default value is `.shortened`, showing for example, "4:29 PM" or "16:29".
+    ///   - noDateSelectedString: The text to be displayed when no date is selected. If this property is `nil`, the localized string “No date selected” will be used.
+    ///   - pickerVisible: This property indicates whether the picker is to be displayed.
+    ///   - hidesSeparator: This property indicates whether the separator is to be displayed. Default is false.
+    init(title: AttributedString,
+         valueLabel: AttributedString? = nil,
+         mandatoryFieldIndicator: TextOrIcon? = .text("*"),
+         isRequired: Bool = false,
+         controlState: ControlState = .normal,
+         errorMessage: AttributedString? = nil,
+         range: ClosedRange<Date>? = nil,
+         selectedDate: Binding<Date?>,
+         dateFormatter: DateFormatter? = nil,
+         pickerComponents: DatePicker.Components = [.date, .hourAndMinute],
+         dateStyle: Date.FormatStyle.DateStyle = .abbreviated,
+         timeStyle: Date.FormatStyle.TimeStyle = .shortened,
+         noDateSelectedString: String? = nil,
+         pickerVisible: Binding<Bool>,
+         hidesSeparator: Bool = false)
+    {
+        self.init(title: title, valueLabel: valueLabel, mandatoryFieldIndicator: mandatoryFieldIndicator, isRequired: isRequired, controlState: controlState, errorMessage: errorMessage, range: range, selectedDate: selectedDate, dateFormatter: dateFormatter, pickerComponents: pickerComponents, dateStyle: dateStyle, timeStyle: timeStyle, noDateSelectedString: noDateSelectedString, pickerVisible: pickerVisible, hidesSeparator: hidesSeparator, showsClearAction: false)
+    }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/DateRangePicker/DateRangePicker.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/DateRangePicker/DateRangePicker.generated.swift
@@ -3,6 +3,8 @@
 import Foundation
 import SwiftUI
 
+import FioriThemeManager
+
 /// `DateRangePicker`  provides a title and value label with Fiori styling and a `MultiDatePicker`.
 /// ## Usage
 /// ```swift
@@ -75,7 +77,7 @@ public struct DateRangePicker {
                 noRangeSelectedString: String? = nil,
                 pickerVisible: Binding<Bool>,
                 showsClearAction: Bool = false,
-                @ViewBuilder clearAction: () -> any View = { Image(systemName: "xmark.circle").foregroundColor(.gray) },
+                @ViewBuilder clearAction: () -> any View = { FioriIcon.actions.sysCancel.foregroundColor(.gray) },
                 componentIdentifier: String? = DateRangePicker.identifier)
     {
         self.title = Title(title: title, componentIdentifier: componentIdentifier)
@@ -110,7 +112,7 @@ public extension DateRangePicker {
          noRangeSelectedString: String? = nil,
          pickerVisible: Binding<Bool>,
          showsClearAction: Bool = false,
-         @ViewBuilder clearAction: () -> any View = { Image(systemName: "xmark.circle").foregroundColor(.gray) })
+         @ViewBuilder clearAction: () -> any View = { FioriIcon.actions.sysCancel.foregroundColor(.gray) })
     {
         self.init(title: {
             TextWithMandatoryFieldIndicator(text: title, isRequired: isRequired, mandatoryFieldIndicator: mandatoryFieldIndicator)

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/DateRangePicker/DateRangePicker.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/DateRangePicker/DateRangePicker.generated.swift
@@ -54,6 +54,10 @@ public struct DateRangePicker {
     let noRangeSelectedString: String?
     /// This property indicates whether the picker is to be displayed or not.
     @Binding var pickerVisible: Bool
+    /// This property indicates whether the clear action should be displayed. Default is false. When selectedDate is nil, the clear action will be hidden.
+    let showsClearAction: Bool
+    /// view for clear the value
+    let clearAction: any View
 
     @Environment(\.dateRangePickerStyle) var style
 
@@ -70,6 +74,8 @@ public struct DateRangePicker {
                 rangeFormatter: DateFormatter? = nil,
                 noRangeSelectedString: String? = nil,
                 pickerVisible: Binding<Bool>,
+                showsClearAction: Bool = false,
+                @ViewBuilder clearAction: () -> any View = { Image(systemName: "xmark.circle").foregroundColor(.gray) },
                 componentIdentifier: String? = DateRangePicker.identifier)
     {
         self.title = Title(title: title, componentIdentifier: componentIdentifier)
@@ -81,6 +87,8 @@ public struct DateRangePicker {
         self.rangeFormatter = rangeFormatter
         self.noRangeSelectedString = noRangeSelectedString
         self._pickerVisible = pickerVisible
+        self.showsClearAction = showsClearAction
+        self.clearAction = clearAction()
         self.componentIdentifier = componentIdentifier ?? DateRangePicker.identifier
     }
 }
@@ -100,11 +108,13 @@ public extension DateRangePicker {
          selectedRange: Binding<ClosedRange<Date>?>,
          rangeFormatter: DateFormatter? = nil,
          noRangeSelectedString: String? = nil,
-         pickerVisible: Binding<Bool>)
+         pickerVisible: Binding<Bool>,
+         showsClearAction: Bool = false,
+         @ViewBuilder clearAction: () -> any View = { Image(systemName: "xmark.circle").foregroundColor(.gray) })
     {
         self.init(title: {
             TextWithMandatoryFieldIndicator(text: title, isRequired: isRequired, mandatoryFieldIndicator: mandatoryFieldIndicator)
-        }, valueLabel: { OptionalText(valueLabel) }, controlState: controlState, errorMessage: errorMessage, range: range, selectedRange: selectedRange, rangeFormatter: rangeFormatter, noRangeSelectedString: noRangeSelectedString, pickerVisible: pickerVisible)
+        }, valueLabel: { OptionalText(valueLabel) }, controlState: controlState, errorMessage: errorMessage, range: range, selectedRange: selectedRange, rangeFormatter: rangeFormatter, noRangeSelectedString: noRangeSelectedString, pickerVisible: pickerVisible, showsClearAction: showsClearAction, clearAction: clearAction)
     }
 }
 
@@ -123,6 +133,8 @@ public extension DateRangePicker {
         self.rangeFormatter = configuration.rangeFormatter
         self.noRangeSelectedString = configuration.noRangeSelectedString
         self._pickerVisible = configuration.$pickerVisible
+        self.showsClearAction = configuration.showsClearAction
+        self.clearAction = configuration.clearAction
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
         self.componentIdentifier = configuration.componentIdentifier
     }
@@ -133,7 +145,7 @@ extension DateRangePicker: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, title: .init(self.title), valueLabel: .init(self.valueLabel), controlState: self.controlState, errorMessage: self.errorMessage, range: self.range, selectedRange: self.$selectedRange, rangeFormatter: self.rangeFormatter, noRangeSelectedString: self.noRangeSelectedString, pickerVisible: self.$pickerVisible)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, title: .init(self.title), valueLabel: .init(self.valueLabel), controlState: self.controlState, errorMessage: self.errorMessage, range: self.range, selectedRange: self.$selectedRange, rangeFormatter: self.rangeFormatter, noRangeSelectedString: self.noRangeSelectedString, pickerVisible: self.$pickerVisible, showsClearAction: self.showsClearAction, clearAction: .init(self.clearAction))).typeErased
                 .transformEnvironment(\.dateRangePickerStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -151,7 +163,7 @@ private extension DateRangePicker {
     }
 
     func defaultStyle() -> some View {
-        DateRangePicker(.init(componentIdentifier: self.componentIdentifier, title: .init(self.title), valueLabel: .init(self.valueLabel), controlState: self.controlState, errorMessage: self.errorMessage, range: self.range, selectedRange: self.$selectedRange, rangeFormatter: self.rangeFormatter, noRangeSelectedString: self.noRangeSelectedString, pickerVisible: self.$pickerVisible))
+        DateRangePicker(.init(componentIdentifier: self.componentIdentifier, title: .init(self.title), valueLabel: .init(self.valueLabel), controlState: self.controlState, errorMessage: self.errorMessage, range: self.range, selectedRange: self.$selectedRange, rangeFormatter: self.rangeFormatter, noRangeSelectedString: self.noRangeSelectedString, pickerVisible: self.$pickerVisible, showsClearAction: self.showsClearAction, clearAction: .init(self.clearAction)))
             .shouldApplyDefaultStyle(false)
             .dateRangePickerStyle(DateRangePickerFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/DateRangePicker/DateRangePickerStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/DateRangePicker/DateRangePickerStyle.generated.swift
@@ -32,9 +32,12 @@ public struct DateRangePickerConfiguration {
     public let rangeFormatter: DateFormatter?
     public let noRangeSelectedString: String?
     @Binding public var pickerVisible: Bool
+    public let showsClearAction: Bool
+    public let clearAction: ClearAction
 
     public typealias Title = ConfigurationViewWrapper
     public typealias ValueLabel = ConfigurationViewWrapper
+    public typealias ClearAction = ConfigurationViewWrapper
 }
 
 extension DateRangePickerConfiguration {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/DateTimePicker/DateTimePicker.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/DateTimePicker/DateTimePicker.generated.swift
@@ -35,6 +35,7 @@ public struct DateTimePicker {
     let controlState: ControlState
     /// The error message of the form view.
     let errorMessage: AttributedString?
+    /// The inclusive range of selectable dates.
     let range: ClosedRange<Date>?
     @Binding var selectedDate: Date?
     /// The `DateFormatter` to be used to display the selected `Date`. Default formatter will use customized dateStyle and timeStyle.
@@ -51,6 +52,10 @@ public struct DateTimePicker {
     @Binding var pickerVisible: Bool
     /// This property indicates whether the separator is to be displayed. Default is false.
     let hidesSeparator: Bool
+    /// This property indicates whether the clear action should be displayed. Default is false. When selectedDate is nil, the clear action will be hidden.
+    let showsClearAction: Bool
+    /// view for clear the value
+    let clearAction: any View
 
     @Environment(\.dateTimePickerStyle) var style
 
@@ -71,6 +76,8 @@ public struct DateTimePicker {
                 noDateSelectedString: String? = nil,
                 pickerVisible: Binding<Bool>,
                 hidesSeparator: Bool = false,
+                showsClearAction: Bool = false,
+                @ViewBuilder clearAction: () -> any View = { Image(systemName: "xmark.circle").foregroundColor(.gray) },
                 componentIdentifier: String? = DateTimePicker.identifier)
     {
         self.title = Title(title: title, componentIdentifier: componentIdentifier)
@@ -86,6 +93,8 @@ public struct DateTimePicker {
         self.noDateSelectedString = noDateSelectedString
         self._pickerVisible = pickerVisible
         self.hidesSeparator = hidesSeparator
+        self.showsClearAction = showsClearAction
+        self.clearAction = clearAction()
         self.componentIdentifier = componentIdentifier ?? DateTimePicker.identifier
     }
 }
@@ -109,11 +118,13 @@ public extension DateTimePicker {
          timeStyle: Date.FormatStyle.TimeStyle = .shortened,
          noDateSelectedString: String? = nil,
          pickerVisible: Binding<Bool>,
-         hidesSeparator: Bool = false)
+         hidesSeparator: Bool = false,
+         showsClearAction: Bool = false,
+         @ViewBuilder clearAction: () -> any View = { Image(systemName: "xmark.circle").foregroundColor(.gray) })
     {
         self.init(title: {
             TextWithMandatoryFieldIndicator(text: title, isRequired: isRequired, mandatoryFieldIndicator: mandatoryFieldIndicator)
-        }, valueLabel: { OptionalText(valueLabel) }, controlState: controlState, errorMessage: errorMessage, range: range, selectedDate: selectedDate, dateFormatter: dateFormatter, pickerComponents: pickerComponents, dateStyle: dateStyle, timeStyle: timeStyle, noDateSelectedString: noDateSelectedString, pickerVisible: pickerVisible, hidesSeparator: hidesSeparator)
+        }, valueLabel: { OptionalText(valueLabel) }, controlState: controlState, errorMessage: errorMessage, range: range, selectedDate: selectedDate, dateFormatter: dateFormatter, pickerComponents: pickerComponents, dateStyle: dateStyle, timeStyle: timeStyle, noDateSelectedString: noDateSelectedString, pickerVisible: pickerVisible, hidesSeparator: hidesSeparator, showsClearAction: showsClearAction, clearAction: clearAction)
     }
 }
 
@@ -136,6 +147,8 @@ public extension DateTimePicker {
         self.noDateSelectedString = configuration.noDateSelectedString
         self._pickerVisible = configuration.$pickerVisible
         self.hidesSeparator = configuration.hidesSeparator
+        self.showsClearAction = configuration.showsClearAction
+        self.clearAction = configuration.clearAction
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
         self.componentIdentifier = configuration.componentIdentifier
     }
@@ -146,7 +159,7 @@ extension DateTimePicker: View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
-            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, title: .init(self.title), valueLabel: .init(self.valueLabel), controlState: self.controlState, errorMessage: self.errorMessage, range: self.range, selectedDate: self.$selectedDate, dateFormatter: self.dateFormatter, pickerComponents: self.pickerComponents, dateStyle: self.dateStyle, timeStyle: self.timeStyle, noDateSelectedString: self.noDateSelectedString, pickerVisible: self.$pickerVisible, hidesSeparator: self.hidesSeparator)).typeErased
+            self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, title: .init(self.title), valueLabel: .init(self.valueLabel), controlState: self.controlState, errorMessage: self.errorMessage, range: self.range, selectedDate: self.$selectedDate, dateFormatter: self.dateFormatter, pickerComponents: self.pickerComponents, dateStyle: self.dateStyle, timeStyle: self.timeStyle, noDateSelectedString: self.noDateSelectedString, pickerVisible: self.$pickerVisible, hidesSeparator: self.hidesSeparator, showsClearAction: self.showsClearAction, clearAction: .init(self.clearAction))).typeErased
                 .transformEnvironment(\.dateTimePickerStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
@@ -164,7 +177,7 @@ private extension DateTimePicker {
     }
 
     func defaultStyle() -> some View {
-        DateTimePicker(.init(componentIdentifier: self.componentIdentifier, title: .init(self.title), valueLabel: .init(self.valueLabel), controlState: self.controlState, errorMessage: self.errorMessage, range: self.range, selectedDate: self.$selectedDate, dateFormatter: self.dateFormatter, pickerComponents: self.pickerComponents, dateStyle: self.dateStyle, timeStyle: self.timeStyle, noDateSelectedString: self.noDateSelectedString, pickerVisible: self.$pickerVisible, hidesSeparator: self.hidesSeparator))
+        DateTimePicker(.init(componentIdentifier: self.componentIdentifier, title: .init(self.title), valueLabel: .init(self.valueLabel), controlState: self.controlState, errorMessage: self.errorMessage, range: self.range, selectedDate: self.$selectedDate, dateFormatter: self.dateFormatter, pickerComponents: self.pickerComponents, dateStyle: self.dateStyle, timeStyle: self.timeStyle, noDateSelectedString: self.noDateSelectedString, pickerVisible: self.$pickerVisible, hidesSeparator: self.hidesSeparator, showsClearAction: self.showsClearAction, clearAction: .init(self.clearAction)))
             .shouldApplyDefaultStyle(false)
             .dateTimePickerStyle(DateTimePickerFioriStyle.ContentFioriStyle())
             .typeErased

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/DateTimePicker/DateTimePicker.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/DateTimePicker/DateTimePicker.generated.swift
@@ -3,6 +3,8 @@
 import Foundation
 import SwiftUI
 
+import FioriThemeManager
+
 /// `DateTimePicker`  provides a title and value label with Fiori styling and a `DatePicker`.
 ///
 /// ## Usage
@@ -77,7 +79,7 @@ public struct DateTimePicker {
                 pickerVisible: Binding<Bool>,
                 hidesSeparator: Bool = false,
                 showsClearAction: Bool = false,
-                @ViewBuilder clearAction: () -> any View = { Image(systemName: "xmark.circle").foregroundColor(.gray) },
+                @ViewBuilder clearAction: () -> any View = { FioriIcon.actions.sysCancel.foregroundColor(.gray) },
                 componentIdentifier: String? = DateTimePicker.identifier)
     {
         self.title = Title(title: title, componentIdentifier: componentIdentifier)
@@ -120,7 +122,7 @@ public extension DateTimePicker {
          pickerVisible: Binding<Bool>,
          hidesSeparator: Bool = false,
          showsClearAction: Bool = false,
-         @ViewBuilder clearAction: () -> any View = { Image(systemName: "xmark.circle").foregroundColor(.gray) })
+         @ViewBuilder clearAction: () -> any View = { FioriIcon.actions.sysCancel.foregroundColor(.gray) })
     {
         self.init(title: {
             TextWithMandatoryFieldIndicator(text: title, isRequired: isRequired, mandatoryFieldIndicator: mandatoryFieldIndicator)

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/DateTimePicker/DateTimePickerStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/DateTimePicker/DateTimePickerStyle.generated.swift
@@ -36,9 +36,12 @@ public struct DateTimePickerConfiguration {
     public let noDateSelectedString: String?
     @Binding public var pickerVisible: Bool
     public let hidesSeparator: Bool
+    public let showsClearAction: Bool
+    public let clearAction: ClearAction
 
     public typealias Title = ConfigurationViewWrapper
     public typealias ValueLabel = ConfigurationViewWrapper
+    public typealias ClearAction = ConfigurationViewWrapper
 }
 
 extension DateTimePickerConfiguration {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/ToastMessage/ToastMessage.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/ToastMessage/ToastMessage.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.3.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.1.7 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 import Foundation
 import SwiftUI

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/ToastMessage/ToastMessageStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/ToastMessage/ToastMessageStyle.generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.3.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.1.7 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 import Foundation
 import SwiftUI

--- a/Sources/FioriSwiftUICore/_generated/SupportingFiles/ViewEmptyChecking+Extension.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/SupportingFiles/ViewEmptyChecking+Extension.generated.swift
@@ -398,14 +398,16 @@ extension Counter: _ViewEmptyChecking {
 extension DateRangePicker: _ViewEmptyChecking {
     public var isEmpty: Bool {
         title.isEmpty &&
-            valueLabel.isEmpty
+            valueLabel.isEmpty &&
+            clearAction.isEmpty
     }
 }
 
 extension DateTimePicker: _ViewEmptyChecking {
     public var isEmpty: Bool {
         title.isEmpty &&
-            valueLabel.isEmpty
+            valueLabel.isEmpty &&
+            clearAction.isEmpty
     }
 }
 

--- a/Tests/FioriSwiftUITests/FioriSwiftUICore/DateTimePickerTests.swift
+++ b/Tests/FioriSwiftUITests/FioriSwiftUICore/DateTimePickerTests.swift
@@ -66,4 +66,269 @@ final class DateTimePickerTests: XCTestCase {
         XCTAssertEqual(picker.controlState, .disabled)
         XCTAssertEqual(picker.errorMessage, errorMessage)
     }
+    
+    // MARK: - DateTimePickerConfiguration Tests
+    
+    func testConfigurationDefaultValues() {
+        let config = DateTimePickerConfiguration(
+            title: .init(Text("Config Title")),
+            valueLabel: .init(EmptyView()),
+            controlState: .normal,
+            errorMessage: nil,
+            range: nil,
+            selectedDate: .constant(nil),
+            dateFormatter: nil,
+            pickerComponents: [.date, .hourAndMinute],
+            dateStyle: .abbreviated,
+            timeStyle: .shortened,
+            noDateSelectedString: nil,
+            pickerVisible: .constant(false),
+            hidesSeparator: false
+        )
+        
+        XCTAssertEqual(config.controlState, .normal)
+        XCTAssertNil(config.errorMessage)
+        XCTAssertNil(config.range)
+        XCTAssertNil(config.selectedDate)
+        XCTAssertNil(config.dateFormatter)
+        XCTAssertEqual(config.pickerComponents, [.date, .hourAndMinute])
+        XCTAssertEqual(config.dateStyle, .abbreviated)
+        XCTAssertEqual(config.timeStyle, .shortened)
+        XCTAssertNil(config.noDateSelectedString)
+        XCTAssertFalse(config.pickerVisible)
+        XCTAssertFalse(config.hidesSeparator)
+        XCTAssertFalse(config.showsClearAction)
+    }
+    
+    func testConfigurationControlState() {
+        let config = DateTimePickerConfiguration(
+            title: .init(Text("Disabled")),
+            valueLabel: .init(EmptyView()),
+            controlState: .disabled,
+            errorMessage: AttributedString("Error"),
+            range: nil,
+            selectedDate: .constant(nil),
+            dateFormatter: nil,
+            pickerComponents: [.date],
+            dateStyle: .abbreviated,
+            timeStyle: .shortened,
+            noDateSelectedString: nil,
+            pickerVisible: .constant(false),
+            hidesSeparator: false
+        )
+        
+        XCTAssertEqual(config.controlState, .disabled)
+        XCTAssertEqual(config.errorMessage, AttributedString("Error"))
+    }
+    
+    func testConfigurationPickerComponents() {
+        let dateOnlyConfig = DateTimePickerConfiguration(
+            title: .init(Text("Date Only")),
+            valueLabel: .init(EmptyView()),
+            controlState: .normal,
+            errorMessage: nil,
+            range: nil,
+            selectedDate: .constant(nil),
+            dateFormatter: nil,
+            pickerComponents: [.date],
+            dateStyle: .long,
+            timeStyle: .omitted,
+            noDateSelectedString: nil,
+            pickerVisible: .constant(false),
+            hidesSeparator: false
+        )
+        
+        XCTAssertEqual(dateOnlyConfig.pickerComponents, [.date])
+        XCTAssertEqual(dateOnlyConfig.dateStyle, .long)
+        XCTAssertEqual(dateOnlyConfig.timeStyle, .omitted)
+        
+        let timeOnlyConfig = DateTimePickerConfiguration(
+            title: .init(Text("Time Only")),
+            valueLabel: .init(EmptyView()),
+            controlState: .normal,
+            errorMessage: nil,
+            range: nil,
+            selectedDate: .constant(nil),
+            dateFormatter: nil,
+            pickerComponents: [.hourAndMinute],
+            dateStyle: .omitted,
+            timeStyle: .complete,
+            noDateSelectedString: nil,
+            pickerVisible: .constant(false),
+            hidesSeparator: false
+        )
+        
+        XCTAssertEqual(timeOnlyConfig.pickerComponents, [.hourAndMinute])
+        XCTAssertEqual(timeOnlyConfig.timeStyle, .complete)
+    }
+    
+    func testConfigurationDateRange() {
+        let start = Date(timeIntervalSince1970: 0)
+        let end = Date(timeIntervalSince1970: 86400)
+        let range = start ... end
+        
+        let config = DateTimePickerConfiguration(
+            title: .init(Text("Range")),
+            valueLabel: .init(EmptyView()),
+            controlState: .normal,
+            errorMessage: nil,
+            range: range,
+            selectedDate: .constant(start),
+            dateFormatter: nil,
+            pickerComponents: [.date],
+            dateStyle: .abbreviated,
+            timeStyle: .shortened,
+            noDateSelectedString: nil,
+            pickerVisible: .constant(false),
+            hidesSeparator: false
+        )
+        
+        XCTAssertEqual(config.range?.lowerBound, start)
+        XCTAssertEqual(config.range?.upperBound, end)
+        XCTAssertEqual(config.selectedDate, start)
+    }
+    
+    func testConfigurationNoDateSelectedString() {
+        let customString = "No date chosen"
+        let config = DateTimePickerConfiguration(
+            title: .init(Text("Custom Placeholder")),
+            valueLabel: .init(EmptyView()),
+            controlState: .normal,
+            errorMessage: nil,
+            range: nil,
+            selectedDate: .constant(nil),
+            dateFormatter: nil,
+            pickerComponents: [.date, .hourAndMinute],
+            dateStyle: .abbreviated,
+            timeStyle: .shortened,
+            noDateSelectedString: customString,
+            pickerVisible: .constant(false),
+            hidesSeparator: false
+        )
+        
+        XCTAssertEqual(config.noDateSelectedString, customString)
+    }
+    
+    func testConfigurationPickerVisibleBinding() {
+        var isVisible = false
+        let visibilityBinding = Binding<Bool>(
+            get: { isVisible },
+            set: { isVisible = $0 }
+        )
+        
+        let config = DateTimePickerConfiguration(
+            title: .init(Text("Visibility")),
+            valueLabel: .init(EmptyView()),
+            controlState: .normal,
+            errorMessage: nil,
+            range: nil,
+            selectedDate: .constant(nil),
+            dateFormatter: nil,
+            pickerComponents: [.date, .hourAndMinute],
+            dateStyle: .abbreviated,
+            timeStyle: .shortened,
+            noDateSelectedString: nil,
+            pickerVisible: visibilityBinding,
+            hidesSeparator: false
+        )
+        
+        XCTAssertFalse(config.pickerVisible)
+        config.pickerVisible = true
+        XCTAssertTrue(isVisible)
+    }
+    
+    func testConfigurationSelectedDateBinding() {
+        let fixedDate = Date(timeIntervalSince1970: 1000000)
+        var currentDate: Date? = nil
+        let dateBinding = Binding<Date?>(
+            get: { currentDate },
+            set: { currentDate = $0 }
+        )
+        
+        let config = DateTimePickerConfiguration(
+            title: .init(Text("Date Binding")),
+            valueLabel: .init(EmptyView()),
+            controlState: .normal,
+            errorMessage: nil,
+            range: nil,
+            selectedDate: dateBinding,
+            dateFormatter: nil,
+            pickerComponents: [.date, .hourAndMinute],
+            dateStyle: .abbreviated,
+            timeStyle: .shortened,
+            noDateSelectedString: nil,
+            pickerVisible: .constant(false),
+            hidesSeparator: false
+        )
+        
+        XCTAssertNil(config.selectedDate)
+        config.selectedDate = fixedDate
+        XCTAssertEqual(currentDate, fixedDate)
+    }
+    
+    func testConfigurationComponentIdentifier() {
+        let config = DateTimePickerConfiguration(
+            title: .init(Text("ID Test")),
+            valueLabel: .init(EmptyView()),
+            controlState: .normal,
+            errorMessage: nil,
+            range: nil,
+            selectedDate: .constant(nil),
+            dateFormatter: nil,
+            pickerComponents: [.date, .hourAndMinute],
+            dateStyle: .abbreviated,
+            timeStyle: .shortened,
+            noDateSelectedString: nil,
+            pickerVisible: .constant(false),
+            hidesSeparator: false
+        )
+        
+        XCTAssertEqual(config.componentIdentifier, DateTimePicker.identifier)
+        XCTAssertEqual(config.componentIdentifier, "fiori_datetimepicker_component")
+    }
+    
+    func testConfigurationIsDirectChild() {
+        let config = DateTimePickerConfiguration(
+            title: .init(Text("Direct Child")),
+            valueLabel: .init(EmptyView()),
+            controlState: .normal,
+            errorMessage: nil,
+            range: nil,
+            selectedDate: .constant(nil),
+            dateFormatter: nil,
+            pickerComponents: [.date, .hourAndMinute],
+            dateStyle: .abbreviated,
+            timeStyle: .shortened,
+            noDateSelectedString: nil,
+            pickerVisible: .constant(false),
+            hidesSeparator: false
+        )
+        
+        XCTAssertTrue(config.isDirectChild(DateTimePicker.identifier))
+        XCTAssertFalse(config.isDirectChild("other_component"))
+    }
+    
+    func testConfigurationCustomDateFormatter() {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MM/dd/yyyy"
+        
+        let config = DateTimePickerConfiguration(
+            title: .init(Text("Formatter")),
+            valueLabel: .init(EmptyView()),
+            controlState: .normal,
+            errorMessage: nil,
+            range: nil,
+            selectedDate: .constant(nil),
+            dateFormatter: formatter,
+            pickerComponents: [.date],
+            dateStyle: .abbreviated,
+            timeStyle: .shortened,
+            noDateSelectedString: nil,
+            pickerVisible: .constant(false),
+            hidesSeparator: false
+        )
+        
+        XCTAssertNotNil(config.dateFormatter)
+        XCTAssertEqual(config.dateFormatter?.dateFormat, "MM/dd/yyyy")
+    }
 }


### PR DESCRIPTION

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-08-19 at 13 24 22" src="https://github.com/user-attachments/assets/475467a1-806b-4b4e-b41c-6793549edaf1" />

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-08-19 at 13 24 30" src="https://github.com/user-attachments/assets/9b9619c0-ebc5-42a1-b518-94cd27b53809" />

# DatePicker & DateRangePicker: Add Clear Action Support

### New Features

✨ Enhanced `DateTimePicker` and `DateRangePicker` components with an optional clear action, allowing users to reset a selected date or date range directly from the picker UI. The clear action is hidden when no value is selected and is suppressed in disabled/read-only control states.

Key highlights:
- New `showsClearAction: Bool` parameter (default: `false`) controls the visibility of the clear button.
- New `clearAction` `@ViewBuilder` parameter allows full customization of the clear button appearance (defaults to a gray `xmark.circle` icon).
- The clear action is only shown when a value is selected and the control is in a normal interactive state.
- Backward-compatible convenience initializers are added to avoid breaking existing API consumers.

### Changes

* `CompositeComponentProtocols.swift`: Added `showsClearAction` and `clearAction` properties to both `_DateTimePickerComponent` and `_DateRangePickerComponent` protocols.
* `DateTimePicker.generated.swift`: Propagated new `showsClearAction` and `clearAction` parameters throughout the component's initializers and configuration resolution logic.
* `DateRangePicker.generated.swift`: Same as above for the `DateRangePicker` component.
* `DateTimePickerStyle.generated.swift`: Added `showsClearAction` and `clearAction` fields to `DateTimePickerConfiguration`, along with `ClearAction` type alias.
* `DateRangePickerStyle.generated.swift`: Same additions for `DateRangePickerConfiguration`.
* `DateTimePickerStyle.fiori.swift`: Wrapped the value label in an `HStack` and conditionally renders the `clearAction` view; tapping it sets `selectedDate` to `nil`. Added backward-compatible convenience initializers.
* `DateRangePickerStyle.fiori.swift`: Same treatment for `DateRangePicker` — tapping clears `selectedRange`. Added backward-compatible convenience initializers.
* `ViewEmptyChecking+Extension.generated.swift`: Updated `isEmpty` checks for `DateRangePicker` and `DateTimePicker` to include `clearAction`.
* `DateTimePickerExample.swift`: Added a "Show Clear Action" toggle and wired `showsClearAction` to all picker instances; demonstrated a customized clear action with a red `xmark.rectangle` icon.
* `DateRangePickerExample.swift`: Same updates for the date range picker example, including a customized clear action demo with a red `xmark.square` icon.
* `ToastMessage.generated.swift` / `ToastMessageStyle.generated.swift`: Minor Sourcery version header update (2.3.0 → 2.1.7).

### Jira Issues

* HCPSDKFIORIUIKIT-3267: DatePicker & DateRangePicker enhancement to support clear action

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.30`

- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- LLM: `anthropic--claude-4.6-sonnet`
- File Content Strategy: Full file content
- Event Trigger: `pull_request.opened`
- Correlation ID: `97edacc0-9b79-11f1-9da9-9d87cfb1506c`
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
</details>
