### PR TITLE
feat: 🎸 Translation Delivery

### DIFF
--- a/Sources/FioriSwiftUICore/_localization/ar.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/ar.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "مؤشر تسجيل الخروج";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "+%d إضافية";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "لم يتم العثور على أي نتائج";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "تحقق من بحثك عن أي أخطاء إملائية أو حاول استخدام مصطلح بحث مختلف.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "خانة الاختيار";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "على الأقل %d من الأحرف";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "على الأقل %d من الأحرف الفريدة";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "رقم واحد على الأقل";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "حرف كبير واحد على الأقل";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "حرف صغير واحد على الأقل";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "حرف خاص واحد على الأقل";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "أرقام فقط";
+

--- a/Sources/FioriSwiftUICore/_localization/bg.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/bg.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "Индикатор за финализиране";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "+ още %d";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "Не са намерени резултати";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "Проверете търсенето за правописни грешки или опитайте с друг критерий за търсене.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "Поле с отметка";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "Поне %d символа";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "Поне %d уникални символа";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "Поне една цифра";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "Поне една главна буква";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "Поне една малка буква";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "Поне един специален символ";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "Само цифри";
+

--- a/Sources/FioriSwiftUICore/_localization/ca.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/ca.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "Indicador de sortida";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "+%d més";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "No s’ha trobat cap resultat";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "Comproveu si hi ha errors d'ortografia o proveu un terme de cerca diferent.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "Casella de selecció";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "%d caràcters com a mínim";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "%d caràcters unívocs com a mínim";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "Com a mínim un dígit";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "Com a mínim una lletra majúscula";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "Com a mínim una lletra minúscula";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "Com a mínim un caràcter especial";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "Només dígits";
+

--- a/Sources/FioriSwiftUICore/_localization/cnr.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/cnr.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "Pokazatelj obrade";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "Još %d";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "Rezultati nijesu nađeni";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "Provjerite da li traženje sadrži pravopisne greške ili pokušajte s drugim traženim terminom.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "Kvadratić za potvrdu";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "Najmanje %d znakova";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "Najmanje %d jedinstvenih znakova";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "Najmanje jedna cifra";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "Najmanje jedno veliko slovo";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "Najmanje jedno malo slovo";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "Najmanje jedan poseban znak";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "Samo cifre";
+

--- a/Sources/FioriSwiftUICore/_localization/cs.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/cs.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "Indikátor odhlášení";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "+ %d další";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "Nebyly nalezeny žádné výsledky";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "Zkontrolujte, zda jste hledaný výraz zadali správně, nebo zkuste použít jiný.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "Zaškrtávací políčko";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "Nejmenší počet znaků: %d";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "Nejmenší počet jedinečných znaků: %d";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "Alespoň jedna číslice";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "Alespoň jedno velké písmeno";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "Alespoň jedno malé písmeno";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "Obsahuje alespoň jeden zvláštní znak";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "Pouze číslice";
+

--- a/Sources/FioriSwiftUICore/_localization/cy.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/cy.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "Dangosydd Sgrin Talu";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "+%d arall";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "Heb Ddod o Hyd i Ganlyniadau";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "Gwiriwch eich chwiliad am unrhyw wallau sillafu neu rhowch gynnig ar derm chwilio gwahanol.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "Blwch ticio";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "O leiaf %d nod";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "O leiaf %d nod unigryw";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "O leiaf un digid";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "O leiaf un llythyren fawr";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "O leiaf un llythyren fach";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "O leiaf un nod arbennig";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "Digidau'n unig";
+

--- a/Sources/FioriSwiftUICore/_localization/da.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/da.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "Udtjekningsindikator";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "+%d mere";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "Ingen resultater blev fundet";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "Kontroller din søgning efter stavefejl, eller prøv et andet søgekriterium.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "Afkrydsningsfelt";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "Mindst %d tegn";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "Mindst %d entydige tegn";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "Mindst et ciffer";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "Mindst et stort bogstav";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "Mindst et lille bogstav";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "Mindst et specialtegn";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "Kun cifre";
+

