### PR TITLE
fix: 🐛 [IOSSDKBUG-2282]Cherry-pick - Liquid glass issues on What's New page

### DIFF
--- a/Sources/FioriSwiftUICore/FioriButton/FioriButtonStyle.swift
+++ b/Sources/FioriSwiftUICore/FioriButton/FioriButtonStyle.swift
@@ -356,6 +356,7 @@ public struct FioriGlassButtonStyle: FioriButtonStyle {
             .tint(config.foregroundColor)
             .padding(config.padding)
             .frame(minWidth: 44, maxWidth: config.maxWidth, minHeight: config.minHeight)
+            .contentShape(Rectangle())
             .ifApply(self.glassEffect == .tint, content: {
                 $0.glassEffect(.regular.tint(.preferredColor(.tintColor)))
             })

--- a/Sources/FioriSwiftUICore/Views/FioriToolbarItem.swift
+++ b/Sources/FioriSwiftUICore/Views/FioriToolbarItem.swift
@@ -1,0 +1,118 @@
+import FioriThemeManager
+import SwiftUI
+
+/// A reusable toolbar/navigation-bar item that renders as a `Button`
+/// with either a text label or an SF Symbol image.
+///
+/// `FioriToolbarItem` is a lightweight, `Sendable` value type designed to be
+/// placed inside a `ToolbarItem`. It lets the system provide the bar-item
+/// background and press behavior (including Liquid Glass on iOS 26+),
+/// matching a hand-written `Button { … } label: { … }`.
+///
+/// Use one of the built-in presets — ``close``, ``back``, or ``textClose`` —
+/// and attach behavior with ``withAction(_:)``. You can also construct a
+/// custom item directly by choosing a ``Style``.
+///
+/// ```swift
+/// .toolbar {
+///     ToolbarItem(placement: .topBarLeading) {
+///         FioriToolbarItem.close
+///             .withAction { dismiss() }
+///     }
+/// }
+/// ```
+///
+/// Because `FioriToolbarItem` conforms to `View`, it can be returned directly
+/// from a `ToolbarItem`'s content builder.
+struct FioriToolbarItem: Hashable, Sendable {
+    static func == (lhs: FioriToolbarItem, rhs: FioriToolbarItem) -> Bool {
+        switch (lhs.style, rhs.style) {
+        case (.text(let lhsText), .text(let rhsText)):
+            return lhsText == rhsText
+        case (.image(let lhsImage), .image(let rhsImage)):
+            return lhsImage == rhsImage
+        default:
+            return false
+        }
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(0)
+    }
+
+    enum Style {
+        case text(String)
+        case image(String)
+    }
+
+    let style: FioriToolbarItem.Style
+    let action: (@Sendable () -> Void)?
+
+    init(style: FioriToolbarItem.Style,
+         action: (@Sendable () -> Void)? = nil)
+    {
+        self.style = style
+        self.action = action
+    }
+}
+
+extension FioriToolbarItem: View {
+    var body: some View {
+        Button {
+            self.action?()
+        } label: {
+            switch self.style {
+            case .text(let text):
+                Text(text)
+            case .image(let imageName):
+                Image(systemName: imageName)
+            }
+        }
+    }
+
+    static let close = FioriToolbarItem(style: .image("xmark"))
+    static let back = FioriToolbarItem(style: .image("chevron.backward"))
+
+    static let textClose = FioriToolbarItem(style: .text("Close"))
+
+    func withAction(_ action: @escaping @Sendable () -> Void) -> FioriToolbarItem {
+        FioriToolbarItem(style: self.style, action: action)
+    }
+}
+
+struct FioriToolbarDemoView: View {
+    var body: some View {
+        NavigationStack {
+            Color.clear
+                .toolbar {
+                    ToolbarItem(placement: .topBarLeading) {
+                        FioriToolbarItem.close
+                            .withAction {}
+                    }
+                    #if !os(visionOS)
+                        if #available(iOS 26.0, *) {
+                            ToolbarSpacer(.flexible, placement: .topBarLeading)
+                        }
+                    #endif
+                    ToolbarItem(placement: .topBarLeading) {
+                        FioriToolbarItem.back
+                            .withAction {}
+                            .foregroundStyle(Color.red)
+                    }
+                    #if !os(visionOS)
+                        if #available(iOS 26.0, *) {
+                            ToolbarSpacer(.flexible, placement: .topBarLeading)
+                        }
+                    #endif
+                    ToolbarItem(placement: .topBarLeading) {
+                        FioriToolbarItem.textClose
+                            .withAction {}
+                    }
+                }
+        }
+    }
+}
+
+#Preview {
+    FioriToolbarDemoView()
+}

