### PR TITLE
fix: 🐛 [IOSSDKBUG-1465] ChartView details is not read out

### DIFF
--- a/Sources/FioriSwiftUICore/_FioriStyles/CardStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/CardStyle.fiori.swift
@@ -603,6 +603,9 @@ public enum CardTests {
             ChartView(CardTests.chartModel)
                 .frame(minWidth: 128)
                 .frame(height: 168)
+                .accessibilityLabel("Column chart: Top Products")
+                .accessibilityValue("Single Beds: Jan: 30, Feb: 22, Mar: 80, Apr: 70, May: 60, Jun: 64, Jul: 50, Aug: 20, Sep: 90, Oct: 80, Nov: 50, Dec: 16. Double Beds: Jan: 22, Feb: 30, Mar: 90, Apr: 80, May: 70, Jun: 32, Jul: 28, Aug: 36, Sep: 84, Oct: 70, Nov: 30, Dec: 32.")
+                .accessibilityHint("Chart showing monthly data for two product series")
             
             VStack(alignment: .leading, spacing: 8) {
                 HStack {


### PR DESCRIPTION
Fixed the issue: IOSSDKBUG-1465 ACC- 264.1 WCAG 2.1, 4.1.2 Level A _ SAP BTP SDK for IOS_ iPad‑ _ chart_ ui details is not read out