### PR TITLE
fix: 🐛 [2278]Fixed FilterFormView's item padding

### DIFF
--- a/Sources/FioriSwiftUICore/Views/CustomBuilder/FilterFormOptionsEnvironments.swift
+++ b/Sources/FioriSwiftUICore/Views/CustomBuilder/FilterFormOptionsEnvironments.swift
@@ -42,7 +42,7 @@ struct FilterFormOptionShapeKey: EnvironmentKey {
 }
 
 struct FilterFormOptionPadding: EnvironmentKey {
-    public static let defaultValue: EdgeInsets = .init(top: 4, leading: 4, bottom: 4, trailing: 4)
+    public static let defaultValue: EdgeInsets = .init(top: 12, leading: 20, bottom: 12, trailing: 20)
 }
 
 struct FilterFormOptionTitleSpacing: EnvironmentKey {

--- a/Sources/FioriSwiftUICore/_FioriStyles/ListPickerDestinationStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/ListPickerDestinationStyle.fiori.swift
@@ -1554,7 +1554,7 @@ public enum ListPickerSearchBarDisplayMode {
 }
 
 struct ListPickerSearchBarDisplayModeKey: EnvironmentKey {
-    static let defaultValue: ListPickerSearchBarDisplayMode = .automatic
+    static let defaultValue: ListPickerSearchBarDisplayMode = .always
 }
 
 public extension EnvironmentValues {


### PR DESCRIPTION
Spacing of long text in filter button gets pinched.
Modify the padding values by referring to the design draft.
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-09-02 at 16 29 53" src="https://github.com/user-attachments/assets/1dc97c33-9e10-46dd-a6f5-44647b80de68" />
