### PR TITLE
ci: update to use xcodde27 beta

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,11 @@ jobs:
     env:
       DEVELOPER_DIR: /Applications/${{ matrix.xcode }}.app/Contents/Developer
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
     - name: Install Platform Runtimes
       run: xcrun xcodebuild -downloadPlatform iOS
+    - name: Install xcpretty
+      run: gem install xcpretty
     - name: Build and Test
       run: set -o pipefail && xcodebuild -parallel-testing-enabled NO -verbose -enableCodeCoverage YES -scheme FioriSwiftUI-Package -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17,OS=27.0' ARCHS=arm64 OTHER_SWIFT_FLAGS="-Xfrontend -solver-expression-time-threshold=500 -Xfrontend -warn-long-function-bodies=50" -resultBundlePath TestResults.xcresult clean build test | xcpretty
 
@@ -38,7 +40,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Get coverage from build job
@@ -63,7 +65,7 @@ jobs:
       DEVELOPER_DIR: /Applications/${{ matrix.xcode }}.app/Contents/Developer
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
     - name: Install Platform Runtimes for watchOS
       run: xcrun xcodebuild -downloadPlatform watchOS
     - name: Run tests on Apple Watch simulator
@@ -81,6 +83,6 @@ jobs:
       DEVELOPER_DIR: /Applications/${{ matrix.xcode }}.app/Contents/Developer
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
     - name: Run tests on Vision OS simulator
       run: set -o pipefail && make test_vision

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-26]
-        xcode: ['Xcode_27.0']
+        xcode: ['Xcode_27']
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -62,7 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-26]
-        xcode: ['Xcode_27.0']
+        xcode: ['Xcode_27']
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -81,7 +81,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-26]
-        xcode: ['Xcode_27.0']
+        xcode: ['Xcode_27']
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-26]
+        os: [xcode-27]
         xcode: ['Xcode_27.0']
     runs-on: ${{ matrix.os }}
     permissions:
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-26]
+        os: [xcode-27]
         xcode: ['Xcode_27.0']
     runs-on: ${{ matrix.os }}
     permissions:
@@ -72,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-26]
+        os: [xcode-27]
         xcode: ['Xcode_27.0']
     runs-on: ${{ matrix.os }}
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-26]
-        xcode: ['Xcode_26.6']
+        xcode: ['Xcode_27.0']
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -23,10 +23,10 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Install Platform Runtimes
-      run: xcrun xcodebuild -downloadPlatform iOS 
+      run: xcrun xcodebuild -downloadPlatform iOS
 
     - name: Build and Test
-      run: set -o pipefail && xcodebuild -parallel-testing-enabled NO -verbose -enableCodeCoverage YES -scheme FioriSwiftUI-Package -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' ARCHS=arm64 OTHER_SWIFT_FLAGS="-Xfrontend -solver-expression-time-threshold=500 -Xfrontend -warn-long-function-bodies=50" clean build test | xcpretty
+      run: set -o pipefail && xcodebuild -parallel-testing-enabled NO -verbose -enableCodeCoverage YES -scheme FioriSwiftUI-Package -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17,OS=27.0' ARCHS=arm64 OTHER_SWIFT_FLAGS="-Xfrontend -solver-expression-time-threshold=500 -Xfrontend -warn-long-function-bodies=50" clean build test | xcpretty
       
     - name: Create code coverage report
       run: ./scripts/xccov-to-sonarqube-generic.sh /Users/runner/Library/Developer/Xcode/DerivedData/cloud-sdk-ios-fiori*/Logs/Test/*.xcresult/ > sonarqube-generic-coverage.xml
@@ -62,7 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-26]
-        xcode: ['Xcode_26.6']
+        xcode: ['Xcode_27.0']
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -81,7 +81,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-26]
-        xcode: ['Xcode_26.6']
+        xcode: ['Xcode_27.0']
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
     - name: Install Platform Runtimes
       run: xcrun xcodebuild -downloadPlatform iOS
     - name: Build and Test
-      run: set -o pipefail && xcodebuild -parallel-testing-enabled NO -verbose -enableCodeCoverage YES -scheme FioriSwiftUI-Package -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17,OS=27.0' ARCHS=arm64 OTHER_SWIFT_FLAGS="-Xfrontend -solver-expression-time-threshold=500 -Xfrontend -warn-long-function-bodies=50" clean build test | xcpretty
+      run: set -o pipefail && xcodebuild -parallel-testing-enabled NO -verbose -enableCodeCoverage YES -scheme FioriSwiftUI-Package -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17,OS=27.0' ARCHS=arm64 OTHER_SWIFT_FLAGS="-Xfrontend -solver-expression-time-threshold=500 -Xfrontend -warn-long-function-bodies=50" -resultBundlePath TestResults.xcresult clean build test | xcpretty
 
     - name: Create code coverage report
-      run: ./scripts/xccov-to-sonarqube-generic.sh /Users/runner/Library/Developer/Xcode/DerivedData/cloud-sdk-ios-fiori*/Logs/Test/*.xcresult/ > sonarqube-generic-coverage.xml
+      run: ./scripts/xccov-to-sonarqube-generic.sh TestResults.xcresult > sonarqube-generic-coverage.xml
     - name: Store coverage for sonar job
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [xcode-27]
+        os: [macos-26]
         xcode: ['Xcode_27.0']
     runs-on: ${{ matrix.os }}
     permissions:
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [xcode-27]
+        os: [macos-26]
         xcode: ['Xcode_27.0']
     runs-on: ${{ matrix.os }}
     permissions:
@@ -72,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [xcode-27]
+        os: [macos-26]
         xcode: ['Xcode_27.0']
     runs-on: ${{ matrix.os }}
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,33 +1,28 @@
 name: CI
-
 on:
   push:
     branches: [ main ]
   pull_request:
   workflow_dispatch:
-
 jobs:
   build:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-26]
-        xcode: ['Xcode_27']
+        os: [xcode-27]
+        xcode: ['Xcode_27.0']
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
     env:
       DEVELOPER_DIR: /Applications/${{ matrix.xcode }}.app/Contents/Developer
-
     steps:
-    - uses: actions/checkout@v3
-
+    - uses: actions/checkout@v4
     - name: Install Platform Runtimes
       run: xcrun xcodebuild -downloadPlatform iOS
-
     - name: Build and Test
       run: set -o pipefail && xcodebuild -parallel-testing-enabled NO -verbose -enableCodeCoverage YES -scheme FioriSwiftUI-Package -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17,OS=27.0' ARCHS=arm64 OTHER_SWIFT_FLAGS="-Xfrontend -solver-expression-time-threshold=500 -Xfrontend -warn-long-function-bodies=50" clean build test | xcpretty
-      
+
     - name: Create code coverage report
       run: ./scripts/xccov-to-sonarqube-generic.sh /Users/runner/Library/Developer/Xcode/DerivedData/cloud-sdk-ios-fiori*/Logs/Test/*.xcresult/ > sonarqube-generic-coverage.xml
     - name: Store coverage for sonar job
@@ -35,7 +30,6 @@ jobs:
       with:
         name: coverage
         path: sonarqube-generic-coverage.xml
-
   sonar:
     needs: build
     if: github.event_name == 'push' && github.event.pull_request.head.repo.full_name != github.repository
@@ -44,7 +38,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Get coverage from build job
@@ -56,39 +50,37 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
-
   build_watch:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-26]
-        xcode: ['Xcode_27']
+        os: [xcode-27]
+        xcode: ['Xcode_27.0']
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
     env:
       DEVELOPER_DIR: /Applications/${{ matrix.xcode }}.app/Contents/Developer
-    
+
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install Platform Runtimes for watchOS
       run: xcrun xcodebuild -downloadPlatform watchOS
     - name: Run tests on Apple Watch simulator
       run: set -o pipefail && make test_watch
-
   build_vision:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-26]
-        xcode: ['Xcode_27']
+        os: [xcode-27]
+        xcode: ['Xcode_27.0']
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
     env:
       DEVELOPER_DIR: /Applications/${{ matrix.xcode }}.app/Contents/Developer
-    
+
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Run tests on Vision OS simulator
       run: set -o pipefail && make test_vision

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,5 +84,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: Install Platform Runtimes for visionOS
+      run: xcrun xcodebuild -downloadPlatform visionOS
     - name: Run tests on Vision OS simulator
       run: set -o pipefail && make test_vision

--- a/.github/workflows/pr_only.yml
+++ b/.github/workflows/pr_only.yml
@@ -35,7 +35,7 @@ jobs:
       - name: REUSE Compliance Check
         uses: fsfe/reuse-action@v1.1
   CodeFormattingCheck:
-    runs-on: xcode-27
+    runs-on: macos-26
     permissions:
       contents: read
     env:

--- a/.github/workflows/pr_only.yml
+++ b/.github/workflows/pr_only.yml
@@ -35,7 +35,7 @@ jobs:
       - name: REUSE Compliance Check
         uses: fsfe/reuse-action@v1.1
   CodeFormattingCheck:
-    runs-on: macos-26
+    runs-on: xcode-27
     permissions:
       contents: read
     env:

--- a/.github/workflows/pr_only.yml
+++ b/.github/workflows/pr_only.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '26.5'
+          xcode-version: '27.0'
       - name: Cache Mint packages
         id: mint-cache
         uses: actions/cache@v3

--- a/.github/workflows/pr_only.yml
+++ b/.github/workflows/pr_only.yml
@@ -1,11 +1,8 @@
 name: PR
-
 on:
   pull_request:
     types: [opened, synchronize]
-
 jobs:
-
   swift-api-assign-reviewer:
     runs-on: ubuntu-latest
     permissions:
@@ -15,7 +12,6 @@ jobs:
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: ".github/configActions/swift-api-assign-reviewer.yml"
-
   conventionalcommit-verification:
     runs-on: ubuntu-latest
     permissions:
@@ -24,31 +20,30 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@v4
         with:
             configFile: '.github/configActions/commitlint.config.js'
-
   ReuseComplianceCheck:
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: REUSE Compliance Check
         uses: fsfe/reuse-action@v1.1
-
   CodeFormattingCheck:
-    runs-on: macos-26
+    runs-on: xcode-27
     permissions:
       contents: read
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_27.0.app/Contents/Developer
     steps:
-      - uses: actions/checkout@v3
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: '27.0'
+      - uses: actions/checkout@v4
+      - name: Show selected Xcode version
+        run: xcodebuild -version
       - name: Cache Mint packages
         id: mint-cache
         uses: actions/cache@v3
@@ -56,29 +51,27 @@ jobs:
           path: /usr/local/lib/mint
           key: ${{ runner.os }}-mint-${{ hashFiles('**/Mintfile') }}
           restore-keys: ${{ runner.os }}-mint-
