### PR TITLE
fix: 🐛 [IOSSDKBUG-2287] Match the tag's foreground color to the skeleton loading animation

### DIFF
--- a/Sources/FioriSwiftUICore/_FioriStyles/TagStyle.fiori.swift
+++ b/Sources/FioriSwiftUICore/_FioriStyles/TagStyle.fiori.swift
@@ -15,12 +15,13 @@ public struct TagBaseStyle: TagStyle {
 public struct TagFioriStyle: TagStyle {
     @Environment(\.tagLimit) var tagLimit
     @Environment(\.tagStyle) var tagStyle
+    @Environment(\.isLoading) var isLoading
     @ViewBuilder
     public func makeBody(_ configuration: TagConfiguration) -> some View {
         Tag(configuration)
             .font(.fiori(forTextStyle: .footnote))
-            .foregroundStyle(Color.preferredColor(.accentLabel10))
-            .ifApply(!(self.tagStyle is OutlinedTagStyle), content: {
+            .foregroundStyle(Color.preferredColor(self.isLoading ? .separator : .accentLabel10))
+            .ifApply(!(self.tagStyle is OutlinedTagStyle) && !self.isLoading, content: {
                 $0.background(
                     RoundedRectangle(cornerRadius: 8)
                         .fill(Color.preferredColor(.accentBackground10))


### PR DESCRIPTION
Before:
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-09-07 at 11 08 31" src="https://github.com/user-attachments/assets/9767f7d4-646d-4a01-9e6b-0f2f89c80fac" />

After:
<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-09-07 at 11 05 47" src="https://github.com/user-attachments/assets/153fe7e8-558d-4e85-9e15-0ca3574a26de" />