--- a/Sources/FioriSwiftUICore/_localization/de-CH.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/de-CH.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "Checkout-Anzeige";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "+%d weitere";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "Keine Ergebnisse gefunden";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "Prüfen Sie Ihre Suchanfrage auf Rechtschreibfehler, oder versuchen Sie es mit einem anderen Suchbegriff.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "Ankreuzfeld";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "Mindestens %d Zeichen";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "Mindestens %d eindeutige Zeichen";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "Mindestens eine Ziffer";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "Mindestens ein Großbuchstabe";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "Mindestens ein Kleinbuchstabe";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "Mindestens ein Sonderzeichen";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "Nur Ziffern";
+

--- a/Sources/FioriSwiftUICore/_localization/de.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/de.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "Checkout-Anzeige";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "+%d weitere";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "Keine Ergebnisse gefunden";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "Prüfen Sie Ihre Suchanfrage auf Rechtschreibfehler, oder versuchen Sie es mit einem anderen Suchbegriff.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "Ankreuzfeld";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "Mindestens %d Zeichen";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "Mindestens %d eindeutige Zeichen";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "Mindestens eine Ziffer";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "Mindestens ein Großbuchstabe";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "Mindestens ein Kleinbuchstabe";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "Mindestens ein Sonderzeichen";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "Nur Ziffern";
+

--- a/Sources/FioriSwiftUICore/_localization/el.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/el.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "Δείκτης Checkout";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "+%d περισσότερα";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "Δεν Βρέθηκαν Αποτελέσματα";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "Ελέγξτε την αναζήτησή σας για τυχόν ορθογραφικά λάθη ή δοκιμάστε έναν διαφορετικό όρο αναζήτησης.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "Πλαίσιο επιλογής";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "Τουλάχιστον %d χαρακτήρες";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "Τουλάχιστον %d μοναδικοί χαρακτήρες";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "Τουλάχιστον ένα ψηφίο";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "Τουλάχιστον ένας κεφαλαίος χαρακτήρας";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "Τουλάχιστον ένας πεζός χαρακτήρας";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "Τουλάχιστον ένας ειδικός χαρακτήρας";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "Μόνο ψηφία";
+

--- a/Sources/FioriSwiftUICore/_localization/en-GB.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/en-GB.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "Checkout Indicator";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "+%d more";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "No Results Found";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "Check your search for any spelling errors or try a different search term.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "Checkbox";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "At least %d characters";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "At least %d unique characters";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "At least one digit";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "At least one uppercase letter";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "At least one lowercase letter";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "At least one special character";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "Digits only";
+

--- a/Sources/FioriSwiftUICore/_localization/es-MX.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/es-MX.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "Indicador de registro de salida";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "+%d más";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "No se encontraron resultados";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "Verifique si hay errores ortográficos en su búsqueda o pruebe con otro término de búsqueda.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "Casilla de selección";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "Al menos %d caracteres";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "Al menos %d caracteres únicos";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "Al menos un dígito";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "Al menos una letra mayúscula";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "Al menos una letra minúscula";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "Al menos un carácter especial";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "Solo dígitos";
+

--- a/Sources/FioriSwiftUICore/_localization/es.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/es.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "Indicador de finalización";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "+%d más";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "No se han encontrado resultados";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "Compruebe que no haya errores de ortografía en la búsqueda o pruebe otro término de búsqueda.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "Casilla de selección";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "Al menos %d caracteres";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "Al menos %d caracteres unívocos";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "Al menos un dígito";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "Al menos una letra mayúscula";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "Al menos una letra minúscula";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "Al menos un carácter especial";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "Solo dígitos";
+

--- a/Sources/FioriSwiftUICore/_localization/et.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/et.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "Väljaregistreerimise tunnus";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "+ veel %d";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "Tulemusi ei leitud";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "Kontrollige, kas teie otsingusõnad on õigesti kirjutatud, või proovige mõnda muud otsingusõna.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "Märkeruut";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "Vähemalt %d märki";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "Vähemalt %d kordumatut märki";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "Vähemalt üks number";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "Vähemalt üks suurtäht";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "Vähemalt üks väiketäht";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "Vähemalt üks erimärk";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "Ainult numbrid";
+

