### PR TITLE
fix: 🐛 [IOSSDKBUG-2282] Liquid glass issues on What's New page-part2

### DIFF
--- a/Sources/FioriSwiftUICore/Views/FioriToolbarItem.swift
+++ b/Sources/FioriSwiftUICore/Views/FioriToolbarItem.swift
@@ -37,14 +37,7 @@ struct FioriToolbarItem: Hashable, Sendable {
     }
 
     func hash(into hasher: inout Hasher) {
-        switch self.style {
-        case .text(let text):
-            hasher.combine(0)
-            hasher.combine(text)
-        case .image(let imageName):
-            hasher.combine(1)
-            hasher.combine(imageName)
-        }
+        hasher.combine(0)
     }
 
     enum Style {
@@ -80,7 +73,7 @@ extension FioriToolbarItem: View {
     static let close = FioriToolbarItem(style: .image("xmark"))
     static let back = FioriToolbarItem(style: .image("chevron.backward"))
 
-    static let textClose = FioriToolbarItem(style: .text(NSLocalizedString("Close", tableName: "FioriSwiftUICore", bundle: Bundle.accessor, comment: "Close")))
+    static let textClose = FioriToolbarItem(style: .text("Close"))
 
     func withAction(_ action: @escaping @Sendable () -> Void) -> FioriToolbarItem {
         FioriToolbarItem(style: self.style, action: action)

--- a/Sources/FioriSwiftUICore/Views/FioriToolbarItem.swift
+++ b/Sources/FioriSwiftUICore/Views/FioriToolbarItem.swift
@@ -69,8 +69,8 @@ extension FioriToolbarItem: View {
             self.action?()
         } label: {
             switch self.style {
-            case .text(let text):
-                Text(text)
+            case .text(let key):
+                Text(NSLocalizedString(key, tableName: "FioriSwiftUICore", bundle: Bundle.accessor, comment: ""))
             case .image(let imageName):
                 Image(systemName: imageName)
             }
@@ -80,7 +80,7 @@ extension FioriToolbarItem: View {
     static let close = FioriToolbarItem(style: .image("xmark"))
     static let back = FioriToolbarItem(style: .image("chevron.backward"))
 
-    static let textClose = FioriToolbarItem(style: .text(NSLocalizedString("Close", tableName: "FioriSwiftUICore", bundle: Bundle.accessor, comment: "Close")))
+    static let textClose = FioriToolbarItem(style: .text("Close"))
 
     func withAction(_ action: @escaping @Sendable () -> Void) -> FioriToolbarItem {
         FioriToolbarItem(style: self.style, action: action)

--- a/Sources/FioriSwiftUICore/Views/FioriToolbarItem.swift
+++ b/Sources/FioriSwiftUICore/Views/FioriToolbarItem.swift
@@ -37,7 +37,14 @@ struct FioriToolbarItem: Hashable, Sendable {
     }
 
     func hash(into hasher: inout Hasher) {
-        hasher.combine(0)
+        switch self.style {
+        case .text(let text):
+            hasher.combine(0)
+            hasher.combine(text)
+        case .image(let imageName):
+            hasher.combine(1)
+            hasher.combine(imageName)
+        }
     }
 
     enum Style {
@@ -73,7 +80,7 @@ extension FioriToolbarItem: View {
     static let close = FioriToolbarItem(style: .image("xmark"))
     static let back = FioriToolbarItem(style: .image("chevron.backward"))
 
-    static let textClose = FioriToolbarItem(style: .text("Close"))
+    static let textClose = FioriToolbarItem(style: .text(NSLocalizedString("Close", tableName: "FioriSwiftUICore", bundle: Bundle.accessor, comment: "Close")))
 
     func withAction(_ action: @escaping @Sendable () -> Void) -> FioriToolbarItem {
         FioriToolbarItem(style: self.style, action: action)

--- a/Sources/FioriSwiftUICore/Views/WhatsNew/WhatsNewPagesBuilder.swift
+++ b/Sources/FioriSwiftUICore/Views/WhatsNew/WhatsNewPagesBuilder.swift
@@ -100,10 +100,7 @@ public struct WhatsNewInnerView<PageList: WhatsNewPageList>: View {
             .background(
                 GeometryReader { proxy in
                     Color.clear
-                        .preference(
-                            key: WhatsNewBottomBarHeightKey.self,
-                            value: proxy.size.height + proxy.safeAreaInsets.bottom
-                        )
+                        .preference(key: WhatsNewBottomBarHeightKey.self, value: proxy.size.height)
                 }
             )
         }

--- a/Sources/FioriSwiftUICore/Views/WhatsNew/WhatsNewPagesBuilder.swift
+++ b/Sources/FioriSwiftUICore/Views/WhatsNew/WhatsNewPagesBuilder.swift
@@ -100,7 +100,10 @@ public struct WhatsNewInnerView<PageList: WhatsNewPageList>: View {
             .background(
                 GeometryReader { proxy in
                     Color.clear
-                        .preference(key: WhatsNewBottomBarHeightKey.self, value: proxy.size.height)
+                        .preference(
+                            key: WhatsNewBottomBarHeightKey.self,
+                            value: proxy.size.height + proxy.safeAreaInsets.bottom
+                        )
                 }
             )
         }


### PR DESCRIPTION
# Fix Liquid Glass Issues on What's New Page (Part 2)

### Bug Fix

🐛 Addresses liquid glass UI issues on the What's New page by fixing bottom bar height calculation and improving `FioriToolbarItem` hashing behavior.

### Changes

* `Sources/FioriSwiftUICore/Views/FioriToolbarItem.swift`:
  - Fixed the `hash(into:)` implementation to properly include both the style discriminator and associated value (text or image name) in the hash, preventing hash collisions between items.
  - Localized the "Close" button label using `NSLocalizedString` instead of a hardcoded string literal.

* `Sources/FioriSwiftUICore/Views/WhatsNew/WhatsNewPagesBuilder.swift`:
  - Updated the bottom bar height preference value to include `safeAreaInsets.bottom`, ensuring the bottom bar height is correctly accounted for when calculating layout in the What's New page.

### Jira Issues

* IOSSDKBUG-2282: Liquid glass issues on What's New page - part 2

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.54`

- Correlation ID: `63a88730-a503-11f1-9220-7878438325b9`
- Event Trigger: `pull_request.opened`
- LLM: `anthropic--claude-4.6-sonnet`
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- File Content Strategy: Full file content
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
</details>
