### PR TITLE
fix: 🐛 [2277] the bg of order picker is error

### DIFF
--- a/Sources/FioriSwiftUICore/Views/SortFilter/SortFilterCFGItemContainer.swift
+++ b/Sources/FioriSwiftUICore/Views/SortFilter/SortFilterCFGItemContainer.swift
@@ -728,7 +728,6 @@ extension SortFilterCFGItemContainer: View {
                 }
             })
             .frame(minHeight: self.orderPickerHeight > 0 ? self.orderPickerHeight : 88.0)
-            .background(Color.preferredColor(.primaryBackground))
             .foregroundColor(Color.preferredColor(.primaryLabel))
         }
     }


### PR DESCRIPTION
Dark mode: bg color should map to the sheet or view bg. 