--- a/Sources/FioriSwiftUICore/_localization/fi.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/fi.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "Uloskuittaustunnus";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "+%d enemmän";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "Tuloksia ei löytynyt";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "Tarkista haku kirjoitusvirheiden varalta tai kokeile toista hakuperustetta.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "Valintaruutu";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "Vähintään %d merkkiä";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "Vähintään %d yksiselitteistä merkkiä";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "Vähintään yksi numero";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "Vähintään yksi iso kirjain";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "Vähintään yksi pieni kirjain";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "Vähintään yksi erikoismerkki";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "Vain numeroita";
+

--- a/Sources/FioriSwiftUICore/_localization/fr-CA.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/fr-CA.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "Indicateur de sortie";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "+%d autres";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "Aucun résultat trouvé";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "Vérifiez que votre recherche ne contient aucune faute d'orthographe ou essayez un autre terme de recherche.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "Case à cocher";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "Au moins %d caractères";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "Au moins %d caractères uniques";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "Au moins un chiffre";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "Au moins une lettre majuscule";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "Au moins une lettre minuscule";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "Au moins un caractère spécial";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "Chiffres uniquement";
+

--- a/Sources/FioriSwiftUICore/_localization/fr.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/fr.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "Indicateur de sortie";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "+%d autres";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "Aucun résultat trouvé";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "Vérifiez que votre recherche ne contient aucune faute d'orthographe ou essayez un autre terme de recherche.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "Case à cocher";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "Au moins %d caractères";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "Au moins %d caractères uniques";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "Au moins un chiffre";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "Au moins une lettre majuscule";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "Au moins une lettre minuscule";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "Au moins un caractère spécial";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "Chiffres uniquement";
+

--- a/Sources/FioriSwiftUICore/_localization/he.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/he.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "סמן פעולת Checkout";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "ועוד %d";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "לא נמצאו תוצאות";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "חפש שגיאות איות בחיפוש או נסה מונח חיפוש אחר.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "תיבת סימון";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "לפחות %d תווים";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "לפחות %d תווים ייחודיים";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "ספרה אחת לפחות";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "אות גדולה אחת לפחות";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "אות קטנה אחת לפחות";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "לפחות תו מיוחד אחד";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "ספרות בלבד";
+

--- a/Sources/FioriSwiftUICore/_localization/hi.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/hi.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "चेकआउट संकेतक";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "+%d अधिक";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "कोई परिणाम नहीं मिले";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "किसी भी वर्तनी त्रुटि के लिए अपनी खोज जांचें या कोई भिन्न खोज शब्द आज़माएं.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "चेकबॉक्स";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "कम से कम %d वर्ण";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "कम से कम %d अद्वितीय वर्ण";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "कम से कम एक अंक";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "कम से कम एक अपरकेस अक्षर";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "कम से कम एक लोअरकेस अक्षर";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "कम से कम एक विशेष वर्ण";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "केवल अंक";
+

--- a/Sources/FioriSwiftUICore/_localization/hr.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/hr.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "Pokazatelj odjave";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "+ još %d";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "Nema pronađenih rezultata";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "Provjerite ima li u vašem pretraživanju pravopisnih pogrešaka ili pokušajte s drugim pojmom pretraživanja.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "Potvrdni okvir";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "Najmanji broj znakova: %d";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "Najmanji broj jedinstvenih znakova: %d";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "Najmanje jedna znamenka";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "Najmanje jedno veliko slovo";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "Najmanje jedno malo slovo";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "Najmanje jedan poseban znak";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "Samo znamenke";
+

