### PR TITLE
fix: 🐛 [IOSSDKBUG-2325] Cherry-pick DateTimePicker: Elements under DateTimePicker are not accessible

### DIFF
--- a/Sources/FioriSwiftUICore/Utils/SkeletonLoading.swift
+++ b/Sources/FioriSwiftUICore/Utils/SkeletonLoading.swift
@@ -152,9 +152,10 @@ struct ShimmerViewModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         self.shimmerContent(content: content)
-            .accessibilityRepresentation {
+            .accessibilityHidden(self.isLoading)
+            .overlay {
                 if self.isLoading {
-                    content
+                    Color.clear
                         .accessibilityElement(children: .ignore)
                         .accessibilityLabel(self.loadingAccLabel)
                         .accessibilityValue("")
@@ -162,8 +163,6 @@ struct ShimmerViewModifier: ViewModifier {
                         .accessibilityAddTraits(.isStaticText)
                         .disabled(true)
                         .allowsHitTesting(false)
-                } else {
-                    content
                 }
             }
     }


### PR DESCRIPTION
# Fix: Accessibility Issue with Elements Under DateTimePicker (Cherry-pick)

### Bug Fix

🐛 Fixes an accessibility issue where elements beneath the `DateTimePicker` were not accessible to assistive technologies. This is a cherry-pick of the original fix for IOSSDKBUG-2325.

### Changes

* `Sources/FioriSwiftUICore/Utils/SkeletonLoading.swift`: Refactored the accessibility implementation in the skeleton loading view modifier. Replaced `accessibilityRepresentation` with `accessibilityHidden(self.isLoading)` to hide the content from accessibility when loading is active. The overlay now uses `Color.clear` instead of `content` as the accessibility element during loading, preventing duplicate or incorrect accessibility elements. Removed the `else` branch that was re-rendering `content` unnecessarily, which was causing elements under components like `DateTimePicker` to become inaccessible.

### Jira Issues

* IOSSDKBUG-2325: DateTimePicker: Elements under DateTimePicker are not accessible

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.31.20`

- Event Trigger: `pull_request.opened`
- Correlation ID: `8b63a6e0-adac-11f1-85c3-101abfda73a7`
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- File Content Strategy: Full file content
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- LLM: `anthropic--claude-4.6-sonnet`
</details>