--- a/Sources/FioriSwiftUICore/Views/FioriToolbarItem.swift
+++ b/Sources/FioriSwiftUICore/Views/FioriToolbarItem.swift
@@ -37,7 +37,14 @@ struct FioriToolbarItem: Hashable, Sendable {
     }
 
     func hash(into hasher: inout Hasher) {
-        hasher.combine(0)
+        switch self.style {
+        case .text(let text):
+            hasher.combine(0)
+            hasher.combine(text)
+        case .image(let imageName):
+            hasher.combine(1)
+            hasher.combine(imageName)
+        }
     }
 
     enum Style {
@@ -62,8 +69,8 @@ extension FioriToolbarItem: View {
             self.action?()
         } label: {
             switch self.style {
-            case .text(let text):
-                Text(text)
+            case .text(let key):
+                Text(NSLocalizedString(key, tableName: "FioriSwiftUICore", bundle: Bundle.accessor, comment: ""))
             case .image(let imageName):
                 Image(systemName: imageName)
             }

--- a/Sources/FioriSwiftUICore/Views/WhatsNew/FioriPageControl.swift
+++ b/Sources/FioriSwiftUICore/Views/WhatsNew/FioriPageControl.swift
@@ -1,0 +1,46 @@
+import FioriThemeManager
+import SwiftUI
+import UIKit
+
+/// A SwiftUI wrapper around the native `UIPageControl`.
+struct FioriPageControl: UIViewRepresentable {
+    let numberOfPages: Int
+    @Binding var currentPage: Int
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(currentPage: self.$currentPage)
+    }
+
+    func makeUIView(context: Context) -> UIPageControl {
+        let control = UIPageControl()
+        control.numberOfPages = self.numberOfPages
+        control.currentPage = self.currentPage
+        control.currentPageIndicatorTintColor = UIColor(Color.preferredColor(.primaryLabel))
+        control.pageIndicatorTintColor = UIColor(Color.preferredColor(.quaternaryLabel))
+        control.addTarget(context.coordinator,
+                          action: #selector(Coordinator.pageChanged(_:)),
+                          for: .valueChanged)
+        control.setContentCompressionResistancePriority(.required, for: .horizontal)
+        control.setContentHuggingPriority(.required, for: .vertical)
+        return control
+    }
+
+    func updateUIView(_ uiView: UIPageControl, context: Context) {
+        uiView.numberOfPages = self.numberOfPages
+        if uiView.currentPage != self.currentPage {
+            uiView.currentPage = self.currentPage
+        }
+    }
+
+    final class Coordinator: NSObject {
+        @Binding var currentPage: Int
+
+        init(currentPage: Binding<Int>) {
+            self._currentPage = currentPage
+        }
+
+        @objc func pageChanged(_ sender: UIPageControl) {
+            self.currentPage = sender.currentPage
+        }
+    }
+}

--- a/Sources/FioriSwiftUICore/Views/WhatsNew/WhatsNewButtonStyle.swift
+++ b/Sources/FioriSwiftUICore/Views/WhatsNew/WhatsNewButtonStyle.swift
@@ -1,0 +1,19 @@
+import FioriThemeManager
+import SwiftUI
+
+extension FioriButtonStyle where Self == AnyFioriButtonStyle {
+    /// The shared button style for the "What's New" primary CTA
+    /// (the list view's "Start" button and the page builder's "Next/Start" button).
+    ///
+    /// Tinted glass on Liquid Glass systems (iOS 26+), falling back to
+    /// the primary Fiori button style on earlier versions.
+    /// - Parameter maxWidth: The maximum width of the button. Defaults to `200`.
+    static func whatsNewPrimary(maxWidth: CGFloat = 200) -> AnyFioriButtonStyle {
+        #if !os(visionOS)
+            if #available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 26.0, *) {
+                return FioriGlassButtonStyle(glassEffect: .tint, maxWidth: maxWidth).eraseToAnyFioriButtonStyle()
+            }
+        #endif
+        return FioriPrimaryButtonStyle(maxWidth).eraseToAnyFioriButtonStyle()
+    }
+}