--- a/Sources/FioriSwiftUICore/_localization/hu.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/hu.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "Folyamatjelző";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "+%d további";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "Nincs találat";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "Ellenőrizze, nem tartalmaz-e a keresés elütést, vagy próbáljon meg más keresőkifejezést használni.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "Jelölőnégyzet";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "Legalább %d  karakter";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "Legalább %d egyedi karakter";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "Legalább egy számjegy";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "Legalább egy nagybetű";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "Legalább egy kisbetű";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "Legalább egy speciális karakter";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "Csak számjegyek";
+

--- a/Sources/FioriSwiftUICore/_localization/id.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/id.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "Indikator Checkout";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "+%d lagi";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "Hasil Tidak Ditemukan";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "Periksa kembali ejaan pencarian Anda atau coba istilah pencarian lainnya.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "Kotak Centang";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "Setidaknya %d karakter";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "Setidaknya %d karakter unik";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "Setidaknya satu digit";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "Setidaknya satu huruf besar";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "Setidaknya satu huruf kecil";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "Setidaknya satu karakter khusus";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "Hanya digit";
+

--- a/Sources/FioriSwiftUICore/_localization/it-CH.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/it-CH.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "Indicatore check-out";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "+%d";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "Nessun risultato trovato";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "Controlla se sono presenti errori di ortografia nella ricerca o prova un termine differente.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "Casella di spunta";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "Almeno %d caratteri";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "Almeno %d caratteri univoci";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "Almeno una cifra";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "Almeno una lettera maiuscola";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "Almeno una lettera minuscola";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "Almeno un carattere speciale";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "Solo cifre";
+

--- a/Sources/FioriSwiftUICore/_localization/it.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/it.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "Indicatore check-out";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "+%d";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "Nessun risultato trovato";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "Controlla se sono presenti errori di ortografia nella ricerca o prova un termine differente.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "Casella di spunta";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "Almeno %d caratteri";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "Almeno %d caratteri univoci";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "Almeno una cifra";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "Almeno una lettera maiuscola";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "Almeno una lettera minuscola";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "Almeno un carattere speciale";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "Solo cifre";
+

--- a/Sources/FioriSwiftUICore/_localization/ja.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/ja.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "チェックアウト区分";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "%d 件追加";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "結果が見つかりません";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "誤った綴りで検索していないかどうかを確認するか、または別の検索語句を試してください。";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "チェックボックス";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "%d 文字以上";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "異なる文字が %d 文字以上";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "少なくとも 1 つの数字";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "少なくとも 1 つの大文字";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "少なくとも 1 つの小文字";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "少なくとも 1 つの特殊文字";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "数字のみ";
+

--- a/Sources/FioriSwiftUICore/_localization/kk.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/kk.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "Шығу кезінде тексеру индикаторы";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "тағы +%d";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "Нәтижелер табылмады";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "Іздеу кезінде емле қателерін тексеріңіз немесе басқа іздеу шартын қолданып көріңіз.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "Құсбелгі ұяшығы";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "Кемінде %d таңба";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "Кемінде %d бірегей таңба";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "Кемінде бір цифр";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "Кемінде бір бас әріп";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "Кемінде бір кіші әріп";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "Кемінде бір арнайы таңба";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "Цифрлар ғана";
+

--- a/Sources/FioriSwiftUICore/_localization/ko.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/ko.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "체크아웃 지시자";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "+%d개 항목 더";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "결과가 없습니다.";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "철자 오류가 없는지 검색을 확인하거나 다른 검색어를 사용해 보십시오.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "체크박스";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "%d자 이상";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "%d자 이상의 고유 문자";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "하나 이상의 숫자";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "하나 이상의 대문자";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "하나 이상의 소문자";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "하나 이상의 특수 문자";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "숫자만";
+

--- a/Sources/FioriSwiftUICore/_localization/lt.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/lt.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "Išregistravimo indikatorius";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "Dar %d";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "Rezultatų nerasta";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "Patikrinkite, ar paieškoje nėra rašybos klaidų, arba išbandykite kitą paieškos terminą.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "Žymės langelis";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "Simbolių turi būti bent %d";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "Unikalių simbolių bent %d";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "Bent vienas skaitmuo";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "Bent viena didžioji raidė";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "Bent viena mažoji raidė";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "Bent vienas specialusis simbolis";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "Tik skaitmenys";
+

