### PR TITLE
fix: 🐛 [2285]KPIHeader skeleton loading display issues

### DIFF
--- a/Sources/FioriSwiftUICore/Views/KPIHeader/KPIContainerStack.swift
+++ b/Sources/FioriSwiftUICore/Views/KPIHeader/KPIContainerStack.swift
@@ -23,6 +23,7 @@ struct KPIContainerStack: View {
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
     @Environment(\.isItemOrderForced) var isItemOrderForced: Bool
     @Environment(\.interItemSpacing) var interItemSpacing: CGFloat?
+    @Environment(\.isLoading) private var isLoading: Bool
     @ObservedObject var context = KPIHeaderContentContext()
     @State private var reArrangedItems: [KPIHeaderItemModel] = []
 
@@ -38,6 +39,12 @@ struct KPIContainerStack: View {
             } else {
                 self.calculateLayoutView()
             }
+        }
+        // When the item set changes (e.g. switching between real data and skeleton data with a
+        // different item count), reset so the layout is re-measured. Without this the header could
+        // keep the previously calculated layout and get stuck.
+        .onChange(of: self.items.count) {
+            self.context.reset()
         }
     }
     
@@ -81,6 +88,19 @@ struct KPIContainerStack: View {
             EmptyView()
         }
     }
+
+    /// The view used for the final (paged) display. While loading, each item is replaced by a
+    /// `KPIHeaderItemSkeleton` so it gets its own element-level placeholders and shimmer. The
+    /// measurement path keeps using `view(at:)` with the real item, so placeholder sizing matches
+    /// the loaded layout and no state branch is added that could get stuck.
+    @ViewBuilder
+    private func displayView(at index: Int) -> some View {
+        if self.isLoading {
+            KPIHeaderItemSkeleton(model: self.reArrangedItems[index], measuredSize: self.context.itemsSize[index])
+        } else {
+            self.view(at: index)
+        }
+    }
     
     @ViewBuilder
     private func headerContentTabViewGenerator() -> some View {
@@ -88,12 +108,12 @@ struct KPIContainerStack: View {
             ForEach(0 ..< min(self.context.organizedItemsIndexes.count, 4), id: \.self) { index in
                 let pageItems: [Int] = self.context.organizedItemsIndexes[index]
                 if pageItems.count == 1 {
-                    self.view(at: pageItems[0])
+                    self.displayView(at: pageItems[0])
                         .frame(width: self.widthOfHStackInOnePage(itemsIndex: pageItems), alignment: .center)
                 } else {
                     HStack(spacing: self.interItemSpacing ?? (self.horizontalSizeClass == .compact ? 40 : 48)) {
                         ForEach(0 ..< pageItems.count, id: \.self) { index in
-                            self.view(at: pageItems[index])
+                            self.displayView(at: pageItems[index])
                                 .frame(width: self.context.itemsSize[index]?.width)
                         }
                     }
@@ -106,11 +126,14 @@ struct KPIContainerStack: View {
         .tabViewStyle(.page(indexDisplayMode: .never))
         .indexViewStyle(PageIndexViewStyle(backgroundDisplayMode: .never))
         .frame(minHeight: 24 + self.context.itemsMaxHeight + 24)
+        // While loading, disable paging/swiping so the skeleton cannot be scrolled and placeholder
+        // blocks never overlap after a swipe.
+        .allowsHitTesting(!self.isLoading)
         .onReceive(self.resizePublisher) { _ in
             self.context.reset()
         }
-        
-        if self.context.organizedItemsIndexes.count > 1 {
+
+        if self.context.organizedItemsIndexes.count > 1, !self.isLoading {
             PageIndicator(numberOfPages: self.context.organizedItemsIndexes.count, currentPage: self.$currentPage)
                 .padding(.top, 4)
                 .padding(.bottom, 8)

--- a/Sources/FioriSwiftUICore/Views/KPIHeader/KPIHeaderContent.swift
+++ b/Sources/FioriSwiftUICore/Views/KPIHeader/KPIHeaderContent.swift
@@ -5,12 +5,13 @@ struct KPIHeaderContent<List: IndexedViewContainer>: View {
     typealias V = List.V
     let list: List
     var maxNumberOfItems = 4
-    
+
     @ObservedObject private var context = KPIHeaderContext<V>()
+    @Environment(\.isLoading) private var isLoading: Bool
     var count: Int {
         self.list.count
     }
-    
+
     var body: some View {
         Group {
             if self.context.isViewOrganized {
@@ -20,9 +21,22 @@ struct KPIHeaderContent<List: IndexedViewContainer>: View {
             }
         }
     }
-    
+
     func view(at index: Int) -> V {
         self.list.view(at: index)
+    }
+
+    /// The view used for the final (paged) display of a builder-provided item. While loading it is
+    /// replaced by a `KPIHeaderItemSkeleton` (fallback placeholder, since the concrete item type is
+    /// not known on this path), so each item gets its own placeholder and shimmer instead of one
+    /// shimmer sweeping across the whole header. The measurement path keeps using the real item.
+    @ViewBuilder
+    func displayItem(_ item: V) -> some View {
+        if self.isLoading {
+            KPIHeaderItemSkeleton(model: nil, measuredSize: nil)
+        } else {
+            item
+        }
     }
 }
 
@@ -32,11 +46,11 @@ extension KPIHeaderContent {
             ForEach(0 ..< self.context.organizedItems.count, id: \.self) { index in
                 let pageItems = self.context.organizedItems[index]
                 if pageItems.count == 1 {
-                    pageItems[0]
+                    self.displayItem(pageItems[0])
                 } else {
                     HStack(spacing: self.minItemSpacing) {
                         ForEach(0 ..< pageItems.count, id: \.self) { index in
-                            pageItems[index]
+                            self.displayItem(pageItems[index])
                         }
                     }
                 }
@@ -45,6 +59,8 @@ extension KPIHeaderContent {
         .tabViewStyle(PageTabViewStyle())
         .indexViewStyle(PageIndexViewStyle(backgroundDisplayMode: .always))
         .frame(minHeight: self.context.itemsMaxHeight)
+        // Disable paging/swiping while loading so the skeleton cannot be scrolled.
+        .allowsHitTesting(!self.isLoading)
         .onReceive(self.resizePublisher) { _ in
             self.context.reset()
         }

--- a/Sources/FioriSwiftUICore/Views/KPIHeader/KPIHeaderItemSkeleton.swift
+++ b/Sources/FioriSwiftUICore/Views/KPIHeader/KPIHeaderItemSkeleton.swift
@@ -1,0 +1,109 @@
+import SwiftUI
+
+/// A skeleton placeholder for a single `KPIHeader` item, shown while the header is loading.
+///
+/// KPIHeader items cannot be skeletonized by the generic `SkeletonLoadingContainer` alone:
+/// - `KPIProgressItem` renders its value as a single `Text` built from differently-sized runs
+///   (e.g. "65" + "%"), which `.redacted(.placeholder)` splits into multiple overlapping blocks
+///   once the surrounding `scaleEffect` is applied.
+/// - A custom view can contain opaque `Color`/`Shape` fills that `.redacted` cannot turn into a
+///   placeholder, so the shimmer masks against the real (e.g. random) colors.
+///
+/// Instead of relying on `.redacted`, this view draws regular placeholder shapes filled with the
+/// `.separator` color (the same base color the generic skeleton uses) and applies the shared
+/// `.skeletonLoading()` shimmer on top. This keeps the shimmer identical to every other skeleton in
+/// the app while giving each element its own, non-overlapping placeholder.
+struct KPIHeaderItemSkeleton: View {
+    /// The item model. `KPIItem` / `KPIProgressItem` get a structure-matching placeholder; any other
+    /// value (including `nil`, used by the builder-based path where the concrete type is unknown)
+    /// falls back to a single rounded placeholder sized to `measuredSize`.
+    let model: (any KPIHeaderItemModel)?
+    /// The measured size of the real item, used to size the fallback placeholder so the layout does
+    /// not jump when loading completes.
+    var measuredSize: CGSize?
+
+    @Environment(\.isAILoading) private var isAILoading: Bool
+
+    // Match the generic skeleton exactly: `.separator` normally, `.tintColor` for AI (tint) loading
+    // — the same colors `ShimmerViewModifier.redactedForegroundColor` / `SkeletonLoadingContainer`
+    // use.
+    private var placeholderColor: Color {
+        Color.preferredColor(self.isAILoading ? .tintColor : .separator).opacity(0.3)
+    }
+
+    var body: some View {
+        self.placeholder
+            .skeletonLoading(isLoading: true, isTintColor: self.isAILoading)
+    }
+
+    @ViewBuilder
+    private var placeholder: some View {
+        if let progress = model as? KPIProgressItem {
+            self.progressPlaceholder(chartSize: progress.chartSize)
+        } else if self.model is KPIItem {
+            self.kpiItemPlaceholder
+        } else {
+            self.fallbackPlaceholder
+        }
+    }
+
+    // MARK: - KPIProgressItem
+
+    @ViewBuilder
+    private func progressPlaceholder(chartSize: KPIProgressItemSize) -> some View {
+        let diameter: CGFloat = chartSize == .large ? 130 : 104
+        // The real item is measured (measuredSize) and drives the container height. Size the whole
+        // placeholder to that measured size so the ring and footnote are never clipped. The ring
+        // takes most of the height; a footnote block sits just below it.
+        let totalHeight = self.measuredSize?.height ?? diameter
+        let ringSize = min(diameter, max(0, totalHeight - 14))
+        VStack(spacing: 2) {
+            ZStack {
+                // The gray progress ring.
+                Circle()
+                    .stroke(self.placeholderColor, lineWidth: 2)
+                    .frame(width: ringSize, height: ringSize)
+                VStack(spacing: 2) {
+                    // A single block replacing the value/percent text (no split, no overlap).
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(self.placeholderColor)
+                        .frame(width: ringSize * 0.42, height: ringSize * 0.22)
+                    // Caption placeholder (inside the ring, like the real layout).
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(self.placeholderColor)
+                        .frame(width: ringSize * 0.5, height: ringSize * 0.1)
+                }
+            }
+            // Footnote placeholder (below the ring), matching the real layout.
+            RoundedRectangle(cornerRadius: 3)
+                .fill(self.placeholderColor)
+                .frame(width: ringSize * 0.7, height: 10)
+        }
+        .frame(width: self.measuredSize?.width ?? diameter, height: totalHeight)
+    }
+
+    // MARK: - KPIItem
+
+    private var kpiItemPlaceholder: some View {
+        VStack(spacing: 4) {
+            // Metric placeholder.
+            RoundedRectangle(cornerRadius: 4)
+                .fill(self.placeholderColor)
+                .frame(width: 96, height: 30)
+            // Caption placeholder.
+            RoundedRectangle(cornerRadius: 3)
+                .fill(self.placeholderColor)
+                .frame(width: 72, height: 14)
+        }
+        .frame(maxWidth: 216)
+    }
+
+    // MARK: - Custom view / fallback
+
+    private var fallbackPlaceholder: some View {
+        RoundedRectangle(cornerRadius: 6)
+            .fill(self.placeholderColor)
+            .frame(width: self.measuredSize?.width ?? 104,
+                   height: self.measuredSize?.height ?? 104)
+    }
+}

--- a/Sources/FioriSwiftUICore/Views/KPIHeader/KPIHeaderItemSkeleton.swift
+++ b/Sources/FioriSwiftUICore/Views/KPIHeader/KPIHeaderItemSkeleton.swift
@@ -28,7 +28,7 @@ struct KPIHeaderItemSkeleton: View {
     // — the same colors `ShimmerViewModifier.redactedForegroundColor` / `SkeletonLoadingContainer`
     // use.
     private var placeholderColor: Color {
-        Color.preferredColor(self.isAILoading ? .tintColor : .separator).opacity(0.3)
+        Color.preferredColor(self.isAILoading ? .tintColor : .separator)
     }
 
     var body: some View {
@@ -51,12 +51,15 @@ struct KPIHeaderItemSkeleton: View {
 
     @ViewBuilder
     private func progressPlaceholder(chartSize: KPIProgressItemSize) -> some View {
+        // The ring diameter matches the real KPIProgressItem, whose chart size is a fixed 130/104
+        // (KPIProgressItemBaseStyle.getFrameWidth) and does not scale with Dynamic Type.
         let diameter: CGFloat = chartSize == .large ? 130 : 104
         // The real item is measured (measuredSize) and drives the container height. Size the whole
-        // placeholder to that measured size so the ring and footnote are never clipped. The ring
-        // takes most of the height; a footnote block sits just below it.
+        // placeholder to that measured size so the ring and footnote are never clipped. Inner block
+        // sizes are derived proportionally so they adapt with the measured size.
         let totalHeight = self.measuredSize?.height ?? diameter
-        let ringSize = min(diameter, max(0, totalHeight - 14))
+        let footnoteHeight = max(8, totalHeight * 0.08)
+        let ringSize = min(diameter, max(0, totalHeight - footnoteHeight - 2))
         VStack(spacing: 2) {
             ZStack {
                 // The gray progress ring.
@@ -77,7 +80,7 @@ struct KPIHeaderItemSkeleton: View {
             // Footnote placeholder (below the ring), matching the real layout.
             RoundedRectangle(cornerRadius: 3)
                 .fill(self.placeholderColor)
-                .frame(width: ringSize * 0.7, height: 10)
+                .frame(width: ringSize * 0.7, height: footnoteHeight)
         }
         .frame(width: self.measuredSize?.width ?? diameter, height: totalHeight)
     }
@@ -85,17 +88,21 @@ struct KPIHeaderItemSkeleton: View {
     // MARK: - KPIItem
 
     private var kpiItemPlaceholder: some View {
-        VStack(spacing: 4) {
+        // Drive sizing from the measured item so the placeholder adapts to Dynamic Type / content.
+        // The metric block takes the upper portion, the caption block the lower portion.
+        let width = self.measuredSize?.width ?? 96
+        let height = self.measuredSize?.height ?? 48
+        return VStack(spacing: max(2, height * 0.08)) {
             // Metric placeholder.
             RoundedRectangle(cornerRadius: 4)
                 .fill(self.placeholderColor)
-                .frame(width: 96, height: 30)
+                .frame(width: width * 0.9, height: height * 0.55)
             // Caption placeholder.
             RoundedRectangle(cornerRadius: 3)
                 .fill(self.placeholderColor)
-                .frame(width: 72, height: 14)
+                .frame(width: width * 0.7, height: height * 0.25)
         }
-        .frame(maxWidth: 216)
+        .frame(width: width, height: height)
     }
 
     // MARK: - Custom view / fallback

--- a/Sources/FioriSwiftUICore/_FioriStyles/KPIHeaderStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/KPIHeaderStyle.fiori.swift
@@ -8,25 +8,28 @@ public struct KPIHeaderBaseStyle: KPIHeaderStyle {
     @Environment(\.headerSeparator) private var separatorConfiguration
     @Environment(\.isLoading) var isLoading
     public func makeBody(_ configuration: KPIHeaderConfiguration) -> some View {
-        SkeletonLoadingContainer {
-            configuration.items
-                .ifApply(configuration.isPresented) { content in
-                    VStack {
-                        content
-                        configuration.bannerMessage
-                    }
+        // The skeleton is applied per item (see `KPIHeaderItemSkeleton`, used inside the item
+        // containers) so each item's shimmer flows on its own and every element gets its own
+        // placeholder. We intentionally do NOT wrap the whole header in a `SkeletonLoadingContainer`
+        // here: a container-level shimmer would sweep across the entire header as one block, and the
+        // container's `.redacted` cannot handle the progress ring / opaque custom fills correctly.
+        configuration.items
+            .ifApply(configuration.isPresented) { content in
+                VStack {
+                    content
+                    configuration.bannerMessage
                 }
-                .ifApply(self.separatorConfiguration.showSeparator) { content in
-                    VStack {
-                        content
-                        self.separatorConfiguration.color
-                            .frame(height: self.isLoading ? 0 : self.separatorConfiguration.lineWidth)
-                    }
+            }
+            .ifApply(self.separatorConfiguration.showSeparator) { content in
+                VStack {
+                    content
+                    self.separatorConfiguration.color
+                        .frame(height: self.isLoading ? 0 : self.separatorConfiguration.lineWidth)
                 }
-                .interItemSpacing(configuration.interItemSpacing)
-                .isItemOrderForced(configuration.isItemOrderForced)
-        }
-        .environment(\.isLoading, self.isLoading)
+            }
+            .interItemSpacing(configuration.interItemSpacing)
+            .isItemOrderForced(configuration.isItemOrderForced)
+            .environment(\.isLoading, self.isLoading)
     }
 }
 


### PR DESCRIPTION
### Problem

When skeleton loading is enabled on `KPIHeader` (via `.environment(\.isLoading, true)`), several display bugs appear (reproducible in `KPIHeaderExample`):

1. **Overlapping placeholder for progress values** — A value like `65%` is a single `Text` composed of differently-sized runs (`"65"` at 48pt + `"%"` at 28pt). `.redacted(.placeholder)` splits it into multiple placeholder blocks that overlap once the surrounding `scaleEffect` is applied.
2. **Header remains swipeable while loading** — Multiple KPI items stay in a paged `TabView`, so the skeleton can be scrolled; after swiping, placeholder regions overlap. The header should not be scrollable while loading.
3. **Broken shimmer for custom views** — A custom item containing an opaque fill (e.g. `Color.random`) renders with a distorted "transparent-to-black" shimmer, because `.redacted` has no effect on `Color`/`Shape`, so the shimmer masks against the opaque content.
4. **Single shimmer sweeps the whole header** — The shimmer was applied at the container level (`SkeletonLoadingContainer` wrapping the entire stack), so one highlight swept across all items as a single block instead of per item.

### Root Cause

The generic `SkeletonLoadingContainer` relies on `.redacted(.placeholder)` to turn content into placeholders. This works for text/image-based components but not for `KPIHeader`, whose items contain a progress ring (`Shape`), multi-run scaled text, and arbitrary custom views with opaque fills — none of which `.redacted` can handle correctly.

### Fix

Introduce a dedicated, `KPIHeader`-specific skeleton container **without modifying** the shared `SkeletonLoadingContainer` / `ShimmerViewModifier` (so the 20+ other components using them are unaffected):

- **New `KPIHeaderItemSkeleton`** — Draws regular placeholder shapes filled with the theme skeleton color and applies the shared `.skeletonLoading()` shimmer on top. Parameters are aligned with the generic skeleton (`.separator` / `.tintColor` base color, `isTintColor` passthrough), so the shimmer looks identical to every other skeleton in the app. Each item type gets a structure-matching, non-overlapping placeholder:
  - `KPIProgressItem`: gray progress ring + a single block for the value (no split/overlap) + caption block inside the ring + footnote block below. Sized from the item's measured size so it is never clipped.
  - `KPIItem`: metric block + caption block.
  - Custom views: a single rounded block (no opaque color bleed-through).
- **Per-item shimmer** — Removed the container-level `SkeletonLoadingContainer` from `KPIHeaderBaseStyle` and apply the skeleton per item, so each item's highlight flows on its own.
- **Disable paging while loading** — Added `.allowsHitTesting(!isLoading)` to the paging `TabView` (both the data-driven and builder-driven paths) and hide the page indicator while loading.
- **Stable layout** — Measurement still uses the real items (so placeholder sizing matches the loaded layout and no state branch is introduced that could get stuck); re-measure on item-count change.


### Before:
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-08-31 at 10 33 41" src="https://github.com/user-attachments/assets/7c68c73a-89f6-4ea9-bb1f-3e92e03fb478" />

### After:

https://github.com/user-attachments/assets/9b1eda95-12e1-4442-a6b6-b7372eeda726