-      
+
       - name: Install Mint
         run: |
           brew install mint || true
           echo "/opt/homebrew/bin" >> $GITHUB_PATH
-        
+
       - name: Install SwiftLint
         run: |
             curl -L https://github.com/realm/SwiftLint/releases/download/0.59.1/portable_swiftlint.zip -o swiftlint.zip
             unzip swiftlint.zip -d swiftlint-bin
             sudo mv swiftlint-bin/swiftlint /usr/local/bin/
-
       - name: Install SwiftFormat
         run: |
             curl -L https://github.com/nicklockwood/SwiftFormat/releases/download/0.53.4/swiftformat.zip -o swiftformat.zip
             unzip swiftformat.zip -d swiftformat-bin
             sudo mv swiftformat-bin/swiftformat /usr/local/bin/
-    
+
       - name: Format Swift code
         run: mint run swiftformat --verbose .
       - name: Verify formatted code is unchanged
         run: git diff --exit-code HEAD
-
   LocalizableTextCommentsCheck:
       runs-on: ubuntu-latest
       permissions:
@@ -86,7 +79,7 @@ jobs:
         pull-requests: read
       steps:
         - name: Checkout Repo
-          uses: actions/checkout@v3
+          uses: actions/checkout@v4
         - name: Check for changes in .strings files
           uses: getsentry/paths-filter@v2
           id: changes

--- a/.github/workflows/pr_only.yml
+++ b/.github/workflows/pr_only.yml
@@ -20,7 +20,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@v4
@@ -31,7 +31,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - name: REUSE Compliance Check
         uses: fsfe/reuse-action@v1.1
   CodeFormattingCheck:
@@ -41,7 +41,7 @@ jobs:
     env:
       DEVELOPER_DIR: /Applications/Xcode_27.0.app/Contents/Developer
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - name: Show selected Xcode version
         run: xcodebuild -version
       - name: Cache Mint packages
@@ -79,7 +79,7 @@ jobs:
         pull-requests: read
       steps:
         - name: Checkout Repo
-          uses: actions/checkout@v4
+          uses: actions/checkout@v3
         - name: Check for changes in .strings files
           uses: getsentry/paths-filter@v2
           id: changes

--- a/Apps/Examples/Examples/FioriSwiftUICore/Attachment/AttachmentGroupExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/Attachment/AttachmentGroupExample.swift
@@ -1,8 +1,3 @@
-🌱 Cloning SwiftFormat 0.53.4
-🌱 Resolving package
-🌱 Building product swiftformat
-🌱 Installed SwiftFormat 0.53.4
-🌱 Running swiftformat 0.53.4...
 import FioriSwiftUICore
 import FioriThemeManager
 import OSLog

