### PR TITLE
fix: 🐛 [IOSSDKBUG-2296](Cherry-pick)Add rounded corners for the swipe-revealed view of the ObjectItem

### DIFF
--- a/Apps/Examples/Examples/FioriSwiftUICore/ObjectItem/ObjectItemListView.swift
+++ b/Apps/Examples/Examples/FioriSwiftUICore/ObjectItem/ObjectItemListView.swift
@@ -12,6 +12,14 @@ struct ObjectItemListView<T: ListDataProtocol>: View {
     @State var cellTapped = false
     @State var singleSelection: Int?
     
+    private var cellHorizontalInset: CGFloat {
+        (self.horizontalSizeClass == .some(.compact) && self.changeLeftMargin) ? 32 : 16
+    }
+    
+    private var cellVerticalInset: CGFloat {
+        (self.horizontalSizeClass == .some(.compact) && self.changeLeftMargin) ? 0 : 16
+    }
+    
     init(title: String, listDataType: T.Type, changeLeftMargin: Bool = true, showEditButton: Bool = true) {
         self.title = title
         self.listDataType = listDataType
@@ -27,6 +35,17 @@ struct ObjectItemListView<T: ListDataProtocol>: View {
         }
     }
     
+    @ViewBuilder
+    private func swipeRoundedTrailing(@ViewBuilder content: () -> some View) -> some View {
+        content()
+            .padding(.horizontal, self.cellHorizontalInset)
+            .padding(.vertical, self.cellVerticalInset)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+            .background(Color(.secondarySystemGroupedBackground))
+            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+            .contentShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+    }
+    
     var body: some View {
         let listData = self.createInstance(typeThing: self.listDataType)
         
@@ -34,22 +53,27 @@ struct ObjectItemListView<T: ListDataProtocol>: View {
             ForEach(0 ..< listData.numberOfSections(), id: \.self) { sectionIndex in
                 Section(header: Text(listData.titleForHeaderInSection(sectionIndex)).textCase(.none)) {
                     ForEach(0 ..< listData.numberOfRowsInSection(sectionIndex), id: \.self) { index in
-                        if listData.containAccessoryView(IndexPath(row: index, section: sectionIndex)) {
-                            NavigationLink(destination: listData.cellForRow(IndexPath(row: index, section: sectionIndex))) {
-                                listData.cellForRow(IndexPath(row: index, section: sectionIndex))
+                        Group {
+                            if listData.containAccessoryView(IndexPath(row: index, section: sectionIndex)) {
+                                NavigationLink(destination: listData.cellForRow(IndexPath(row: index, section: sectionIndex))) {
+                                    self.swipeRoundedTrailing {
+                                        listData.cellForRow(IndexPath(row: index, section: sectionIndex))
+                                    }
+                                }
+                            } else {
+                                self.swipeRoundedTrailing {
+                                    listData.cellForRow(IndexPath(row: index, section: sectionIndex))
+                                }
                             }
-                        } else {
-                            listData.cellForRow(IndexPath(row: index, section: sectionIndex))
                         }
+                        .listRowInsets(EdgeInsets())
+                        .alignmentGuide(.listRowSeparatorLeading) { _ in 16 }
+                        .alignmentGuide(.listRowSeparatorTrailing) { d in d.width - 16 }
                     }
                     .onDelete { indexSet in
                         print("delete \(indexSet)")
                     }
                 }
-            }
-            .listRowBackground(Color.preferredColor(.secondaryGroupedBackground))
-            .ifApply(self.horizontalSizeClass == .some(.compact) && self.changeLeftMargin) {
-                $0.listRowInsets(EdgeInsets(top: 0, leading: 32, bottom: 0, trailing: 32))
             }
             .objectItemStyle(.actionStyle(ObjectItemBorderedAction()))
         }


### PR DESCRIPTION
# Fix: Add Rounded Corners for Swipe-Revealed View of ObjectItem

### Bug Fix

🐛 Fixes the missing rounded corners on the swipe-revealed view of `ObjectItem` list cells. Previously, the list rows lacked proper rounded corner styling when swipe actions were revealed. This change introduces a reusable helper that applies consistent rounded corner styling, background, and padding to all cell variants (both with and without accessory/navigation views).

### Changes

* `Apps/Examples/Examples/FioriSwiftUICore/ObjectItem/ObjectItemListView.swift`:
  - Added computed properties `cellHorizontalInset` and `cellVerticalInset` to dynamically calculate padding based on horizontal size class and margin settings.
  - Introduced a new `swipeRoundedTrailing` helper view builder that wraps cell content with horizontal/vertical padding, a secondary grouped background, and a `RoundedRectangle` clip/content shape with a 16pt corner radius.
  - Refactored the cell rendering logic inside the `ForEach` to use a `Group` and apply `swipeRoundedTrailing` consistently to both `NavigationLink`-wrapped and plain cells.
  - Moved `.listRowInsets`, `.alignmentGuide` modifiers to the `Group` level for unified application.
  - Removed the previously used `.listRowBackground` and conditional `.listRowInsets` modifiers that were applied at the `ForEach` level, as padding and background are now handled within `swipeRoundedTrailing`.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.31.20`

- File Content Strategy: Full file content
- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Event Trigger: `pull_request.opened`
- Correlation ID: `05d3ec20-adb0-11f1-9de3-6acecff5078b`
- LLM: `anthropic--claude-4.6-sonnet`
</details>