--- a/Sources/FioriSwiftUICore/_localization/lv.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/lv.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "Paņemšanas indikators";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "+ vēl %d";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "Nekādi rezultāti nav atrasti";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "Pārbaudiet, vai meklēšanas kritērijā nav pareizrakstības kļūdu, vai mēģiniet izmantot citu meklēšanas kritēriju.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "Izvēles rūtiņa";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "Vismaz %d rakstzīmes";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "Vismaz %d unikālas rakstzīmes";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "Vismaz viens cipars";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "Vismaz viens lielais burts";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "Vismaz viens mazais burts";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "Vismaz viena speciālā rakstzīme";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "Tikai cipari";
+

--- a/Sources/FioriSwiftUICore/_localization/mk.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/mk.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "Показател за обработка";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "Уште +%d";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "Не се најдени резултати";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "Проверете дали пребарувањето содржи правописни грешки или обидете се со друг термин за пребарување.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "Поле за означување";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "Најмалку %d знаци";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "Најмалку %d уникатни знаци";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "Најмалку една цифра";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "Најмалку една голема буква";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "Најмалку една мала буква";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "Најмалку еден специјален знак";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "Само цифри";
+

--- a/Sources/FioriSwiftUICore/_localization/ms.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/ms.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "Penunjuk Daftar Keluar";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "+%d lagi";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "Tiada Hasil Ditemui";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "Semak carian anda untuk apa-apa ralat ejaan atau cuba istilah carian yang berbeza.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "Kotak Semak";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "Sekurang-kurangnya %d aksara";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "Sekurang-kurangnya %d aksara unik";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "Sekurang-kurangnya satu digit";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "Sekurang-kurangnya satu huruf besar";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "Sekurang-kurangnya satu huruf kecil";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "Sekurang-kurangnya satu aksara khas";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "Digit sahaja";
+

--- a/Sources/FioriSwiftUICore/_localization/nb.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/nb.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "Utsjekkingsindikator";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "+%d til";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "Ingen treff";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "Kontroller om søket inneholder stavefeil eller prøv med en annen søkestreng.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "Avmerkingsboks";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "Minst %d tegn";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "Minst %d unike tegn";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "Minst ett siffer";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "Minst én stor bokstav";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "Minst én liten bokstav";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "Minst ett spesialtegn";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "Bare sifre";
+

--- a/Sources/FioriSwiftUICore/_localization/nl.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/nl.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "Uitcheckteken";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "+ nog %d";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "Geen resultaten gevonden";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "Controleer uw zoekopdracht op spelfouten of probeer een ander zoekbegrip.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "Selectievakje";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "Ten minste %d tekens";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "Ten minste %d unieke tekens";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "Ten minste één cijfer";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "Ten minste één hoofdletter";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "Ten minste één kleine letter";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "Ten minste één speciaal teken";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "Alleen cijfers";
+

--- a/Sources/FioriSwiftUICore/_localization/pl.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/pl.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "Wskaźnik realizacji";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "+%d więcej";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "Nie znaleziono wyników";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "Sprawdź, czy wyszukiwanie nie zawiera błędów pisowni, i spróbuj ponownie z innym szukanym ciągiem znaków.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "Pole wyboru";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "Co najmniej %d znaki(-ów)";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "Co najmniej %d znaki(-ów) unikalne(-ych)";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "Co najmniej jedna cyfra";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "Co najmniej jedna wielka litera";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "Co najmniej jedna mała litera";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "Co najmniej jeden znak specjalny";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "Tylko cyfry";
+

--- a/Sources/FioriSwiftUICore/_localization/pt-PT.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/pt-PT.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "Indicador de checkout";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "+%d mais";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "Não foram encontrados resultados";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "Verifique se existem erros de ortografia na sua pesquisa ou tente um termo de pesquisa diferente.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "Caixa de seleção";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "Pelo menos %d carateres";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "Pelo menos %d carateres únicos";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "Pelo menos um dígito";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "Pelo menos uma letra maiúscula";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "Pelo menos uma letra minúscula";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "Pelo menos um caráter especial";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "Só dígitos";
+