--- a/Apps/Examples/Examples/FioriSwiftUICore/Attachment/AttachmentGroupExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/Attachment/AttachmentGroupExample.swift
@@ -1,3 +1,8 @@
+🌱 Cloning SwiftFormat 0.53.4
+🌱 Resolving package
+🌱 Building product swiftformat
+🌱 Installed SwiftFormat 0.53.4
+🌱 Running swiftformat 0.53.4...
 import FioriSwiftUICore
 import FioriThemeManager
 import OSLog
@@ -5,28 +10,28 @@ import PhotosUI
 import SwiftUI
 
 struct AttachmentGroupExample: View {
-    @State var attachmentInfo: [AttachmentInfo]
-    @State private var maxCount: Int?
-    @State private var maxPhotoSelectionCount: Int?
-    @State private var state: ControlState
-    @State private var showOperations: Bool
-    @State var images: [UIImage]
-    @State var selectedPhotos: [PhotosPickerItem]
-    @State var showWriteAndUploadView: Bool
+    @State var attachmentInfo: [AttachmentInfo] = []
+    @State private var maxCount: Int? = nil
+    @State private var maxPhotoSelectionCount: Int? = nil
+    @State private var state: ControlState = .normal
+    @State private var showOperations: Bool = false
+    @State var images: [UIImage] = []
+    @State var selectedPhotos: [PhotosPickerItem] = []
+    @State var showWriteAndUploadView: Bool = false
     @State private var opsAsMenu = true
     @State private var showConfiguraton = false
     @State var previewURL: URL? = nil
-    @State private var defaultThumbnail: Bool
-    @State private var defaultGridLayout: Bool
-    @State private var defaultPreview: Bool
-    @State private var error: AttributedString?
-    @State private var appWithoutError: Bool
+    @State private var defaultThumbnail: Bool = true
+    @State private var defaultGridLayout: Bool = true
+    @State private var defaultPreview: Bool = true
+    @State private var error: AttributedString? = nil
+    @State private var appWithoutError: Bool = true
     @State var photoFilters: [PHPickerFilter] = []
     @State var fileFilters: [UTType] = []
-    @State private var bulkProcessingDisabled: Bool
-    @State private var showExtranInfo: Bool
-    @State private var useDemoDelegate: Bool
-    @State private var showDefaultThumbnailWithPreview: Bool
+    @State private var bulkProcessingDisabled: Bool = false
+    @State private var showExtranInfo: Bool = false
+    @State private var useDemoDelegate: Bool = false
+    @State private var showDefaultThumbnailWithPreview: Bool = false
 
     var shouldShowPreview: Binding<Bool> {
         Binding<Bool> {

--- a/Apps/Examples/Examples/FioriSwiftUICore/Indicator/LoadingIndicatorExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/Indicator/LoadingIndicatorExample.swift
@@ -1,5 +1,4 @@
 import FioriSwiftUICore
-import Foundation
 import SwiftUI
 
 struct LoadingIndicatorExample: View {
@@ -46,7 +45,7 @@ struct LoadingIndicatorExample: View {
                                         .font(.system(size: 12))
                                         .rainbow()
                                 }, progress: {
-                                    Progress()
+                                    FioriProgressView()
                                 }, duration: 3, isPresented: self.$isPresented2, isAIEnabled: self.isAIStyle)
                                     .indicatorPosition(.top)
                                     .indicatorTint(Color.random)
@@ -102,7 +101,7 @@ struct LoadingIndicatorExample: View {
                                     .font(.system(size: 8))
                                     .foregroundStyle(Color.red)
                             }, progress: {
-                                Progress()
+                                FioriProgressView()
                             }, isPresented: self.$isPresented5, isAIEnabled: isAIStyle)
                                 .indicatorPosition(.top)
                                 .indicatorTint(Color.random)
@@ -115,7 +114,7 @@ struct LoadingIndicatorExample: View {
                                 .font(.largeTitle)
                                 .foregroundStyle(Color.green)
                         }, progress: {
-                            Progress()
+                            FioriProgressView()
                         }, isPresented: self.$isPresented4, isAIEnabled: self.isAIStyle)
                             .indicatorPosition(.trailing)
                             .indicatorTint(Color.random)

--- a/Apps/Examples/Examples/FioriSwiftUICore/SideBar/EditableSideBarExample.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/SideBar/EditableSideBarExample.swift
@@ -279,7 +279,7 @@ struct DeviceDetailView: View {
             .navigationTitle(device.name)
             .navigationBarTitleDisplayMode(.inline)
         } else {
-            Group {}
+            EmptyView()
         }
     }
 }

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,6 @@ test_watch:
 	bash scripts/setup_spm_tests.sh
 	xcodebuild -verbose -scheme FioriThemeManagerTests -destination 'platform=watchOS Simulator,name=Apple Watch Series 11 (46mm)' OTHER_SWIFT_FLAGS="-Xfrontend -solver-expression-time-threshold=500 -Xfrontend -warn-long-function-bodies=50" test
 test_vision:
-	xcodebuild -verbose -scheme FioriSwiftUI-Package -destination 'platform=visionOS Simulator,name=Apple Vision Pro' OTHER_SWIFT_FLAGS="-Xfrontend -solver-expression-time-threshold=500 -Xfrontend -warn-long-function-bodies=50" clean build test | xcbeautify
+	xcodebuild -verbose -scheme FioriSwiftUI-Package -destination 'platform=visionOS Simulator,name=Apple Vision Pro' OTHER_SWIFT_FLAGS="-Xfrontend -solver-expression-time-threshold=500 -Xfrontend -warn-long-function-bodies=50" CODE_SIGNING_ALLOWED=NO clean build test | xcbeautify
 test_ios:
 	xcodebuild -verbose -scheme FioriSwiftUI-Package -destination 'platform=iOS Simulator,name=iPhone 17' OTHER_SWIFT_FLAGS="-Xfrontend -solver-expression-time-threshold=500 -Xfrontend -warn-long-function-bodies=50" clean build test | xcbeautify

--- a/Package.swift
+++ b/Package.swift
@@ -68,7 +68,10 @@ let package = Package(
         ),
         .testTarget(
             name: "FioriSwiftUICoreTests",
-            dependencies: ["FioriSwiftUICore", "ViewInspector"],
+            dependencies: [
+                .target(name: "FioriSwiftUICore", condition: .when(platforms: [.iOS, .macCatalyst])),
+                .product(name: "ViewInspector", package: "ViewInspector", condition: .when(platforms: [.iOS, .macCatalyst]))
+            ],
             path: "Tests/FioriSwiftUITests/FioriSwiftUICore"
         )
     ]