--- a/Sources/FioriSwiftUICore/Views/WhatsNew/WhatsNewPagesBuilder.swift
+++ b/Sources/FioriSwiftUICore/Views/WhatsNew/WhatsNewPagesBuilder.swift
@@ -100,7 +100,10 @@ public struct WhatsNewInnerView<PageList: WhatsNewPageList>: View {
             .background(
                 GeometryReader { proxy in
                     Color.clear
-                        .preference(key: WhatsNewBottomBarHeightKey.self, value: proxy.size.height)
+                        .preference(
+                            key: WhatsNewBottomBarHeightKey.self,
+                            value: proxy.size.height + proxy.safeAreaInsets.bottom
+                        )
                 }
             )
         }

--- a/Sources/FioriSwiftUICore/Views/WhatsNew/WhatsNewPagesBuilder.swift
+++ b/Sources/FioriSwiftUICore/Views/WhatsNew/WhatsNewPagesBuilder.swift
@@ -25,42 +25,49 @@ public extension WhatsNewPageList {
     }
 }
 
+/// Preference key used to communicate the measured height of the floating
+/// bottom bar (action button + page control) up the view hierarchy.
+private struct WhatsNewBottomBarHeightKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
+    }
+}
+
 public struct WhatsNewInnerView<PageList: WhatsNewPageList>: View {
     let pageList: PageList
     @State var actionButtonTitle: AttributedString = "Next"
-    @State private var buttonHeight: CGFloat = 0
     @State private var isCompactMode: Bool = false
+    @State private var bottomBarHeight: CGFloat = 0
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
     @Environment(\.whatsNewPageIndex) var whatsNewPageIndex
     @Environment(\.whatsNewPageDidFinish) var whatsNewPageDidFinish
 
     init(pageList: PageList) {
         self.pageList = pageList
-        UIPageControl.appearance().currentPageIndicatorTintColor = UIColor(Color.preferredColor(.primaryLabel))
-        UIPageControl.appearance().pageIndicatorTintColor = UIColor(Color.preferredColor(.quaternaryLabel))
     }
-    
+
     public var body: some View {
-        ZStack {
-            TabView(selection: self.whatsNewPageIndex) {
-                ForEach(0 ..< self.pageList.count, id: \.self) { index in
-                    ScrollView {
-                        VStack {
-                            self.pageList.view(at: index).typeErased
-                            Spacer()
-                        }
-                        .padding(.top, 52)
-                        .padding(.bottom, self.buttonHeight + 50)
+        TabView(selection: self.whatsNewPageIndex) {
+            ForEach(0 ..< self.pageList.count, id: \.self) { index in
+                ScrollView {
+                    VStack {
+                        self.pageList.view(at: index).typeErased
+                        Spacer()
                     }
-                    .padding(.horizontal, self.isCompactMode ? 32 : 72)
-                    .tag(index)
+                    .padding(.top, 52)
+                    // Reserve space at the bottom so the content can scroll
+                    // completely clear of the floating bottom bar.
+                    .padding(.bottom, self.bottomBarHeight)
                 }
+                .padding(.horizontal, self.isCompactMode ? 32 : 72)
+                .tag(index)
             }
-            .tabViewStyle(.page)
-            .indexViewStyle(.page(backgroundDisplayMode: .never))
-            .animation(.easeInOut(duration: 1.0), value: self.whatsNewPageIndex.wrappedValue)
-            VStack {
-                Spacer()
+        }
+        .tabViewStyle(.page(indexDisplayMode: .never))
+        .animation(.easeInOut(duration: 1.0), value: self.whatsNewPageIndex.wrappedValue)
+        .overlay(alignment: .bottom) {
+            VStack(spacing: 16) {
                 FioriButton(title: self.actionButtonTitle, action: { _ in
                     if (self.whatsNewPageIndex.wrappedValue ?? 0) < self.pageList.count - 1 {
                         withAnimation {
@@ -70,12 +77,35 @@ public struct WhatsNewInnerView<PageList: WhatsNewPageList>: View {
                         self.whatsNewPageDidFinish?()
                     }
                 })
-                .fioriButtonStyle(FioriPrimaryButtonStyle(201))
-                .padding(.bottom, 34)
-                .sizeReader { size in
-                    self.buttonHeight = size.height
+                .fioriButtonStyle(.whatsNewPrimary())
+
+                if self.pageList.count > 1 {
+                    FioriPageControl(
+                        numberOfPages: self.pageList.count,
+                        currentPage: Binding(
+                            get: { self.whatsNewPageIndex.wrappedValue ?? 0 },
+                            set: { newValue in
+                                withAnimation {
+                                    self.whatsNewPageIndex.wrappedValue = newValue
+                                }
+                            }
+                        )
+                    )
+                    .frame(width: 168, height: 44)
+                    .ifApplyGlassEffectContainer()
                 }
             }
+            .padding(.horizontal, self.isCompactMode ? 32 : 72)
+            .padding(.bottom, 34)
+            .background(
+                GeometryReader { proxy in
+                    Color.clear
+                        .preference(key: WhatsNewBottomBarHeightKey.self, value: proxy.size.height)
+                }
+            )
+        }
+        .onPreferenceChange(WhatsNewBottomBarHeightKey.self) { height in
+            self.bottomBarHeight = height
         }
         .sizeReader { size in
             self.isCompactMode = size.width < 540
@@ -85,6 +115,21 @@ public struct WhatsNewInnerView<PageList: WhatsNewPageList>: View {
                 self.actionButtonTitle = (self.whatsNewPageIndex.wrappedValue ?? 0) < self.pageList.count - 1 ? "Next" : "Start"
             }
         }
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func ifApplyGlassEffectContainer() -> some View {
+        #if !os(visionOS)
+            if #available(iOS 26.0, *), LiquidGlassHelper.usesLiquidGlassUI {
+                self.glassEffect(.regular, in: .rect(cornerRadius: 22))
+            } else {
+                self
+            }
+        #else
+            self
+        #endif
     }
 }
 

--- a/Sources/FioriSwiftUICore/_FioriStyles/WhatsNewListViewStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/WhatsNewListViewStyle.fiori.swift
@@ -18,13 +18,19 @@ public struct WhatsNewListViewBaseStyle: WhatsNewListViewStyle {
                 VStack {
                     Spacer()
                     FioriButton(title: "Start", action: { _ in configuration.didFinish?() })
-                        .fioriButtonStyle(FioriPrimaryButtonStyle(200))
+                        .fioriButtonStyle(.whatsNewPrimary())
                         .padding(.bottom, 34)
                 }
             }
-            .navigationBarItems(trailing: Button(NSLocalizedString("Close", comment: ""), action: {
-                configuration.didClose?()
-            }))
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    FioriToolbarItem.close
+                        .withAction {
+                            configuration.didClose?()
+                        }
+                        .foregroundStyle(Color.preferredColor(.primaryLabel))
+                }
+            }
             .navigationTitle("What's New")
             .navigationBarTitleDisplayMode(.inline)
         }

--- a/Sources/FioriSwiftUICore/_FioriStyles/WhatsNewPageViewStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/WhatsNewPageViewStyle.fiori.swift
@@ -5,13 +5,21 @@ import SwiftUI
 // Base Layout style
 public struct WhatsNewPageViewBaseStyle: WhatsNewPageViewStyle {
     public func makeBody(_ configuration: WhatsNewPageViewConfiguration) -> some View {
-        NavigationView {
+        let didClose = configuration.didClose
+
+        return NavigationView {
             configuration.whatsNewPages
                 .navigationTitle("What's New")
                 .navigationBarTitleDisplayMode(.inline)
-                .navigationBarItems(trailing: Button(NSLocalizedString("Close", comment: ""), action: {
-                    configuration.didClose?()
-                }))
+                .toolbar {
+                    ToolbarItem(placement: .topBarLeading) {
+                        FioriToolbarItem.close
+                            .withAction {
+                                didClose?()
+                            }
+                            .foregroundStyle(Color.preferredColor(.primaryLabel))
+                    }
+                }
         }
         .environment(\.whatsNewPageIndex, configuration.$currentIndex)
         .environment(\.whatsNewPageDidFinish, configuration.didFinish)


### PR DESCRIPTION
# Fix: Liquid Glass Issues on What's New Page

### Bug Fix

🐛 Resolves multiple Liquid Glass rendering issues on the What's New page (iOS 26+), including incorrect button styling, broken page control appearance, and improper navigation bar close button behavior.

### Changes

* `FioriButtonStyle.swift`: Added `.contentShape(Rectangle())` to `FioriGlassButtonStyle` to ensure the full button area is tappable.

* `FioriToolbarItem.swift` *(new)*: Introduced a reusable `FioriToolbarItem` struct for toolbar/navigation-bar buttons (text or SF Symbol). Includes built-in presets (`close`, `back`, `textClose`) and supports chaining actions via `withAction(_:)`. Renders natively as a `Button` inside `ToolbarItem`, enabling correct Liquid Glass behavior on iOS 26+.

* `FioriPageControl.swift` *(new)*: Added a `UIViewRepresentable` wrapper around `UIPageControl`, replacing the previous global `UIPageControl.appearance()` override with a properly scoped, binding-driven component.

* `WhatsNewButtonStyle.swift` *(new)*: Extracted a shared `.whatsNewPrimary()` `FioriButtonStyle` extension that applies tinted Liquid Glass on iOS 26+ and falls back to `FioriPrimaryButtonStyle` on earlier versions.

* `WhatsNewPagesBuilder.swift`: Refactored the layout from a `ZStack`-based approach to a `.overlay(alignment: .bottom)` pattern for the floating bottom bar. Replaced `UIPageControl.appearance()` with the new `FioriPageControl` component. Introduced `WhatsNewBottomBarHeightKey` preference key to dynamically measure and reserve bottom padding for scroll content. Integrated `.ifApplyGlassEffectContainer()` on the page control for Liquid Glass styling.

* `WhatsNewListViewStyle.fiori.swift`: Replaced deprecated `.navigationBarItems` with a `.toolbar` + `FioriToolbarItem.close` approach. Updated button style to use the new `.whatsNewPrimary()` style.

* `WhatsNewPageViewStyle.fiori.swift`: Replaced deprecated `.navigationBarItems` with `.toolbar` + `FioriToolbarItem.close`. Minor refactor to capture `didClose` before use in the builder.

### Jira Issues

* IOSSDKBUG-2282

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.54`

- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Event Trigger: `pull_request.opened`
- Correlation ID: `ec20f310-a2c7-11f1-95b5-de408b89aa34`
- File Content Strategy: Full file content
- LLM: `anthropic--claude-4.6-sonnet`
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
</details>