--- a/Sources/FioriSwiftUICore/_localization/pt.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/pt.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "Indicador de check-out";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "Mais %d";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "Nenhum resultado encontrado";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "Verifique se há erros ortográficos na sua pesquisa ou tente outro termo de pesquisa.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "Campo de seleção";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "Pelo menos %d caracteres";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "Pelo menos %d caracteres únicos";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "Pelo menos um dígito";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "Pelo menos uma letra maiúscula";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "Pelo menos uma letra minúscula";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "Pelo menos um caractere especial";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "Somente dígitos";
+

--- a/Sources/FioriSwiftUICore/_localization/ro.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/ro.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "Indicator check-out";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "+ încă %d";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "Niciun rezultat găsit";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "Verificați dacă există greșeli de ortografie în căutare sau încercați cu un termen de căutare diferit.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "Casetă de marcaj";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "Cel puțin %d caractere";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "Cel puțin %d caractere univoce";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "Cel puțin o cifră";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "Cel puțin o literă majusculă";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "Cel puțin o literă minusculă";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "Cel puțin un caracter special";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "Numai cifre";
+

--- a/Sources/FioriSwiftUICore/_localization/ru.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/ru.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "Индикатор чек-аута";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "+ еще %d";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "Результаты не найдены";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "Проверьте критерий поиска на орфографические ошибки или попробуйте другой критерий.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "Флажок";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "Минимум символов: %d";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "Минимум различных символов: %d";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "Минимум одна цифра";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "Минимум одна прописная буква";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "Минимум одна строчная буква";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "Минимум один специальный символ";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "Только цифры";
+

--- a/Sources/FioriSwiftUICore/_localization/sk.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/sk.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "Znak výstupnej kontroly";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "+%d ďalších";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "Nenašli sa žiadne výsledky";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "Skontrolujte, či sa vo vyhľadávaní nenachádzajú pravopisné chyby, alebo skúste iný hľadaný výraz.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "Začiarkavacie pole";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "Aspoň %d znakov";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "Aspoň %d jedinečných znakov";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "Aspoň jedna číslica";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "Aspoň jedno veľké písmeno";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "Aspoň jedno malé písmeno";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "Aspoň jeden špeciálny znak";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "Iba číslice";
+

--- a/Sources/FioriSwiftUICore/_localization/sl.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/sl.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "Oznaka izvoza";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "+ še %d";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "Rezultati niso najdeni";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "Preverite, ali je pri iskanju prišlo do napak pri črkovanju, ali poskusite z drugačnim iskalnim pojmom.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "Potrditveno okno";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "Vsaj toliko znakov: %d";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "Vsaj toliko enoličnih znakov: %d";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "Vsaj ena števka";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "Vsaj ena velika črka";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "Vsaj ena mala črka";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "Vsaj en posebni znak";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "Samo števke";
+

--- a/Sources/FioriSwiftUICore/_localization/sr-Latn-RS.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/sr-Latn-RS.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "Pokazatelj obrade";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "Još +%d";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "Rezultati nisu nađeni";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "Proverite da li pretraga sadrži pravopisne greške ili pokušajte s drugim traženim terminom.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "Kvadratić za potvrdu";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "Najmanje %d znakova";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "Najmanje %d jedinstvenih znakova";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "Najmanje jedna cifra";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "Najmanje jedno veliko slovo";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "Najmanje jedno malo slovo";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "Najmanje jedan poseban znak";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "Samo cifre";
+

--- a/Sources/FioriSwiftUICore/_localization/sr.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/sr.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "Показатељ обраде";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "Још +%d";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "Резултати нису нађени";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "Проверите да ли претрага садржи правописне грешке или покушајте с другим траженим термином.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "Квадратић за потврду";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "Најмање %d знакова";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "Најмање %d јединствених знакова";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "Најмање једна цифра";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "Најмање једно велико слово";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "Најмање једно мало слово";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "Најмање један посебан знак";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "Само цифре";
+

