### PR TITLE
fix: 🐛 [IOSSDKBUG-2325] [SwiftUI] DateTimePicker: Elements under DateTimePicker are not accessible

### DIFF
--- a/Sources/FioriSwiftUICore/Utils/SkeletonLoading.swift
+++ b/Sources/FioriSwiftUICore/Utils/SkeletonLoading.swift
@@ -151,10 +151,11 @@ struct ShimmerViewModifier: ViewModifier {
     }
 
     func body(content: Content) -> some View {
-        if self.isLoading {
-            self.shimmerContent(content: content)
-                .accessibilityRepresentation {
-                    content
+        self.shimmerContent(content: content)
+            .accessibilityHidden(self.isLoading)
+            .overlay {
+                if self.isLoading {
+                    Color.clear
                         .accessibilityElement(children: .ignore)
                         .accessibilityLabel(self.loadingAccLabel)
                         .accessibilityValue("")
@@ -163,9 +164,7 @@ struct ShimmerViewModifier: ViewModifier {
                         .disabled(true)
                         .allowsHitTesting(false)
                 }
-        } else {
-            self.shimmerContent(content: content)
-        }
+            }
     }
     
     func shimmerContent(content: Content) -> some View {

--- a/Sources/FioriSwiftUICore/Utils/SkeletonLoading.swift
+++ b/Sources/FioriSwiftUICore/Utils/SkeletonLoading.swift
@@ -151,9 +151,9 @@ struct ShimmerViewModifier: ViewModifier {
     }
 
     func body(content: Content) -> some View {
-        self.shimmerContent(content: content)
-            .accessibilityRepresentation {
-                if self.isLoading {
+        if self.isLoading {
+            self.shimmerContent(content: content)
+                .accessibilityRepresentation {
                     content
                         .accessibilityElement(children: .ignore)
                         .accessibilityLabel(self.loadingAccLabel)
@@ -162,10 +162,10 @@ struct ShimmerViewModifier: ViewModifier {
                         .accessibilityAddTraits(.isStaticText)
                         .disabled(true)
                         .allowsHitTesting(false)
-                } else {
-                    content
                 }
-            }
+        } else {
+            self.shimmerContent(content: content)
+        }
     }
     
     func shimmerContent(content: Content) -> some View {


### PR DESCRIPTION
# Fix DateTimePicker Accessibility: Elements Under Picker Now Accessible

### Bug Fix

🐛 Fixed an accessibility issue where elements underneath the `DateTimePicker` (and other views using skeleton/shimmer loading) were not accessible to assistive technologies like VoiceOver in SwiftUI.

The root cause was that `accessibilityRepresentation` was being applied unconditionally — even when `isLoading` was `false` — causing the accessibility tree to be incorrectly altered and blocking interaction with underlying elements.

### Changes

* `Sources/FioriSwiftUICore/Utils/SkeletonLoading.swift`: Refactored the `body(content:)` method to conditionally apply `accessibilityRepresentation` **only** when `isLoading` is `true`. When `isLoading` is `false`, the shimmer content is rendered without any accessibility override, restoring normal accessibility behavior for underlying elements.

### Jira Issues

* IOSSDKBUG-2325: [SwiftUI] DateTimePicker: Elements under DateTimePicker are not accessible

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.31.14`

- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Correlation ID: `a8e20d50-aa92-11f1-879e-fd5688288349`
- File Content Strategy: Full file content
- Event Trigger: `pull_request.opened`
- LLM: `anthropic--claude-4.6-sonnet`
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
</details>
