### PR TITLE
fix: 🐛 [IOSSDKBUG-2281]Cherry-pick - Liquid glass issues on EULA & User Consent Form

### DIFF
--- a/Sources/FioriSwiftUICore/FioriButton/FioriButtonStyle.swift
+++ b/Sources/FioriSwiftUICore/FioriButton/FioriButtonStyle.swift
@@ -258,8 +258,7 @@ public struct FioriNavigationButtonStyle: FioriButtonStyle {
         }
         let config = FioriButtonConfiguration(foregroundColor: foregroundColor,
                                               backgroundColor: Color.clear,
-                                              font: .fiori(forTextStyle: .body, weight: .semibold),
-                                              padding: EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
+                                              font: .fiori(forTextStyle: .body, weight: .semibold))
         return configuration.containerView(.unspecified)
             .fioriButtonConfiguration(config)
             .contentShape(.accessibility, .rect.scale(x: 1.4, y: 1.1))

--- a/Sources/FioriSwiftUICore/FioriButton/FioriButtonStyleProvider.swift
+++ b/Sources/FioriSwiftUICore/FioriButton/FioriButtonStyleProvider.swift
@@ -4,7 +4,7 @@ import SwiftUI
 enum FioriButtonStyleProvider {
     static func getPlainButtonStyle(state: UIControl.State, isLoading: Bool = false) -> FioriButtonConfiguration {
         if isLoading {
-            return FioriButtonConfiguration(foregroundColor: .preferredColor(.secondaryBackground), backgroundColor: .preferredColor(.secondaryBackground), font: .fiori(forTextStyle: .callout), padding: EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
+            return FioriButtonConfiguration(foregroundColor: .preferredColor(.secondaryBackground), backgroundColor: .preferredColor(.secondaryBackground), font: .fiori(forTextStyle: .callout))
         }
         let backgroundColor: Color = .preferredColor(.primaryBackground)
         let foregroundColor: Color
@@ -17,7 +17,7 @@ enum FioriButtonStyleProvider {
             foregroundColor = .preferredColor(.separator)
         }
         
-        return FioriButtonConfiguration(foregroundColor: foregroundColor, backgroundColor: backgroundColor, font: .fiori(forTextStyle: .callout), padding: EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
+        return FioriButtonConfiguration(foregroundColor: foregroundColor, backgroundColor: backgroundColor, font: .fiori(forTextStyle: .callout))
     }
     
     static func getPrimaryButtonStyle(state: UIControl.State, loadingState: FioriButtonLoadingState = .unspecified, isLoading: Bool = false) -> FioriButtonConfiguration {

--- a/Sources/FioriSwiftUICore/_FioriStyles/UserConsentFormStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/UserConsentFormStyle.fiori.swift
@@ -11,10 +11,7 @@ public struct UserConsentFormBaseStyle: UserConsentFormStyle {
     @Environment(\.userConsentFormDidAllow) var userConsentFormDidAllow
     
     public func makeBody(_ configuration: UserConsentFormConfiguration) -> some View {
-        VStack {
-            self.makeContent(configuration)
-            self.toolBar(configuration)
-        }
+        self.makeContent(configuration)
     }
     
     @ViewBuilder
@@ -29,17 +26,19 @@ public struct UserConsentFormBaseStyle: UserConsentFormStyle {
                     self.navBarTrailingView(configuration)
                         .fixedSize()
                 }
+                self.toolBar(configuration)
             }
             .navigationTitle(self.navTitle(configuration))
             .alert(configuration: self.alertConfiguration(configuration), isPresented: self.$showAlert.0)
     }
     
-    @ViewBuilder
-    private func toolBar(_ configuration: UserConsentFormConfiguration) -> some View {
-        HStack {
+    @ToolbarContentBuilder
+    private func toolBar(_ configuration: UserConsentFormConfiguration) -> some ToolbarContent {
+        ToolbarItemGroup(placement: .bottomBar) {
             if self.pageIndex == configuration.userConsentPages.count - 1 {
                 if configuration.isRequired {
                     configuration.denyAction
+                        .fixedSize()
                         .onSimultaneousTapGesture {
                             if configuration.alertConfiguration?(.deny) != nil {
                                 self.showAlert = (true, .deny)
@@ -49,6 +48,7 @@ public struct UserConsentFormBaseStyle: UserConsentFormStyle {
                         }
                 } else {
                     configuration.notNowAction
+                        .fixedSize()
                         .onSimultaneousTapGesture {
                             self.didDeny(configuration)?(configuration.isRequired)
                         }
@@ -57,12 +57,12 @@ public struct UserConsentFormBaseStyle: UserConsentFormStyle {
                 Spacer()
                 
                 configuration.allowAction
+                    .fixedSize()
                     .onSimultaneousTapGesture {
                         self.didAllow(configuration)?()
                     }
             }
         }
-        .padding()
     }
     
     private func navTitle(_ configuration: UserConsentFormConfiguration) -> String {


### PR DESCRIPTION
# Fix: Liquid Glass Issues on EULA & User Consent Form

### Bug Fix

🐛 Resolves visual layout issues with the Liquid Glass design on the EULA and User Consent Form screens. The changes address improper padding and toolbar placement that caused rendering problems.

### Changes

* `FioriButtonStyle.swift`: Removed explicit zero-padding `EdgeInsets` from the plain button style configuration, allowing the button to use default padding behavior.

* `FioriButtonStyleProvider.swift`: Removed explicit zero-padding `EdgeInsets` from both loading and standard plain button style configurations for consistency.

* `UserConsentFormStyle.fiori.swift`: Refactored the toolbar layout in `UserConsentFormBaseStyle`:
  - Removed the outer `VStack` wrapping content and toolbar, replacing it with a single `makeContent` call.
  - Moved the toolbar rendering inside the `.toolbar` modifier of the content view, converting `toolBar` from a `@ViewBuilder` returning `some View` to a `@ToolbarContentBuilder` returning `some ToolbarContent`.
  - Migrated toolbar items to use `ToolbarItemGroup(placement: .bottomBar)` for proper bottom bar placement.
  - Added `.fixedSize()` modifiers to `denyAction`, `notNowAction`, and `allowAction` buttons within the toolbar.
  - Removed the `.padding()` modifier from the toolbar container to fix unwanted spacing with the Liquid Glass effect.

### Jira Issues

* IOSSDKBUG-2281: Cherry-pick - Liquid glass issues on EULA & User Consent Form

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.31.13`

- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- File Content Strategy: Full file content
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Event Trigger: `pull_request.opened`
- Correlation ID: `14f78800-a807-11f1-8912-b2bd9ecac8e9`
- LLM: `anthropic--claude-4.6-sonnet`
</details>