--- a/Sources/FioriSwiftUICore/_localization/sv.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/sv.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "Genomförandeindikator";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "+%d till";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "Inga resultat hittades";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "Kontrollera att sökningen inte innehåller stavfel eller försök med ett annat sökbegrepp.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "Kryssruta";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "Minst %d tecken";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "Minst %d unika tecken";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "Minst en siffra";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "Minst en versal";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "Minst en gemen";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "Minst ett specialtecken";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "Endast siffror";
+

--- a/Sources/FioriSwiftUICore/_localization/th.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/th.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "ตัวบ่งชี้การเช็คเอาท์";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "และอีก %d รายการ";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "ไม่พบผลลัพธ์";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "ตรวจสอบการค้นหาของคุณเพื่อดูข้อผิดพลาดในการสะกดคำหรือลองใช้คำที่ใช้ค้นหาอื่น";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "เช็คบ็อกซ์";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "อย่างน้อย %d อักขระ";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "อย่างน้อย %d อักขระที่ไม่ซ้ำกัน";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "ตัวเลขอย่างน้อยหนึ่งตัว";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "ตัวพิมพ์ใหญ่อย่างน้อยหนึ่งตัว";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "ตัวพิมพ์เล็กอย่างน้อยหนึ่งตัว";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "อักขระพิเศษอย่างน้อยหนึ่งตัว";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "ตัวเลขเท่านั้น";
+

--- a/Sources/FioriSwiftUICore/_localization/tr.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/tr.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "Ödeme göstergesi";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "+%d tane daha";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "Sonuç bulunamadı";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "Aramanızda yazım hatası olup olmadığını kontrol edin veya başka bir arama terimi deneyin.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "Onay kutusu";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "En az %d karakter";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "En az %d benzersiz karakter";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "En az bir rakam";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "En az bir büyük harf";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "En az bir küçük harf";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "En az bir özel karakter";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "Yalnızca rakamlar";
+

--- a/Sources/FioriSwiftUICore/_localization/uk.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/uk.lproj/FioriSwiftUICore.strings
@@ -716,5 +716,38 @@
 "AI processing" = "Обробка ШІ";
 
 /* Checkout Indicator accessibility label: Checkout Indicator */
-"Checkout Indicator" = "Індикатор реєстрації при виході";
+"Checkout Indicator" = "Індикатор взяття на редагування";
+
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "+ ще %d";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "Результатів не знайдено";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "Перевірте, чи немає в пошуковому запиті орфографічних помилок, або спробуйте інший шуканий термін.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "Прапорець";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "Принаймні %d символів";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "Принаймні %d унікальних символів";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "Принаймні одна цифра";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "Принаймні одна велика літера";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "Принаймні одна мала літера";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "Принаймні один спеціальний символ";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "Лише цифри";
 

--- a/Sources/FioriSwiftUICore/_localization/vi.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/vi.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "Chỉ báo thanh toán";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "+%d mục khác";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "Không tìm thấy kết quả";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "Kiểm tra tìm kiếm của bạn để xem có bất kỳ lỗi chính tả nào không hoặc thử một thuật ngữ tìm kiếm khác.";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "Ô đánh dấu";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "Ít nhất %d ký tự";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "Ít nhất %d ký tự duy nhất";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "Ít nhất một chữ số";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "Ít nhất một chữ cái viết hoa";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "Ít nhất một chữ cái viết thường";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "Ít nhất một ký tự đặc biệt";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "Chỉ chữ số";
+

--- a/Sources/FioriSwiftUICore/_localization/zh-Hans.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/zh-Hans.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "检出标识";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "另外 %d 个";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "未找到结果";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "请检查您的搜索是否有任何拼写错误，或者尝试不同的搜索词。";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "复选框";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "至少 %d 个字符";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "至少 %d 个唯一字符";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "至少一个数字";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "至少一个大写字母";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "至少一个小写字母";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "至少一个特殊字符";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "仅数字";
+