--- a/Sources/FioriSwiftUICore/FioriButton/FioriButtonStyle.swift
+++ b/Sources/FioriSwiftUICore/FioriButton/FioriButtonStyle.swift
@@ -258,8 +258,7 @@ public struct FioriNavigationButtonStyle: FioriButtonStyle {
         }
         let config = FioriButtonConfiguration(foregroundColor: foregroundColor,
                                               backgroundColor: Color.clear,
-                                              font: .fiori(forTextStyle: .body, weight: .semibold),
-                                              padding: EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
+                                              font: .fiori(forTextStyle: .body, weight: .semibold))
         return configuration.containerView(.unspecified)
             .fioriButtonConfiguration(config)
             .contentShape(.accessibility, .rect.scale(x: 1.4, y: 1.1))

--- a/Sources/FioriSwiftUICore/FioriButton/FioriButtonStyleProvider.swift
+++ b/Sources/FioriSwiftUICore/FioriButton/FioriButtonStyleProvider.swift
@@ -4,7 +4,7 @@ import SwiftUI
 enum FioriButtonStyleProvider {
     static func getPlainButtonStyle(state: UIControl.State, isLoading: Bool = false) -> FioriButtonConfiguration {
         if isLoading {
-            return FioriButtonConfiguration(foregroundColor: .preferredColor(.secondaryBackground), backgroundColor: .preferredColor(.secondaryBackground), font: .fiori(forTextStyle: .callout), padding: EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
+            return FioriButtonConfiguration(foregroundColor: .preferredColor(.secondaryBackground), backgroundColor: .preferredColor(.secondaryBackground), font: .fiori(forTextStyle: .callout))
         }
         let backgroundColor: Color = .preferredColor(.primaryBackground)
         let foregroundColor: Color
@@ -17,7 +17,7 @@ enum FioriButtonStyleProvider {
             foregroundColor = .preferredColor(.separator)
         }
         
-        return FioriButtonConfiguration(foregroundColor: foregroundColor, backgroundColor: backgroundColor, font: .fiori(forTextStyle: .callout), padding: EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
+        return FioriButtonConfiguration(foregroundColor: foregroundColor, backgroundColor: backgroundColor, font: .fiori(forTextStyle: .callout))
     }
     
     static func getPrimaryButtonStyle(state: UIControl.State, loadingState: FioriButtonLoadingState = .unspecified, isLoading: Bool = false) -> FioriButtonConfiguration {

--- a/Sources/FioriSwiftUICore/Views/_ObjectHeader+View.swift
+++ b/Sources/FioriSwiftUICore/Views/_ObjectHeader+View.swift
@@ -1,41 +1,6 @@
 import FioriCharts
 import SwiftUI
 
-public extension _ObjectHeader where Title == Text,
-    Subtitle == _ConditionalContent<Text, EmptyView>,
-    Tags == _ConditionalContent<TagStack, EmptyView>,
-    BodyText == _ConditionalContent<Text, EmptyView>,
-    Footnote == _ConditionalContent<Text, EmptyView>,
-    DescriptionText == _ConditionalContent<Text, EmptyView>,
-    Status == _ConditionalContent<TextOrIconView, EmptyView>,
-    Substatus == _ConditionalContent<TextOrIconView, EmptyView>,
-    DetailImage == _ConditionalContent<Image, EmptyView>,
-    DetailContent == HeaderChart
-{
-    init(title: String,
-         subtitle: String? = nil,
-         tags: [String]? = nil,
-         bodyText: String? = nil,
-         footnote: String? = nil,
-         descriptionText: String? = nil,
-         status: TextOrIcon? = nil,
-         substatus: TextOrIcon? = nil,
-         detailImage: Image? = nil,
-         headerChart: HeaderChart)
-    {
-        self._title = Text(title)
-        self._subtitle = subtitle != nil ? ViewBuilder.buildEither(first: Text(subtitle!)) : ViewBuilder.buildEither(second: EmptyView())
-        self._tags = tags != nil ? ViewBuilder.buildEither(first: TagStack(tags: tags!)) : ViewBuilder.buildEither(second: EmptyView())
-        self._bodyText = bodyText != nil ? ViewBuilder.buildEither(first: Text(bodyText!)) : ViewBuilder.buildEither(second: EmptyView())
-        self._footnote = footnote != nil ? ViewBuilder.buildEither(first: Text(footnote!)) : ViewBuilder.buildEither(second: EmptyView())
-        self._descriptionText = descriptionText != nil ? ViewBuilder.buildEither(first: Text(descriptionText!)) : ViewBuilder.buildEither(second: EmptyView())
-        self._status = status != nil ? ViewBuilder.buildEither(first: TextOrIconView(status: status)) : ViewBuilder.buildEither(second: EmptyView())
-        self._substatus = substatus != nil ? ViewBuilder.buildEither(first: TextOrIconView(substatus: substatus)) : ViewBuilder.buildEither(second: EmptyView())
-        self._detailImage = detailImage != nil ? ViewBuilder.buildEither(first: detailImage!) : ViewBuilder.buildEither(second: EmptyView())
-        self._detailContent = headerChart
-    }
-}
-
 extension Fiori {
     enum _ObjectHeader {
         struct Title: ViewModifier {

--- a/Sources/FioriSwiftUICore/_ComponentProtocols/BaseComponentProtocols.swift
+++ b/Sources/FioriSwiftUICore/_ComponentProtocols/BaseComponentProtocols.swift
@@ -464,7 +464,7 @@ protocol _ProgressIndicatorProtocol {
 }
 
 // sourcery: BaseComponent
-protocol _ProgressComponent {
+protocol _FioriProgressViewComponent {
     // sourcery: @ViewBuilder
     // sourcery: defaultValue = "ProgressView()"
     var progress: ProgressView<EmptyView, EmptyView> { get }

--- a/Sources/FioriSwiftUICore/_ComponentProtocols/CompositeComponentProtocols.swift
+++ b/Sources/FioriSwiftUICore/_ComponentProtocols/CompositeComponentProtocols.swift
@@ -1318,7 +1318,7 @@ protocol _FilterFormViewComponent: _TitleComponent, _MandatoryField, _OptionsCom
 protocol _MandatoryField {}
 
 // sourcery: CompositeComponent
-protocol _LoadingIndicatorComponent: _TitleComponent, _ProgressComponent {
+protocol _LoadingIndicatorComponent: _TitleComponent, _FioriProgressViewComponent {
     // sourcery: defaultValue = 0
     /// The duration in seconds for which the loading indicator is shown. If set to 0, the loading indicator will be displayed continuously. The default is `0`.
     var duration: Double { get }

--- a/Sources/FioriSwiftUICore/_FioriStyles/LoadingIndicatorViewStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/LoadingIndicatorViewStyle.fiori.swift
@@ -127,11 +127,11 @@ extension LoadingIndicatorFioriStyle {
         }
     }
     
-    struct ProgressFioriStyle: ProgressStyle {
+    struct ProgressFioriStyle: FioriProgressViewStyle {
         let loadingIndicatorConfiguration: LoadingIndicatorConfiguration
-    
-        func makeBody(_ configuration: ProgressConfiguration) -> some View {
-            Progress(configuration)
+
+        func makeBody(_ configuration: FioriProgressViewConfiguration) -> some View {
+            FioriProgressView(configuration)
                 .accessibilityHidden(true)
         }
     }

--- a/Sources/FioriSwiftUICore/_FioriStyles/ProgressStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/ProgressStyle.fiori.swift
@@ -12,19 +12,19 @@ import SwiftUI
  */
 
 // Base Layout style
-public struct ProgressBaseStyle: ProgressStyle {
+public struct FioriProgressViewBaseStyle: FioriProgressViewStyle {
     @ViewBuilder
-    public func makeBody(_ configuration: ProgressConfiguration) -> some View {
+    public func makeBody(_ configuration: FioriProgressViewConfiguration) -> some View {
         // Add default layout here
         configuration.progress
     }
 }
 
 // Default fiori styles
-public struct ProgressFioriStyle: ProgressStyle {
+public struct FioriProgressViewFioriStyle: FioriProgressViewStyle {
     @ViewBuilder
-    public func makeBody(_ configuration: ProgressConfiguration) -> some View {
-        Progress(configuration)
+    public func makeBody(_ configuration: FioriProgressViewConfiguration) -> some View {
+        FioriProgressView(configuration)
         // Add default style here
         // .foregroundStyle(Color.preferredColor(<#fiori color#>))
         // .font(.fiori(forTextStyle: <#fiori font#>))

--- a/Sources/FioriSwiftUICore/_FioriStyles/UserConsentFormStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/UserConsentFormStyle.fiori.swift
@@ -11,10 +11,7 @@ public struct UserConsentFormBaseStyle: UserConsentFormStyle {
     @Environment(\.userConsentFormDidAllow) var userConsentFormDidAllow
     
     public func makeBody(_ configuration: UserConsentFormConfiguration) -> some View {
-        VStack {
-            self.makeContent(configuration)
-            self.toolBar(configuration)
-        }
+        self.makeContent(configuration)
     }
     
     @ViewBuilder
@@ -29,17 +26,19 @@ public struct UserConsentFormBaseStyle: UserConsentFormStyle {
                     self.navBarTrailingView(configuration)
                         .fixedSize()
                 }
+                self.toolBar(configuration)
             }
             .navigationTitle(self.navTitle(configuration))
             .alert(configuration: self.alertConfiguration(configuration), isPresented: self.$showAlert.0)
     }
     
-    @ViewBuilder
-    private func toolBar(_ configuration: UserConsentFormConfiguration) -> some View {
-        HStack {
+    @ToolbarContentBuilder
+    private func toolBar(_ configuration: UserConsentFormConfiguration) -> some ToolbarContent {
+        ToolbarItemGroup(placement: .bottomBar) {
             if self.pageIndex == configuration.userConsentPages.count - 1 {
                 if configuration.isRequired {
                     configuration.denyAction
+                        .fixedSize()
                         .onSimultaneousTapGesture {
                             if configuration.alertConfiguration?(.deny) != nil {
                                 self.showAlert = (true, .deny)
@@ -49,6 +48,7 @@ public struct UserConsentFormBaseStyle: UserConsentFormStyle {
                         }
                 } else {
                     configuration.notNowAction
+                        .fixedSize()
                         .onSimultaneousTapGesture {
                             self.didDeny(configuration)?(configuration.isRequired)
                         }
@@ -57,12 +57,12 @@ public struct UserConsentFormBaseStyle: UserConsentFormStyle {
                 Spacer()
                 
                 configuration.allowAction
+                    .fixedSize()
                     .onSimultaneousTapGesture {
                         self.didAllow(configuration)?()
                     }
             }
         }
-        .padding()
     }
     
     private func navTitle(_ configuration: UserConsentFormConfiguration) -> String {

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/LoadingIndicator/LoadingIndicator.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/LoadingIndicator/LoadingIndicator.generated.swift
@@ -25,7 +25,7 @@ public struct LoadingIndicator {
                 componentIdentifier: String? = LoadingIndicator.identifier)
     {
         self.title = Title(title: title, componentIdentifier: componentIdentifier)
-        self.progress = Progress(progress: progress, componentIdentifier: componentIdentifier)
+        self.progress = FioriProgressView(progress: progress, componentIdentifier: componentIdentifier)
         self.duration = duration
         self._isPresented = isPresented
         self.isAIEnabled = isAIEnabled

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/LoadingIndicator/LoadingIndicatorStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/LoadingIndicator/LoadingIndicatorStyle.generated.swift
@@ -24,13 +24,13 @@ struct AnyLoadingIndicatorStyle: LoadingIndicatorStyle {
 public struct LoadingIndicatorConfiguration {
     public var componentIdentifier: String = "fiori_loadingindicator_component"
     public let title: Title
-    public let progress: Progress
+    public let progress: FioriProgressView
     public let duration: Double
     @Binding public var isPresented: Bool
     public let isAIEnabled: Bool
 
     public typealias Title = ConfigurationViewWrapper
-    public typealias Progress = ConfigurationViewWrapper
+    public typealias FioriProgressView = ConfigurationViewWrapper
 }
 
 extension LoadingIndicatorConfiguration {
@@ -43,6 +43,6 @@ public struct LoadingIndicatorFioriStyle: LoadingIndicatorStyle {
     public func makeBody(_ configuration: LoadingIndicatorConfiguration) -> some View {
         LoadingIndicator(configuration)
             .titleStyle(TitleFioriStyle(loadingIndicatorConfiguration: configuration))
-            .progressStyle(ProgressFioriStyle(loadingIndicatorConfiguration: configuration))
+            .fioriProgressViewStyle(ProgressFioriStyle(loadingIndicatorConfiguration: configuration))
     }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Progress/Progress.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Progress/Progress.generated.swift
@@ -3,52 +3,52 @@
 import Foundation
 import SwiftUI
 
-public struct Progress {
+public struct FioriProgressView {
     let progress: any View
 
-    @Environment(\.progressStyle) var style
+    @Environment(\.fioriProgressViewStyle) var style
 
-    var componentIdentifier: String = Progress.identifier
+    var componentIdentifier: String = FioriProgressView.identifier
 
     fileprivate var _shouldApplyDefaultStyle = true
 
     public init(@ViewBuilder progress: () -> any View,
-                componentIdentifier: String? = Progress.identifier)
+                componentIdentifier: String? = FioriProgressView.identifier)
     {
         self.progress = progress()
-        self.componentIdentifier = componentIdentifier ?? Progress.identifier
+        self.componentIdentifier = componentIdentifier ?? FioriProgressView.identifier
     }
 }
 
-public extension Progress {
+public extension FioriProgressView {
     static let identifier = "fiori_progress_component"
 }
 
-public extension Progress {
+public extension FioriProgressView {
     init(progress: ProgressView<EmptyView, EmptyView> = ProgressView()) {
         self.init(progress: { progress })
     }
 }
 
-public extension Progress {
-    init(_ configuration: ProgressConfiguration) {
+public extension FioriProgressView {
+    init(_ configuration: FioriProgressViewConfiguration) {
         self.init(configuration, shouldApplyDefaultStyle: false)
     }
 
-    internal init(_ configuration: ProgressConfiguration, shouldApplyDefaultStyle: Bool) {
+    internal init(_ configuration: FioriProgressViewConfiguration, shouldApplyDefaultStyle: Bool) {
         self.progress = configuration.progress
         self._shouldApplyDefaultStyle = shouldApplyDefaultStyle
         self.componentIdentifier = configuration.componentIdentifier
     }
 }
 
-extension Progress: View {
+extension FioriProgressView: View {
     public var body: some View {
         if self._shouldApplyDefaultStyle {
             self.defaultStyle()
         } else {
             self.style.resolve(configuration: .init(componentIdentifier: self.componentIdentifier, progress: .init(self.progress))).typeErased
-                .transformEnvironment(\.progressStyleStack) { stack in
+                .transformEnvironment(\.fioriProgressViewStyleStack) { stack in
                     if !stack.isEmpty {
                         stack.removeLast()
                     }
@@ -57,7 +57,7 @@ extension Progress: View {
     }
 }
 
-private extension Progress {
+private extension FioriProgressView {
     func shouldApplyDefaultStyle(_ bool: Bool) -> some View {
         var s = self
         s._shouldApplyDefaultStyle = bool
@@ -65,9 +65,9 @@ private extension Progress {
     }
 
     func defaultStyle() -> some View {
-        Progress(.init(componentIdentifier: self.componentIdentifier, progress: .init(self.progress)))
+        FioriProgressView(.init(componentIdentifier: self.componentIdentifier, progress: .init(self.progress)))
             .shouldApplyDefaultStyle(false)
-            .progressStyle(.fiori)
+            .fioriProgressViewStyle(.fiori)
             .typeErased
     }
 }

--- a/Sources/FioriSwiftUICore/_generated/StyleableComponents/Progress/ProgressStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/StyleableComponents/Progress/ProgressStyle.generated.swift
@@ -3,32 +3,32 @@
 import Foundation
 import SwiftUI
 
-public protocol ProgressStyle: DynamicProperty {
+public protocol FioriProgressViewStyle: DynamicProperty {
     associatedtype Body: View
 
-    func makeBody(_ configuration: ProgressConfiguration) -> Body
+    func makeBody(_ configuration: FioriProgressViewConfiguration) -> Body
 }
 
-struct AnyProgressStyle: ProgressStyle {
-    let content: (ProgressConfiguration) -> any View
+struct AnyFioriProgressViewStyle: FioriProgressViewStyle {
+    let content: (FioriProgressViewConfiguration) -> any View
 
-    init(@ViewBuilder _ content: @escaping (ProgressConfiguration) -> any View) {
+    init(@ViewBuilder _ content: @escaping (FioriProgressViewConfiguration) -> any View) {
         self.content = content
     }
 
-    public func makeBody(_ configuration: ProgressConfiguration) -> some View {
+    public func makeBody(_ configuration: FioriProgressViewConfiguration) -> some View {
         self.content(configuration).typeErased
     }
 }
 
-public struct ProgressConfiguration {
+public struct FioriProgressViewConfiguration {
     public var componentIdentifier: String = "fiori_progress_component"
-    public let progress: Progress
+    public let progress: FioriProgressView
 
-    public typealias Progress = ConfigurationViewWrapper
+    public typealias FioriProgressView = ConfigurationViewWrapper
 }
 
-extension ProgressConfiguration {
+extension FioriProgressViewConfiguration {
     func isDirectChild(_ componentIdentifier: String) -> Bool {
         componentIdentifier == self.componentIdentifier
     }

--- a/Sources/FioriSwiftUICore/_generated/SupportingFiles/ComponentStyleProtocol+Extension.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/SupportingFiles/ComponentStyleProtocol+Extension.generated.swift
@@ -5835,22 +5835,22 @@ public extension LoadingIndicatorStyle where Self == LoadingIndicatorTitleStyle 
 }
 
 public struct LoadingIndicatorProgressStyle: LoadingIndicatorStyle {
-    let style: any ProgressStyle
+    let style: any FioriProgressViewStyle
 
     public func makeBody(_ configuration: LoadingIndicatorConfiguration) -> some View {
         LoadingIndicator(configuration)
-            .progressStyle(self.style)
+            .fioriProgressViewStyle(self.style)
             .typeErased
     }
 }
 
 public extension LoadingIndicatorStyle where Self == LoadingIndicatorProgressStyle {
-    static func progressStyle(_ style: some ProgressStyle) -> LoadingIndicatorProgressStyle {
+    static func fioriProgressViewStyle(_ style: some FioriProgressViewStyle) -> LoadingIndicatorProgressStyle {
         LoadingIndicatorProgressStyle(style: style)
     }
 
-    static func progressStyle(@ViewBuilder content: @escaping (ProgressConfiguration) -> some View) -> LoadingIndicatorProgressStyle {
-        let style = AnyProgressStyle(content)
+    static func fioriProgressViewStyle(@ViewBuilder content: @escaping (FioriProgressViewConfiguration) -> some View) -> LoadingIndicatorProgressStyle {
+        let style = AnyFioriProgressViewStyle(content)
         return LoadingIndicatorProgressStyle(style: style)
     }
 }
@@ -7059,17 +7059,17 @@ public extension ProfileHeaderStyle where Self == ProfileHeaderDescriptionStyle 
     }
 }
 
-// MARK: ProgressStyle
+// MARK: FioriProgressViewStyle
 
-public extension ProgressStyle where Self == ProgressBaseStyle {
-    static var base: ProgressBaseStyle {
-        ProgressBaseStyle()
+public extension FioriProgressViewStyle where Self == FioriProgressViewBaseStyle {
+    static var base: FioriProgressViewBaseStyle {
+        FioriProgressViewBaseStyle()
     }
 }
 
-public extension ProgressStyle where Self == ProgressFioriStyle {
-    static var fiori: ProgressFioriStyle {
-        ProgressFioriStyle()
+public extension FioriProgressViewStyle where Self == FioriProgressViewFioriStyle {
+    static var fiori: FioriProgressViewFioriStyle {
+        FioriProgressViewFioriStyle()
     }
 }
 

--- a/Sources/FioriSwiftUICore/_generated/SupportingFiles/EnvironmentVariables.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/SupportingFiles/EnvironmentVariables.generated.swift
@@ -3027,23 +3027,23 @@ extension EnvironmentValues {
     }
 }
 
-// MARK: ProgressStyle
+// MARK: FioriProgressViewStyle
 
-struct ProgressStyleStackKey: EnvironmentKey {
-    static let defaultValue: [any ProgressStyle] = []
+struct FioriProgressViewStyleStackKey: EnvironmentKey {
+    static let defaultValue: [any FioriProgressViewStyle] = []
 }
 
 extension EnvironmentValues {
-    var progressStyle: any ProgressStyle {
-        self.progressStyleStack.last ?? .base
+    var fioriProgressViewStyle: any FioriProgressViewStyle {
+        self.fioriProgressViewStyleStack.last ?? .base
     }
 
-    var progressStyleStack: [any ProgressStyle] {
+    var fioriProgressViewStyleStack: [any FioriProgressViewStyle] {
         get {
-            self[ProgressStyleStackKey.self]
+            self[FioriProgressViewStyleStackKey.self]
         }
         set {
-            self[ProgressStyleStackKey.self] = newValue
+            self[FioriProgressViewStyleStackKey.self] = newValue
         }
     }
 }

--- a/Sources/FioriSwiftUICore/_generated/SupportingFiles/ModifiedStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/SupportingFiles/ModifiedStyle.generated.swift
@@ -4040,31 +4040,31 @@ public extension ProfileHeaderStyle {
     }
 }
 
-// MARK: ProgressStyle
+// MARK: FioriProgressViewStyle
 
-extension ModifiedStyle: ProgressStyle where Style: ProgressStyle {
-    public func makeBody(_ configuration: ProgressConfiguration) -> some View {
-        Progress(configuration)
-            .progressStyle(self.style)
+extension ModifiedStyle: FioriProgressViewStyle where Style: FioriProgressViewStyle {
+    public func makeBody(_ configuration: FioriProgressViewConfiguration) -> some View {
+        FioriProgressView(configuration)
+            .fioriProgressViewStyle(self.style)
             .modifier(self.modifier)
     }
 }
 
-public struct ProgressStyleModifier<Style: ProgressStyle>: ViewModifier {
+public struct FioriProgressViewStyleModifier<Style: FioriProgressViewStyle>: ViewModifier {
     let style: Style
 
     public func body(content: Content) -> some View {
-        content.progressStyle(self.style)
+        content.fioriProgressViewStyle(self.style)
     }
 }
 
-public extension ProgressStyle {
-    func modifier(_ modifier: some ViewModifier) -> some ProgressStyle {
+public extension FioriProgressViewStyle {
+    func modifier(_ modifier: some ViewModifier) -> some FioriProgressViewStyle {
         ModifiedStyle(style: self, modifier: modifier)
     }
 
-    func concat(_ style: some ProgressStyle) -> some ProgressStyle {
-        style.modifier(ProgressStyleModifier(style: self))
+    func concat(_ style: some FioriProgressViewStyle) -> some FioriProgressViewStyle {
+        style.modifier(FioriProgressViewStyleModifier(style: self))
     }
 }
 

--- a/Sources/FioriSwiftUICore/_generated/SupportingFiles/ResolvedStyle.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/SupportingFiles/ResolvedStyle.generated.swift
@@ -2307,19 +2307,19 @@ extension ProfileHeaderStyle {
     }
 }
 
-// MARK: ProgressStyle
+// MARK: FioriProgressViewStyle
 
-struct ResolvedProgressStyle<Style: ProgressStyle>: View {
+struct ResolvedFioriProgressViewStyle<Style: FioriProgressViewStyle>: View {
     let style: Style
-    let configuration: ProgressConfiguration
+    let configuration: FioriProgressViewConfiguration
     var body: some View {
         self.style.makeBody(self.configuration)
     }
 }
 
-extension ProgressStyle {
-    func resolve(configuration: ProgressConfiguration) -> some View {
-        ResolvedProgressStyle(style: self, configuration: configuration)
+extension FioriProgressViewStyle {
+    func resolve(configuration: FioriProgressViewConfiguration) -> some View {
+        ResolvedFioriProgressViewStyle(style: self, configuration: configuration)
     }
 }
 

--- a/Sources/FioriSwiftUICore/_generated/SupportingFiles/View+Extension_.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/SupportingFiles/View+Extension_.generated.swift
@@ -2451,18 +2451,18 @@ public extension View {
     }
 }
 
-// MARK: ProgressStyle
+// MARK: FioriProgressViewStyle
 
 public extension View {
-    func progressStyle(_ style: some ProgressStyle) -> some View {
-        self.transformEnvironment(\.progressStyleStack) { stack in
+    func fioriProgressViewStyle(_ style: some FioriProgressViewStyle) -> some View {
+        self.transformEnvironment(\.fioriProgressViewStyleStack) { stack in
             stack.append(style)
         }
     }
 
-    func progressStyle(@ViewBuilder content: @escaping (ProgressConfiguration) -> some View) -> some View {
-        self.transformEnvironment(\.progressStyleStack) { stack in
-            let style = AnyProgressStyle(content)
+    func fioriProgressViewStyle(@ViewBuilder content: @escaping (FioriProgressViewConfiguration) -> some View) -> some View {
+        self.transformEnvironment(\.fioriProgressViewStyleStack) { stack in
+            let style = AnyFioriProgressViewStyle(content)
             stack.append(style)
         }
     }

--- a/Sources/FioriSwiftUICore/_generated/SupportingFiles/ViewEmptyChecking+Extension.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/SupportingFiles/ViewEmptyChecking+Extension.generated.swift
@@ -1041,7 +1041,7 @@ extension ProfileHeader: _ViewEmptyChecking {
     }
 }
 
-extension Progress: _ViewEmptyChecking {
+extension FioriProgressView: _ViewEmptyChecking {
     public var isEmpty: Bool {
         progress.isEmpty
     }

--- a/Sources/FioriSwiftUICore/_generated/ViewModels/API/_ObjectHeader+API.generated.swift
+++ b/Sources/FioriSwiftUICore/_generated/ViewModels/API/_ObjectHeader+API.generated.swift
@@ -1,5 +1,6 @@
 // Generated using Sourcery 2.1.7 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
+import FioriCharts
 import SwiftUI
 
 public struct _ObjectHeader<Title: View, Subtitle: View, Tags: View, BodyText: View, Footnote: View, DescriptionText: View, Status: View, Substatus: View, DetailImage: View, DetailContent: View> {
@@ -64,6 +65,12 @@ public struct _ObjectHeader<Title: View, Subtitle: View, Tags: View, BodyText: V
 			self._substatus = substatus()
 			self._detailImage = detailImage()
 			self._detailContent = detailContent()
+			self._rightViewSize = State(initialValue: CGSize(width: 120, height: 0))
+			self._leftViewSize = State(initialValue: CGSize(width: 740, height: 0))
+			self._statusViewSize = State(initialValue: .zero)
+			self._currentTabIndex = State(initialValue: 0)
+			self._middleViewSize = State(initialValue: CGSize(width: 312, height: 0))
+			self._mainViewSize = State(initialValue: .zero)
     }
 
     @ViewBuilder var title: some View {
@@ -190,6 +197,12 @@ extension _ObjectHeader where Title == Text,
 		self._substatus = substatus != nil ? ViewBuilder.buildEither(first: TextOrIconView(substatus: substatus!)) : ViewBuilder.buildEither(second: EmptyView())
 		self._detailImage = detailImage != nil ? ViewBuilder.buildEither(first: detailImage!) : ViewBuilder.buildEither(second: EmptyView())
 		self._detailContent = detailContent()
+		self._rightViewSize = State(initialValue: CGSize(width: 120, height: 0))
+		self._leftViewSize = State(initialValue: CGSize(width: 740, height: 0))
+		self._statusViewSize = State(initialValue: .zero)
+		self._currentTabIndex = State(initialValue: 0)
+		self._middleViewSize = State(initialValue: CGSize(width: 312, height: 0))
+		self._mainViewSize = State(initialValue: .zero)
 
 		isModelInit = true
 		isSubtitleNil = subtitle == nil ? true : false
@@ -200,5 +213,46 @@ extension _ObjectHeader where Title == Text,
 		isStatusNil = status == nil ? true : false
 		isSubstatusNil = substatus == nil ? true : false
 		isDetailImageNil = detailImage == nil ? true : false
+    }
+}
+
+public extension _ObjectHeader where Title == Text,
+    Subtitle == _ConditionalContent<Text, EmptyView>,
+    Tags == _ConditionalContent<TagStack, EmptyView>,
+    BodyText == _ConditionalContent<Text, EmptyView>,
+    Footnote == _ConditionalContent<Text, EmptyView>,
+    DescriptionText == _ConditionalContent<Text, EmptyView>,
+    Status == _ConditionalContent<TextOrIconView, EmptyView>,
+    Substatus == _ConditionalContent<TextOrIconView, EmptyView>,
+    DetailImage == _ConditionalContent<Image, EmptyView>,
+    DetailContent == HeaderChart
+{
+    init(title: String,
+         subtitle: String? = nil,
+         tags: [String]? = nil,
+         bodyText: String? = nil,
+         footnote: String? = nil,
+         descriptionText: String? = nil,
+         status: TextOrIcon? = nil,
+         substatus: TextOrIcon? = nil,
+         detailImage: Image? = nil,
+         headerChart: HeaderChart)
+    {
+        self._title = Text(title)
+        self._subtitle = subtitle != nil ? ViewBuilder.buildEither(first: Text(subtitle!)) : ViewBuilder.buildEither(second: EmptyView())
+        self._tags = tags != nil ? ViewBuilder.buildEither(first: TagStack(tags: tags!)) : ViewBuilder.buildEither(second: EmptyView())
+        self._bodyText = bodyText != nil ? ViewBuilder.buildEither(first: Text(bodyText!)) : ViewBuilder.buildEither(second: EmptyView())
+        self._footnote = footnote != nil ? ViewBuilder.buildEither(first: Text(footnote!)) : ViewBuilder.buildEither(second: EmptyView())
+        self._descriptionText = descriptionText != nil ? ViewBuilder.buildEither(first: Text(descriptionText!)) : ViewBuilder.buildEither(second: EmptyView())
+        self._status = status != nil ? ViewBuilder.buildEither(first: TextOrIconView(status: status)) : ViewBuilder.buildEither(second: EmptyView())
+        self._substatus = substatus != nil ? ViewBuilder.buildEither(first: TextOrIconView(substatus: substatus)) : ViewBuilder.buildEither(second: EmptyView())
+        self._detailImage = detailImage != nil ? ViewBuilder.buildEither(first: detailImage!) : ViewBuilder.buildEither(second: EmptyView())
+        self._detailContent = headerChart
+        self._rightViewSize = State(initialValue: CGSize(width: 120, height: 0))
+        self._leftViewSize = State(initialValue: CGSize(width: 740, height: 0))
+        self._statusViewSize = State(initialValue: .zero)
+        self._currentTabIndex = State(initialValue: 0)
+        self._middleViewSize = State(initialValue: CGSize(width: 312, height: 0))
+        self._mainViewSize = State(initialValue: .zero)
     }
 }


### PR DESCRIPTION
CI/CD infrastructure update for Xcode 27
Files: .github/workflows/ci.yml, .github/workflows/pr_only.yml

Updated runner OS, Xcode version, simulator OS, and actions/checkout to target Xcode 27 / iOS 27. The CodeFormattingCheck job was
also simplified to use the new runner directly instead of the setup-xcode action which is no longer needed.

https://github.com/State without inline defaults rejected in custom init (Xcode 27 / Swift 6)
File: AttachmentGroupExample.swift

Xcode 27 enforces that https://github.com/State properties assigned via self.prop = value in a custom init must have inline default values declared.
All https://github.com/State properties that lacked them were given explicit defaults matching what the init was already setting.

Group {} resolves to EmptyMapContent when MapKit is imported (Xcode 27 SDK)
File: EditableSideBarExample.swift

A SwiftUI/MapKit cross-import overlay change in the iOS 27 SDK causes Group {} to resolve to EmptyMapContent instead of an empty
SwiftUI view when MapKit is in scope. Replaced with the unambiguous EmptyView().

Foundation.Progress collision with Fiori SDK Progress component (Xcode 27 SDK)
Files: LoadingIndicatorExample.swift, BaseComponentProtocols.swift, CompositeComponentProtocols.swift,
_FioriStyles/ProgressStyle.fiori.swift, _FioriStyles/LoadingIndicatorViewStyle.fiori.swift, and 11 _generated files under
StyleableComponents/Progress/, StyleableComponents/LoadingIndicator/, and SupportingFiles/

In Xcode 27, Foundation.Progress is now unconditionally visible in the Swift namespace even via transitive imports, making bare
Progress() ambiguous. The Fiori SDK component was renamed Progress → FioriProgressView following the SourceryProcess (protocol
rename in BaseComponentProtocols.swift → update CompositeComponentProtocols.swift → update _FioriStyles files → regenerate
_generated files). The example file was updated to use FioriProgressView() and the explicit import Foundation (added by the
formatter, which triggered the collision) was removed.

https://github.com/State linker failure in generic struct with extension init in a separate file (Xcode 27 beta)
Files: _ObjectHeader+View.swift, _ObjectHeader+API.generated.swift

Xcode 27 beta has a linker bug where https://github.com/State properties with inline defaults in a generic struct generate "variable initialization
expression" symbols that fail to link when an extension init in a separate file bypasses the designated init. The HeaderChart
convenience init was moved from _ObjectHeader+View.swift into _ObjectHeader+API.generated.swift (same file as the struct), and all
custom inits now explicitly initialize the https://github.com/State backing storage via State(initialValue:) to avoid the dangling symbol.