--- a/Sources/FioriSwiftUICore/_localization/zh-Hant.lproj/FioriSwiftUICore.strings
+++ b/Sources/FioriSwiftUICore/_localization/zh-Hant.lproj/FioriSwiftUICore.strings
@@ -718,3 +718,36 @@
 /* Checkout Indicator accessibility label: Checkout Indicator */
 "Checkout Indicator" = "簽出指示碼";
 
+/* XMSG: More tag text shown when tags are truncated in MHStack, %d is the count of hidden tags */
+"+%d more" = "+%d 個其他項";
+
+/* XTIT: The title of the empty state view */
+"No Results Found" = "找不到結果";
+
+/* XTIT: The description of the empty state view */
+"Check your search for any spelling errors or try a different search term." = "請檢查搜尋拼字錯誤，或嘗試不同的搜尋條件。";
+
+/* XACT: The accessibility label for the checkbox */
+"Checkbox" = "核取方塊";
+
+/* XMSG: Passcode policy requirement - minimum length, %d is the required number of characters */
+"At least %d characters" = "至少 %d 個字元";
+
+/* XMSG: Passcode policy requirement - minimum number of unique characters, %d is the required count */
+"At least %d unique characters" = "至少 %d 個特殊字元";
+
+/* XMSG: Passcode policy requirement - at least one digit */
+"At least one digit" = "至少一個數字";
+
+/* XMSG: Passcode policy requirement - at least one uppercase letter */
+"At least one uppercase letter" = "至少一個大寫字母";
+
+/* XMSG: Passcode policy requirement - at least one lowercase letter */
+"At least one lowercase letter" = "至少一個小寫字母";
+
+/* XMSG: Passcode policy requirement - at least one special character */
+"At least one special character" = "至少一個特殊字元";
+
+/* XMSG: Passcode policy requirement - digits only */
+"Digits only" = "僅數字";
+


### PR DESCRIPTION
# Translation Delivery: Add New Localization Strings for Multiple Languages

### Chore

🌍 Added new localized string entries across all supported language files in `FioriSwiftUICore`. This update delivers translations for newly introduced UI strings to ensure full internationalization support.

### Changes

The following new string keys have been added to **all supported locale files** (40+ languages including ar, bg, ca, cnr, cs, cy, da, de, de-CH, el, en-GB, es, es-MX, et, fi, fr, fr-CA, he, hi, hr, hu, id, it, it-CH, ja, kk, ko, lt, lv, mk, ms, nb, nl, pl, pt, pt-PT, ro, ru, sk, sl, sr, sr-Latn-RS, sv, th, tr, uk, vi, zh-Hans, zh-Hant):

| String Key | Purpose |
|---|---|
| `+%d more` | Overflow tag count label in MHStack |
| `No Results Found` | Empty state view title |
| `Check your search for any spelling errors or try a different search term.` | Empty state view description |
| `Checkbox` | Accessibility label for checkbox component |
| `At least %d characters` | Passcode policy: minimum length requirement |
| `At least %d unique characters` | Passcode policy: unique character requirement |
| `At least one digit` | Passcode policy requirement |
| `At least one uppercase letter` | Passcode policy requirement |
| `At least one lowercase letter` | Passcode policy requirement |
| `At least one special character` | Passcode policy requirement |
| `Digits only` | Passcode policy: digits-only mode |

* `uk.lproj/FioriSwiftUICore.strings`: Additionally corrects an existing translation for `"Checkout Indicator"` (updated from `"Індикатор реєстрації при виході"` to `"Індикатор взяття на редагування"`).

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.30`

- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- LLM: `anthropic--claude-4.6-sonnet`
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- File Content Strategy: Full file content
- Correlation ID: `07da6a30-9b8b-11f1-9c79-4a77c6213c3e`
- Event Trigger: `pull_request.opened`
</details>
